### PR TITLE
azure/core: add dns_servers property to vnet_config

### DIFF
--- a/modules/azure/core/README.md
+++ b/modules/azure/core/README.md
@@ -53,7 +53,7 @@ No Modules.
 | route\_config | Route configuration. Not applied to aks subnets. | <pre>list(object({<br>    subnet_name = string # Short name for the subnet<br>    routes = list(object({<br>      name                   = string # Name of the route<br>      address_prefix         = string # Example: 192.168.0.0/24<br>      next_hop_type          = string # VirtualNetworkGateway, VnetLocal, Internet, VirtualAppliance and None<br>      next_hop_in_ip_address = string # Only set if next_hop_type is VirtualAppliance<br>    }))<br><br>  }))</pre> | `[]` | no |
 | subscription\_name | The subscriptionCommonName to use for the deploy | `string` | n/a | yes |
 | unique\_suffix | Unique suffix that is used in globally unique resources names | `string` | `""` | no |
-| vnet\_config | Address spaces used by virtual network. | <pre>object({<br>    address_space = list(string)<br>    subnets = list(object({<br>      name              = string<br>      cidr              = string<br>      service_endpoints = list(string)<br>      aks_subnet        = bool<br>    }))<br>  })</pre> | n/a | yes |
+| vnet\_config | Address spaces used by virtual network. | <pre>object({<br>    address_space = list(string)<br>    dns_servers   = list(string)<br>    subnets = list(object({<br>      name              = string<br>      cidr              = string<br>      service_endpoints = list(string)<br>      aks_subnet        = bool<br>    }))<br>  })</pre> | n/a | yes |
 
 ## Outputs
 

--- a/modules/azure/core/network.tf
+++ b/modules/azure/core/network.tf
@@ -3,6 +3,7 @@ resource "azurerm_virtual_network" "this" {
   resource_group_name = data.azurerm_resource_group.this.name
   location            = data.azurerm_resource_group.this.location
   address_space       = var.vnet_config.address_space
+  dns_servers         = var.vnet_config.dns_servers
 }
 
 resource "azurerm_virtual_network_peering" "this" {

--- a/modules/azure/core/variables.tf
+++ b/modules/azure/core/variables.tf
@@ -22,6 +22,7 @@ variable "vnet_config" {
   description = "Address spaces used by virtual network."
   type = object({
     address_space = list(string)
+    dns_servers   = list(string)
     subnets = list(object({
       name              = string
       cidr              = string

--- a/validation/azure/core/main.tf
+++ b/validation/azure/core/main.tf
@@ -15,6 +15,7 @@ module "core" {
   name              = "core"
   vnet_config = {
     address_space = ["10.180.0.0/16"]
+    dns_servers   = []
     subnets = [
       {
         name              = "servers"


### PR DESCRIPTION
Closes #152

**INTRODUCES BREAKING CHANGE**

A new property is added to the vnet_config object (dns_server). Can be empty list ([]) if not needed.