### PR TITLE
Disable priority class

### DIFF
--- a/modules/kubernetes/opa-gatekeeper/files/gatekeeper-values.yaml
+++ b/modules/kubernetes/opa-gatekeeper/files/gatekeeper-values.yaml
@@ -2,3 +2,7 @@ podAnnotations:
   ad.datadoghq.com/manager.check_names: '["openmetrics"]'
   ad.datadoghq.com/manager.init_configs: "[{}]"
   ad.datadoghq.com/manager.instances: '[{"prometheus_url":"http://%%host%%:8888/metrics","namespace":"opa","metrics":["*"]}]'
+controllerManager:
+  priorityClassName: ""
+audit:
+  priorityClassName: ""


### PR DESCRIPTION
This disables the priority class set by default in the gatekeeper Helm chart which is `system-node-critical`. The reason this needs to be done is because only "newer" >1.17 clusters will allow use of this priority class outside of the kube-system namespace. This change should be reverted when all clusters run the latest version of Kubernetes.

https://github.com/kubernetes/kubernetes/issues/78383