### PR TITLE
Add monitor resources

### DIFF
--- a/modules/kubernetes/aad-pod-identity/README.md
+++ b/modules/kubernetes/aad-pod-identity/README.md
@@ -26,6 +26,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [helm_release.aad_pod_identity](https://registry.terraform.io/providers/hashicorp/helm/2.1.0/docs/resources/release) | resource |
+| [helm_release.aad_pod_identity_extras](https://registry.terraform.io/providers/hashicorp/helm/2.1.0/docs/resources/release) | resource |
 | [kubernetes_namespace.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.0.3/docs/resources/namespace) | resource |
 
 ## Inputs
@@ -34,6 +35,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_aad_pod_identity"></a> [aad\_pod\_identity](#input\_aad\_pod\_identity) | Configuration for aad pod identity | <pre>map(object({<br>    id        = string<br>    client_id = string<br>  }))</pre> | n/a | yes |
 | <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | Namespaces to create AzureIdentity and AzureIdentityBindings in. | <pre>list(<br>    object({<br>      name = string<br>    })<br>  )</pre> | n/a | yes |
+| <a name="input_prometheus_enabled"></a> [prometheus\_enabled](#input\_prometheus\_enabled) | Should a ServiceMonitor be created | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/kubernetes/aad-pod-identity/charts/aad-pod-identity-extras/.helmignore
+++ b/modules/kubernetes/aad-pod-identity/charts/aad-pod-identity-extras/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/modules/kubernetes/aad-pod-identity/charts/aad-pod-identity-extras/Chart.yaml
+++ b/modules/kubernetes/aad-pod-identity/charts/aad-pod-identity-extras/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: aad-pod-identity-extras
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/modules/kubernetes/aad-pod-identity/charts/aad-pod-identity-extras/templates/mic-monitor.yaml
+++ b/modules/kubernetes/aad-pod-identity/charts/aad-pod-identity-extras/templates/mic-monitor.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.prometheusEnabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: aad-pod-identity-mic
+  labels:
+    xkf.xenit.io/monitoring: platform
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: aad-pod-identity
+      app.kubernetes.io/name: aad-pod-identity
+      app.kubernetes.io/component: mic
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics
+{{- end }}

--- a/modules/kubernetes/aad-pod-identity/charts/aad-pod-identity-extras/templates/nmi-monitor.yaml
+++ b/modules/kubernetes/aad-pod-identity/charts/aad-pod-identity-extras/templates/nmi-monitor.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.prometheusEnabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: aad-pod-identity-nmi
+  labels:
+    xkf.xenit.io/monitoring: platform
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: aad-pod-identity
+      app.kubernetes.io/name: aad-pod-identity
+      app.kubernetes.io/component: nmi
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics
+{{- end }}

--- a/modules/kubernetes/aad-pod-identity/charts/aad-pod-identity-extras/values.yaml
+++ b/modules/kubernetes/aad-pod-identity/charts/aad-pod-identity-extras/values.yaml
@@ -1,0 +1,1 @@
+prometheusEnabled: false

--- a/modules/kubernetes/aad-pod-identity/main.tf
+++ b/modules/kubernetes/aad-pod-identity/main.tf
@@ -26,7 +26,7 @@ locals {
 resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
-      name = "aad-pod-identity"
+      name                = "aad-pod-identity"
       "xkf.xenit.io/kind" = "platform"
     }
     name = "aad-pod-identity"

--- a/modules/kubernetes/aad-pod-identity/main.tf
+++ b/modules/kubernetes/aad-pod-identity/main.tf
@@ -27,6 +27,7 @@ resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
       name = "aad-pod-identity"
+      "xkf.xenit.io/kind" = "platform"
     }
     name = "aad-pod-identity"
   }
@@ -39,4 +40,17 @@ resource "helm_release" "aad_pod_identity" {
   version    = "4.0.0"
   namespace  = kubernetes_namespace.this.metadata[0].name
   values     = [local.values]
+}
+
+resource "helm_release" "aad_pod_identity_extras" {
+  depends_on = [helm_release.aad_pod_identity]
+
+  chart     = "${path.module}/charts/aad-pod-identity-extras"
+  name      = "aad-pod-identity-extras"
+  namespace = kubernetes_namespace.this.metadata[0].name
+
+  set {
+    name  = "prometheusEnabled"
+    value = var.prometheus_enabled
+  }
 }

--- a/modules/kubernetes/aad-pod-identity/templates/values.yaml.tpl
+++ b/modules/kubernetes/aad-pod-identity/templates/values.yaml.tpl
@@ -1,6 +1,11 @@
 forceNameSpaced: true
+
+mic:
+  prometheusPort: 8888
+
 nmi:
   allowNetworkPluginKubenet: true
+  prometheusPort: 9090
 
 azureIdentities:
 %{ for namespace in namespaces ~}

--- a/modules/kubernetes/aad-pod-identity/variables.tf
+++ b/modules/kubernetes/aad-pod-identity/variables.tf
@@ -1,3 +1,9 @@
+variable "prometheus_enabled" {
+  description = "Should a ServiceMonitor be created"
+  type        = bool
+  default     = false
+}
+
 variable "aad_pod_identity" {
   description = "Configuration for aad pod identity"
   type = map(object({

--- a/modules/kubernetes/aks-core/k8s-namespace.tf
+++ b/modules/kubernetes/aks-core/k8s-namespace.tf
@@ -14,7 +14,7 @@ resource "kubernetes_namespace" "tenant" {
     labels = merge(
       { for k, v in each.value.labels : k => v },
       {
-        "name" = each.value.name,
+        "name"              = each.value.name,
         "xkf.xenit.io/kind" = "tenant"
       }
     )

--- a/modules/kubernetes/aks-core/k8s-namespace.tf
+++ b/modules/kubernetes/aks-core/k8s-namespace.tf
@@ -13,7 +13,10 @@ resource "kubernetes_namespace" "tenant" {
   metadata {
     labels = merge(
       { for k, v in each.value.labels : k => v },
-      { "name" = each.value.name }
+      {
+        "name" = each.value.name,
+        "xkf.xenit.io/kind" = "tenant"
+      }
     )
     name = each.value.name
   }

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -132,7 +132,7 @@ module "ingress_nginx" {
 
   source = "../../kubernetes/ingress-nginx"
 
-  http_snippet = var.ingress_config.http_snippet
+  http_snippet       = var.ingress_config.http_snippet
   prometheus_enabled = var.prometheus_enabled
 }
 

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -78,6 +78,7 @@ module "fluxcd_v2_azure_devops" {
       repo        = ns.flux.azure_devops.repo
     }
   }]
+  prometheus_enabled = var.prometheus_enabled
 }
 
 module "fluxcd_v2_github" {
@@ -116,6 +117,7 @@ module "aad_pod_identity" {
   namespaces = [for ns in var.namespaces : {
     name = ns.name
   }]
+  prometheus_enabled = var.prometheus_enabled
 }
 
 # Ingress Nginx
@@ -131,6 +133,7 @@ module "ingress_nginx" {
   source = "../../kubernetes/ingress-nginx"
 
   http_snippet = var.ingress_config.http_snippet
+  prometheus_enabled = var.prometheus_enabled
 }
 
 # External DNS
@@ -154,6 +157,7 @@ module "external_dns" {
     client_id       = var.external_dns_config.client_id
     resource_id     = var.external_dns_config.resource_id
   }
+  prometheus_enabled = var.prometheus_enabled
 }
 
 # Cert Manager
@@ -177,6 +181,7 @@ module "cert_manager" {
     client_id           = var.external_dns_config.client_id
     resource_id         = var.external_dns_config.resource_id
   }
+  prometheus_enabled = var.prometheus_enabled
 }
 
 # Velero
@@ -200,6 +205,7 @@ module "velero" {
     client_id                 = var.velero_config.identity.client_id
     resource_id               = var.velero_config.identity.resource_id
   }
+  prometheus_enabled = var.prometheus_enabled
 }
 
 # csi-secrets-store-provider-azure
@@ -213,6 +219,8 @@ module "csi_secrets_store_provider_azure" {
   }
 
   source = "../../kubernetes/csi-secrets-store-provider-azure"
+
+  prometheus_enabled = var.prometheus_enabled
 }
 
 # datadog
@@ -261,6 +269,8 @@ module "reloader" {
   }
 
   source = "../../kubernetes/reloader"
+
+  prometheus_enabled = var.prometheus_enabled
 }
 
 # azad-kube-proxy

--- a/modules/kubernetes/azad-kube-proxy/main.tf
+++ b/modules/kubernetes/azad-kube-proxy/main.tf
@@ -1,11 +1,11 @@
 /**
  * # Azure AD Kubernetes API Proxy
  * Adds [`azad-kube-proxy`](https://github.com/XenitAB/azad-kube-proxy) to a Kubernetes clusters.
- * 
+ *
  * ## Configuring Azure AD Applications
- * 
+ *
  * ### Azure AD App: azad-kube-proxy
- * 
+ *
  * ```shell
  * ENVIRONMENT="dev"
  * TENANT_ID=$(az account show --output tsv --query tenantId)
@@ -23,9 +23,9 @@
  * az ad app permission add --id ${AZ_APP_ID} --api 00000003-0000-0000-c000-000000000000 --api-permissions 7ab1d382-f21e-4acd-a863-ba3e13f7da61=Role
  * az ad app permission admin-consent --id ${AZ_APP_ID}
  * ```
- * 
+ *
  * ### Azure AD App: k8dash
- * 
+ *
  * ```shell
  * AZ_APP_DASH_NAME="aks-dashboard-${ENVIRONMENT}"
  * AZ_APP_DASH_REPLY_URL="https://aks.${ENVIRONMENT}.example.com/"
@@ -36,28 +36,28 @@
  * az rest --method PATCH --uri "https://graph.microsoft.com/beta/applications/${AZ_APP_DASH_OBJECT_ID}" --body '{"api":{"requestedAccessTokenVersion": 2}}'
  * AZ_APP_DASH_SECRET=$(az ad sp credential reset --name ${AZ_APP_DASH_ID} --credential-description "azad-kube-proxy" --output tsv --query password)
  * ```
- * 
+ *
  * ### Azure KeyVault
- * 
+ *
  * ```shell
  * JSON_FMT='{"client_id":"%s","client_secret":"%s","tenant_id":"%s","k8dash_client_id":"%s","k8dash_client_secret":"%s","k8dash_scope":"%s"}'
  * KV_SECRET=$(printf "${JSON_FMT}" "${AZ_APP_ID}" "${AZ_APP_SECRET}" "${TENANT_ID}" "${AZ_APP_DASH_ID}" "${AZ_APP_DASH_SECRET}" "${AZ_APP_URI}/.default")
  * az keyvault secret set --vault-name <keyvault name> --name azad-kube-proxy --value "${KV_SECRET}"
  * ```
- * 
+ *
  * ## Terraform example (aks-core)
- * 
+ *
  * ```terraform
  * data "azurerm_key_vault_secret" "azad_kube_proxy" {
  *   key_vault_id = data.azurerm_key_vault.core.id
  *   name         = "azad-kube-proxy"
  * }
- * 
+ *
  * module "aks_core" {
  *   source = "github.com/xenitab/terraform-modules//modules/kubernetes/aks-core?ref=[ref]"
- * 
+ *
  *   [...]
- * 
+ *
  *   azad_kube_proxy_enabled = true
  *   azad_kube_proxy_config = {
  *     fqdn                  = "aks.${var.dns_zone}"
@@ -77,7 +77,7 @@
  *   }
  * }
  * ```
- * 
+ *
 */
 
 terraform {
@@ -115,6 +115,7 @@ resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
       name = "azad-kube-proxy"
+      "xkf.xenit.io/kind" = "platform"
     }
     name = "azad-kube-proxy"
   }

--- a/modules/kubernetes/azad-kube-proxy/main.tf
+++ b/modules/kubernetes/azad-kube-proxy/main.tf
@@ -114,7 +114,7 @@ locals {
 resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
-      name = "azad-kube-proxy"
+      name                = "azad-kube-proxy"
       "xkf.xenit.io/kind" = "platform"
     }
     name = "azad-kube-proxy"

--- a/modules/kubernetes/cert-manager/README.md
+++ b/modules/kubernetes/cert-manager/README.md
@@ -38,6 +38,7 @@ No modules.
 | <a name="input_azure_config"></a> [azure\_config](#input\_azure\_config) | Azure specific configuration | <pre>object({<br>    subscription_id     = string,<br>    hosted_zone_name    = string,<br>    resource_group_name = string,<br>    client_id           = string,<br>    resource_id         = string,<br>  })</pre> | <pre>{<br>  "client_id": "",<br>  "hosted_zone_name": "",<br>  "resource_group_name": "",<br>  "resource_id": "",<br>  "subscription_id": ""<br>}</pre> | no |
 | <a name="input_cloud_provider"></a> [cloud\_provider](#input\_cloud\_provider) | Cloud provider to use. | `string` | n/a | yes |
 | <a name="input_notification_email"></a> [notification\_email](#input\_notification\_email) | Email address to send certificate expiration notifications | `string` | n/a | yes |
+| <a name="input_prometheus_enabled"></a> [prometheus\_enabled](#input\_prometheus\_enabled) | Should a ServiceMonitor be created | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/kubernetes/cert-manager/main.tf
+++ b/modules/kubernetes/cert-manager/main.tf
@@ -26,7 +26,7 @@ locals {
 resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
-      name = local.namespace
+      name                = local.namespace
       "xkf.xenit.io/kind" = "platform"
     }
     name = local.namespace

--- a/modules/kubernetes/cert-manager/main.tf
+++ b/modules/kubernetes/cert-manager/main.tf
@@ -27,6 +27,7 @@ resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
       name = local.namespace
+      "xkf.xenit.io/kind" = "platform"
     }
     name = local.namespace
   }
@@ -38,7 +39,11 @@ resource "helm_release" "cert_manager" {
   name       = "cert-manager"
   namespace  = kubernetes_namespace.this.metadata[0].name
   version    = "v1.3.0"
-  values     = [templatefile("${path.module}/templates/values.yaml.tpl", { provider = var.cloud_provider, aws_config = var.aws_config })]
+  values = [templatefile("${path.module}/templates/values.yaml.tpl", {
+    provider           = var.cloud_provider,
+    aws_config         = var.aws_config,
+    prometheus_enabled = var.prometheus_enabled,
+  })]
 }
 
 resource "helm_release" "cert_manager_extras" {

--- a/modules/kubernetes/cert-manager/templates/values.yaml.tpl
+++ b/modules/kubernetes/cert-manager/templates/values.yaml.tpl
@@ -11,3 +11,10 @@ serviceAccount:
 securityContext:
   fsGroup: 1001
 %{ endif }
+
+prometheus:
+  enabled: ${prometheus_enabled}
+  servicemonitor:
+    enabled: ${prometheus_enabled}
+    labels:
+      xkf.xenit.io/monitoring: platform

--- a/modules/kubernetes/cert-manager/variables.tf
+++ b/modules/kubernetes/cert-manager/variables.tf
@@ -1,3 +1,9 @@
+variable "prometheus_enabled" {
+  description = "Should a ServiceMonitor be created"
+  type        = bool
+  default     = false
+}
+
 variable "notification_email" {
   description = "Email address to send certificate expiration notifications"
   type        = string

--- a/modules/kubernetes/csi-secrets-store-provider-azure/README.md
+++ b/modules/kubernetes/csi-secrets-store-provider-azure/README.md
@@ -26,11 +26,14 @@ No modules.
 | Name | Type |
 |------|------|
 | [helm_release.csi_secrets_store_provider_azure](https://registry.terraform.io/providers/hashicorp/helm/2.1.0/docs/resources/release) | resource |
+| [helm_release.csi_secrets_store_provider_azure_extras](https://registry.terraform.io/providers/hashicorp/helm/2.1.0/docs/resources/release) | resource |
 | [kubernetes_namespace.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.0.3/docs/resources/namespace) | resource |
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_prometheus_enabled"></a> [prometheus\_enabled](#input\_prometheus\_enabled) | Should a ServiceMonitor be created | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/kubernetes/csi-secrets-store-provider-azure/charts/csi-secrets-store-provider-azure-extras/.helmignore
+++ b/modules/kubernetes/csi-secrets-store-provider-azure/charts/csi-secrets-store-provider-azure-extras/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/modules/kubernetes/csi-secrets-store-provider-azure/charts/csi-secrets-store-provider-azure-extras/Chart.yaml
+++ b/modules/kubernetes/csi-secrets-store-provider-azure/charts/csi-secrets-store-provider-azure-extras/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: csi-secret-store-provider-azure-extras
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/modules/kubernetes/csi-secrets-store-provider-azure/charts/csi-secrets-store-provider-azure-extras/templates/csi-driver-monitor.yaml
+++ b/modules/kubernetes/csi-secrets-store-provider-azure/charts/csi-secrets-store-provider-azure-extras/templates/csi-driver-monitor.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.prometheusEnabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: secrets-store-csi-driver
+  labels:
+    xkf.xenit.io/monitoring: platform
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: secrets-store-csi-driver
+      app.kubernetes.io/instance: csi-secrets-store-provider-azure
+  podMetricsEndpoints:
+    - path: /metrics
+      port: "8081"
+{{- end }}

--- a/modules/kubernetes/csi-secrets-store-provider-azure/charts/csi-secrets-store-provider-azure-extras/values.yaml
+++ b/modules/kubernetes/csi-secrets-store-provider-azure/charts/csi-secrets-store-provider-azure-extras/values.yaml
@@ -1,0 +1,1 @@
+prometheusEnabled: false

--- a/modules/kubernetes/csi-secrets-store-provider-azure/main.tf
+++ b/modules/kubernetes/csi-secrets-store-provider-azure/main.tf
@@ -23,6 +23,7 @@ resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
       name = "csi-secrets-store-provider-azure"
+      "xkf.xenit.io/kind" = "platform"
     }
     name = "csi-secrets-store-provider-azure"
   }
@@ -53,5 +54,18 @@ resource "helm_release" "csi_secrets_store_provider_azure" {
   set {
     name  = "secrets-store-csi-driver.linux.tolerations[0].operator"
     value = "Exists"
+  }
+}
+
+resource "helm_release" "csi_secrets_store_provider_azure_extras" {
+  depends_on = [helm_release.csi_secrets_store_provider_azure]
+
+  chart     = "${path.module}/charts/csi-secrets-store-provider-azure-extras"
+  name      = "csi-secrets-store-provider-azure-extras"
+  namespace = kubernetes_namespace.this.metadata[0].name
+
+  set {
+    name  = "prometheusEnabled"
+    value = var.prometheus_enabled
   }
 }

--- a/modules/kubernetes/csi-secrets-store-provider-azure/main.tf
+++ b/modules/kubernetes/csi-secrets-store-provider-azure/main.tf
@@ -22,7 +22,7 @@ terraform {
 resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
-      name = "csi-secrets-store-provider-azure"
+      name                = "csi-secrets-store-provider-azure"
       "xkf.xenit.io/kind" = "platform"
     }
     name = "csi-secrets-store-provider-azure"

--- a/modules/kubernetes/csi-secrets-store-provider-azure/variables.tf
+++ b/modules/kubernetes/csi-secrets-store-provider-azure/variables.tf
@@ -1,0 +1,5 @@
+variable "prometheus_enabled" {
+  description = "Should a ServiceMonitor be created"
+  type        = bool
+  default     = false
+}

--- a/modules/kubernetes/datadog/main.tf
+++ b/modules/kubernetes/datadog/main.tf
@@ -31,7 +31,7 @@ locals {
 resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
-      name = "datadog"
+      name                = "datadog"
       "xkf.xenit.io/kind" = "platform"
     }
     name = "datadog"

--- a/modules/kubernetes/datadog/main.tf
+++ b/modules/kubernetes/datadog/main.tf
@@ -32,6 +32,7 @@ resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
       name = "datadog"
+      "xkf.xenit.io/kind" = "platform"
     }
     name = "datadog"
   }

--- a/modules/kubernetes/external-dns/README.md
+++ b/modules/kubernetes/external-dns/README.md
@@ -36,6 +36,7 @@ No modules.
 | <a name="input_aws_config"></a> [aws\_config](#input\_aws\_config) | AWS specific configuration | <pre>object({<br>    role_arn = string,<br>    region   = string<br>  })</pre> | <pre>{<br>  "region": "",<br>  "role_arn": ""<br>}</pre> | no |
 | <a name="input_azure_config"></a> [azure\_config](#input\_azure\_config) | AWS specific configuration | <pre>object({<br>    subscription_id = string,<br>    tenant_id       = string,<br>    resource_group  = string,<br>    client_id       = string,<br>    resource_id     = string<br>  })</pre> | <pre>{<br>  "client_id": "",<br>  "resource_group": "",<br>  "resource_id": "",<br>  "subscription_id": "",<br>  "tenant_id": ""<br>}</pre> | no |
 | <a name="input_dns_provider"></a> [dns\_provider](#input\_dns\_provider) | DNS provider to use. | `string` | n/a | yes |
+| <a name="input_prometheus_enabled"></a> [prometheus\_enabled](#input\_prometheus\_enabled) | Should a ServiceMonitor be created | `bool` | `false` | no |
 | <a name="input_sources"></a> [sources](#input\_sources) | k8s resource types to observe | `list(string)` | <pre>[<br>  "ingress",<br>  "service"<br>]</pre> | no |
 | <a name="input_txt_owner_id"></a> [txt\_owner\_id](#input\_txt\_owner\_id) | The txt-owner-id for external-dns | `string` | n/a | yes |
 

--- a/modules/kubernetes/external-dns/main.tf
+++ b/modules/kubernetes/external-dns/main.tf
@@ -33,7 +33,7 @@ locals {
 resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
-      name = "external-dns"
+      name                = "external-dns"
       "xkf.xenit.io/kind" = "platform"
     }
     name = "external-dns"

--- a/modules/kubernetes/external-dns/main.tf
+++ b/modules/kubernetes/external-dns/main.tf
@@ -21,11 +21,12 @@ terraform {
 
 locals {
   values = templatefile("${path.module}/templates/values.yaml.tpl", {
-    provider     = var.dns_provider,
-    sources      = var.sources,
-    azure_config = var.azure_config,
-    aws_config   = var.aws_config,
-    txt_owner_id = var.txt_owner_id,
+    provider           = var.dns_provider,
+    sources            = var.sources,
+    azure_config       = var.azure_config,
+    aws_config         = var.aws_config,
+    txt_owner_id       = var.txt_owner_id,
+    prometheus_enabled = var.prometheus_enabled
   })
 }
 
@@ -33,6 +34,7 @@ resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
       name = "external-dns"
+      "xkf.xenit.io/kind" = "platform"
     }
     name = "external-dns"
   }

--- a/modules/kubernetes/external-dns/templates/values.yaml.tpl
+++ b/modules/kubernetes/external-dns/templates/values.yaml.tpl
@@ -26,3 +26,10 @@ serviceAccount:
 policy: sync # will also delete the record
 registry: "txt"
 txtOwnerId: "${txt_owner_id}"
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: ${prometheus_enabled}
+    selector:
+      xkf.xenit.io/monitoring: platform

--- a/modules/kubernetes/external-dns/variables.tf
+++ b/modules/kubernetes/external-dns/variables.tf
@@ -1,3 +1,9 @@
+variable "prometheus_enabled" {
+  description = "Should a ServiceMonitor be created"
+  type        = bool
+  default     = false
+}
+
 variable "dns_provider" {
   description = "DNS provider to use."
   type        = string

--- a/modules/kubernetes/external-secrets/main.tf
+++ b/modules/kubernetes/external-secrets/main.tf
@@ -29,6 +29,7 @@ resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
       name = "external-secrets"
+      "xkf.xenit.io/kind" = "platform"
     }
     name = "external-secrets"
   }

--- a/modules/kubernetes/external-secrets/main.tf
+++ b/modules/kubernetes/external-secrets/main.tf
@@ -28,7 +28,7 @@ locals {
 resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
-      name = "external-secrets"
+      name                = "external-secrets"
       "xkf.xenit.io/kind" = "platform"
     }
     name = "external-secrets"

--- a/modules/kubernetes/falco/main.tf
+++ b/modules/kubernetes/falco/main.tf
@@ -34,7 +34,7 @@ locals {
 resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
-      name = "falco"
+      name                = "falco"
       "xkf.xenit.io/kind" = "platform"
     }
     name = "falco"

--- a/modules/kubernetes/falco/main.tf
+++ b/modules/kubernetes/falco/main.tf
@@ -35,6 +35,7 @@ resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
       name = "falco"
+      "xkf.xenit.io/kind" = "platform"
     }
     name = "falco"
   }

--- a/modules/kubernetes/fluxcd-v2-azdo/README.md
+++ b/modules/kubernetes/fluxcd-v2-azdo/README.md
@@ -50,6 +50,7 @@ No modules.
 | [azuredevops_git_repository_file.sync](https://registry.terraform.io/providers/xenitab/azuredevops/0.3.0/docs/resources/git_repository_file) | resource |
 | [azuredevops_git_repository_file.tenant](https://registry.terraform.io/providers/xenitab/azuredevops/0.3.0/docs/resources/git_repository_file) | resource |
 | [helm_release.azdo_proxy](https://registry.terraform.io/providers/hashicorp/helm/2.1.0/docs/resources/release) | resource |
+| [helm_release.flux_v2_extras](https://registry.terraform.io/providers/hashicorp/helm/2.1.0/docs/resources/release) | resource |
 | [kubectl_manifest.install](https://registry.terraform.io/providers/gavinbunney/kubectl/1.10.0/docs/resources/manifest) | resource |
 | [kubectl_manifest.sync](https://registry.terraform.io/providers/gavinbunney/kubectl/1.10.0/docs/resources/manifest) | resource |
 | [kubernetes_namespace.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.0.3/docs/resources/namespace) | resource |
@@ -75,6 +76,7 @@ No modules.
 | <a name="input_cluster_repo"></a> [cluster\_repo](#input\_cluster\_repo) | Name of cluster repository | `string` | `"fleet-infra"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name of the cluster | `string` | n/a | yes |
 | <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | The namespaces to configure flux with | <pre>list(<br>    object({<br>      name = string<br>      flux = object({<br>        enabled     = bool<br>        create_crds = bool<br>        org         = string<br>        proj        = string<br>        repo        = string<br>      })<br>    })<br>  )</pre> | n/a | yes |
+| <a name="input_prometheus_enabled"></a> [prometheus\_enabled](#input\_prometheus\_enabled) | Should a ServiceMonitor be created | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/kubernetes/fluxcd-v2-azdo/charts/flux-v2-extras/.helmignore
+++ b/modules/kubernetes/fluxcd-v2-azdo/charts/flux-v2-extras/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/modules/kubernetes/fluxcd-v2-azdo/charts/flux-v2-extras/Chart.yaml
+++ b/modules/kubernetes/fluxcd-v2-azdo/charts/flux-v2-extras/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: flux-v2-extras
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/modules/kubernetes/fluxcd-v2-azdo/charts/flux-v2-extras/templates/helm-controller-monitor.yaml
+++ b/modules/kubernetes/fluxcd-v2-azdo/charts/flux-v2-extras/templates/helm-controller-monitor.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.prometheusEnabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: helm-controller
+  labels:
+    xkf.xenit.io/monitoring: platform
+spec:
+  selector:
+    matchLabels:
+      app: helm-controller
+  podMetricsEndpoints:
+    - port: http-prom
+{{- end }}

--- a/modules/kubernetes/fluxcd-v2-azdo/charts/flux-v2-extras/templates/kustomize-controller-monitor.yaml
+++ b/modules/kubernetes/fluxcd-v2-azdo/charts/flux-v2-extras/templates/kustomize-controller-monitor.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.prometheusEnabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: kustomize-controller
+  labels:
+    xkf.xenit.io/monitoring: platform
+spec:
+  selector:
+    matchLabels:
+      app: kustomize-controller
+  podMetricsEndpoints:
+    - port: http-prom
+{{- end }}

--- a/modules/kubernetes/fluxcd-v2-azdo/charts/flux-v2-extras/templates/notification-controller-monitor.yaml
+++ b/modules/kubernetes/fluxcd-v2-azdo/charts/flux-v2-extras/templates/notification-controller-monitor.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.prometheusEnabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: notification-controller
+  labels:
+    xkf.xenit.io/monitoring: platform
+spec:
+  selector:
+    matchLabels:
+      app: notification-controller
+  podMetricsEndpoints:
+    - port: http-prom
+{{- end }}

--- a/modules/kubernetes/fluxcd-v2-azdo/charts/flux-v2-extras/templates/source-controller-monitor.yaml
+++ b/modules/kubernetes/fluxcd-v2-azdo/charts/flux-v2-extras/templates/source-controller-monitor.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.prometheusEnabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: source-controller
+  labels:
+    xkf.xenit.io/monitoring: platform
+spec:
+  selector:
+    matchLabels:
+      app: source-controller
+  podMetricsEndpoints:
+    - port: http-prom
+{{- end }}

--- a/modules/kubernetes/fluxcd-v2-azdo/charts/flux-v2-extras/values.yaml
+++ b/modules/kubernetes/fluxcd-v2-azdo/charts/flux-v2-extras/values.yaml
@@ -1,0 +1,1 @@
+prometheusEnabled: false

--- a/modules/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/main.tf
@@ -93,6 +93,18 @@ resource "helm_release" "azdo_proxy" {
   values     = [local.azdo_proxy_values]
 }
 
+# Monitoring
+resource "helm_release" "flux_v2_extras" {
+  chart     = "${path.module}/charts/flux-v2-extras"
+  name      = "flux-v2-extras"
+  namespace = kubernetes_namespace.this.metadata[0].name
+
+  set {
+    name  = "prometheusEnabled"
+    value = var.prometheus_enabled
+  }
+}
+
 # Cluster
 data "azuredevops_git_repository" "cluster" {
   project_id = data.azuredevops_project.this.id
@@ -182,7 +194,7 @@ resource "azuredevops_git_repository_file" "sync" {
 resource "azuredevops_git_repository_file" "kustomize" {
   repository_id       = data.azuredevops_git_repository.cluster.id
   file                = data.flux_sync.this.kustomize_path
-  content             = data.flux_sync.this.kustomize_content
+  content             = file("${path.module}/templates/kustomization-override.yaml")
   branch              = "refs/heads/${var.branch}"
   overwrite_on_create = true
 }

--- a/modules/kubernetes/fluxcd-v2-azdo/templates/kustomization-override.yaml
+++ b/modules/kubernetes/fluxcd-v2-azdo/templates/kustomization-override.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- gotk-sync.yaml
+- gotk-components.yaml
+patchesStrategicMerge:
+- |-
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: flux-system
+    labels:
+      xkf.xenit.io/kind: "platform"

--- a/modules/kubernetes/fluxcd-v2-azdo/variables.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/variables.tf
@@ -1,3 +1,9 @@
+variable "prometheus_enabled" {
+  description = "Should a ServiceMonitor be created"
+  type        = bool
+  default     = false
+}
+
 variable "azure_devops_pat" {
   description = "PAT to authenticate with Azure DevOps"
   type        = string

--- a/modules/kubernetes/fluxcd-v2-github/main.tf
+++ b/modules/kubernetes/fluxcd-v2-github/main.tf
@@ -51,6 +51,7 @@ resource "kubernetes_namespace" "flux_system" {
     name = "flux-system"
     labels = {
       name = "flux-system"
+      "xkf.xenit.io/kind" = "platform"
     }
   }
 

--- a/modules/kubernetes/fluxcd-v2-github/main.tf
+++ b/modules/kubernetes/fluxcd-v2-github/main.tf
@@ -50,7 +50,7 @@ resource "kubernetes_namespace" "flux_system" {
   metadata {
     name = "flux-system"
     labels = {
-      name = "flux-system"
+      name                = "flux-system"
       "xkf.xenit.io/kind" = "platform"
     }
   }

--- a/modules/kubernetes/ingress-nginx/README.md
+++ b/modules/kubernetes/ingress-nginx/README.md
@@ -33,6 +33,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_http_snippet"></a> [http\_snippet](#input\_http\_snippet) | Configure helm ingress http-snippet | `string` | `""` | no |
+| <a name="input_prometheus_enabled"></a> [prometheus\_enabled](#input\_prometheus\_enabled) | Should a ServiceMonitor be created | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/kubernetes/ingress-nginx/main.tf
+++ b/modules/kubernetes/ingress-nginx/main.tf
@@ -23,6 +23,7 @@ resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
       name = "ingress-nginx"
+      "xkf.xenit.io/kind" = "platform"
     }
     name = "ingress-nginx"
   }
@@ -35,6 +36,7 @@ resource "helm_release" "ingress_nginx" {
   namespace  = kubernetes_namespace.this.metadata[0].name
   version    = "3.29.0"
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
-    http_snippet = var.http_snippet
+    http_snippet       = var.http_snippet,
+    prometheus_enabled = var.prometheus_enabled,
   })]
 }

--- a/modules/kubernetes/ingress-nginx/main.tf
+++ b/modules/kubernetes/ingress-nginx/main.tf
@@ -22,7 +22,7 @@ terraform {
 resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
-      name = "ingress-nginx"
+      name                = "ingress-nginx"
       "xkf.xenit.io/kind" = "platform"
     }
     name = "ingress-nginx"

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -8,3 +8,10 @@ controller:
     http-snippet: |
       ${http_snippet}
     %{ endif }
+
+  metrics:
+    enabled: ${prometheus_enabled}
+    serviceMonitor:
+      enabled: ${prometheus_enabled}
+      additionalLabels:
+        xkf.xenit.io/monitoring: platform

--- a/modules/kubernetes/ingress-nginx/variables.tf
+++ b/modules/kubernetes/ingress-nginx/variables.tf
@@ -1,3 +1,9 @@
+variable "prometheus_enabled" {
+  description = "Should a ServiceMonitor be created"
+  type        = bool
+  default     = false
+}
+
 variable "http_snippet" {
   description = "Configure helm ingress http-snippet"
   type        = string

--- a/modules/kubernetes/kyverno/main.tf
+++ b/modules/kubernetes/kyverno/main.tf
@@ -17,6 +17,7 @@ resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
       name = "kyverno"
+      "xkf.xenit.io/kind" = "platform"
     }
     name = "kyverno"
   }

--- a/modules/kubernetes/kyverno/main.tf
+++ b/modules/kubernetes/kyverno/main.tf
@@ -16,7 +16,7 @@ terraform {
 resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
-      name = "kyverno"
+      name                = "kyverno"
       "xkf.xenit.io/kind" = "platform"
     }
     name = "kyverno"

--- a/modules/kubernetes/loki/main.tf
+++ b/modules/kubernetes/loki/main.tf
@@ -50,7 +50,7 @@ resource "azurerm_storage_container" "loki" {
 resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
-      name = "loki"
+      name                = "loki"
       "xkf.xenit.io/kind" = "platform"
     }
     name = "loki"

--- a/modules/kubernetes/loki/main.tf
+++ b/modules/kubernetes/loki/main.tf
@@ -51,6 +51,7 @@ resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
       name = "loki"
+      "xkf.xenit.io/kind" = "platform"
     }
     name = "loki"
   }

--- a/modules/kubernetes/opa-gatekeeper/main.tf
+++ b/modules/kubernetes/opa-gatekeeper/main.tf
@@ -112,7 +112,7 @@ resource "kubernetes_namespace" "this" {
     labels = {
       name                             = "gatekeeper-system"
       "admission.gatekeeper.sh/ignore" = "no-self-managing"
-      "xkf.xenit.io/kind" = "platform"
+      "xkf.xenit.io/kind"              = "platform"
     }
     name = "gatekeeper-system"
   }

--- a/modules/kubernetes/opa-gatekeeper/main.tf
+++ b/modules/kubernetes/opa-gatekeeper/main.tf
@@ -112,6 +112,7 @@ resource "kubernetes_namespace" "this" {
     labels = {
       name                             = "gatekeeper-system"
       "admission.gatekeeper.sh/ignore" = "no-self-managing"
+      "xkf.xenit.io/kind" = "platform"
     }
     name = "gatekeeper-system"
   }
@@ -133,7 +134,7 @@ resource "helm_release" "gatekeeper_templates" {
   chart      = "gatekeeper-library-templates"
   name       = "gatekeeper-library-templates"
   namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "v0.7.0"
+  version    = "v0.7.1"
   values     = [local.values]
 }
 
@@ -144,6 +145,6 @@ resource "helm_release" "gatekeeper_constraints" {
   chart      = "gatekeeper-library-constraints"
   name       = "gatekeeper-library-constraints"
   namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "v0.7.0"
+  version    = "v0.7.1"
   values     = [local.values]
 }

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/templates/prometheus-servicemonitor.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/templates/prometheus-servicemonitor.yaml
@@ -12,4 +12,4 @@ spec:
       port: web
   selector:
     matchLabels:
-      xkf.xenit.se/monitoring: platform
+      xkf.xenit.io/monitoring: platform

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/templates/prometheus.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/templates/prometheus.yaml
@@ -10,13 +10,13 @@ spec:
   serviceAccountName: {{ .Values.serviceAccount.name }}
   serviceMonitorSelector:
     matchLabels:
-      xkf.xenit.se/monitoring: platform
+      xkf.xenit.io/monitoring: platform
   probeSelector:
     matchLabels:
-      xkf.xenit.se/monitoring: platform
+      xkf.xenit.io/monitoring: platform
   podMonitorSelector:
     matchLabels:
-      xkf.xenit.se/monitoring: platform
+      xkf.xenit.io/monitoring: platform
   {{- if .Values.remoteWrite.enabled }}
   remoteWrite:
     - url: {{ .Values.remoteWrite.url }}

--- a/modules/kubernetes/prometheus/main.tf
+++ b/modules/kubernetes/prometheus/main.tf
@@ -27,7 +27,7 @@ locals {
 resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
-      name = local.namespace
+      name                = local.namespace
       "xkf.xenit.io/kind" = "platform"
     }
     name = local.namespace

--- a/modules/kubernetes/prometheus/main.tf
+++ b/modules/kubernetes/prometheus/main.tf
@@ -28,6 +28,7 @@ resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
       name = local.namespace
+      "xkf.xenit.io/kind" = "platform"
     }
     name = local.namespace
   }

--- a/modules/kubernetes/prometheus/templates/values.yaml.tpl
+++ b/modules/kubernetes/prometheus/templates/values.yaml.tpl
@@ -15,13 +15,32 @@ alertmanager:
 
 prometheus:
   enabled: false
+  prometheusSpec:
+    serviceMonitorSelector:
+      matchLabels:
+       "xkf.xenit.io/monitoring": platform
+    serviceMonitorNamespaceSelector:
+      matchLabels:
+       "xkf.xenit.io/kind": platform
+    podMonitorSelector:
+      matchLabels:
+       "xkf.xenit.io/monitoring": platform
+    podMonitorNamespaceSelector:
+      matchLabels:
+       "xkf.xenit.io/kind": platform
+    probeSelector:
+      matchLabels:
+       "xkf.xenit.io/monitoring": platform
+    probeNamespaceSelector:
+      matchLabels:
+       "xkf.xenit.io/kind": platform
 
 kube-state-metrics:
   podSecurityPolicy:
     enabled: false
 
 commonLabels:
-  xkf.xenit.se/monitoring: platform
+  xkf.xenit.io/monitoring: platform
 
 global:
   rbac:

--- a/modules/kubernetes/reloader/README.md
+++ b/modules/kubernetes/reloader/README.md
@@ -30,7 +30,9 @@ No modules.
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_prometheus_enabled"></a> [prometheus\_enabled](#input\_prometheus\_enabled) | Should a ServiceMonitor be created | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/kubernetes/reloader/main.tf
+++ b/modules/kubernetes/reloader/main.tf
@@ -2,7 +2,7 @@
   * # Reloader
   *
   * Adds [`Reloader`](https://github.com/stakater/Reloader) to a Kubernetes clusters.
-  * 
+  *
   */
 
 terraform {
@@ -24,6 +24,7 @@ resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
       name = "reloader"
+      "xkf.xenit.io/kind" = "platform"
     }
     name = "reloader"
   }
@@ -35,4 +36,7 @@ resource "helm_release" "reloader" {
   name       = "reloader"
   namespace  = kubernetes_namespace.this.metadata[0].name
   version    = "v0.0.86"
+  values     = [templatefile("${path.module}/templates/values.yaml.tpl", {
+    prometheus_enabled = var.prometheus_enabled
+  })]
 }

--- a/modules/kubernetes/reloader/main.tf
+++ b/modules/kubernetes/reloader/main.tf
@@ -23,7 +23,7 @@ terraform {
 resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
-      name = "reloader"
+      name                = "reloader"
       "xkf.xenit.io/kind" = "platform"
     }
     name = "reloader"
@@ -36,7 +36,7 @@ resource "helm_release" "reloader" {
   name       = "reloader"
   namespace  = kubernetes_namespace.this.metadata[0].name
   version    = "v0.0.86"
-  values     = [templatefile("${path.module}/templates/values.yaml.tpl", {
+  values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     prometheus_enabled = var.prometheus_enabled
   })]
 }

--- a/modules/kubernetes/reloader/templates/values.yaml.tpl
+++ b/modules/kubernetes/reloader/templates/values.yaml.tpl
@@ -1,0 +1,5 @@
+reloader:
+  serviceMonitor:
+    enabled: ${prometheus_enabled}
+    labels:
+      xkf.xenit.io/monitoring: platform

--- a/modules/kubernetes/reloader/variables.tf
+++ b/modules/kubernetes/reloader/variables.tf
@@ -1,0 +1,5 @@
+variable "prometheus_enabled" {
+  description = "Should a ServiceMonitor be created"
+  type        = bool
+  default     = false
+}

--- a/modules/kubernetes/velero/README.md
+++ b/modules/kubernetes/velero/README.md
@@ -36,6 +36,7 @@ No modules.
 | <a name="input_aws_config"></a> [aws\_config](#input\_aws\_config) | AWS specific configuration | <pre>object({<br>    role_arn     = string,<br>    region       = string,<br>    s3_bucket_id = string<br>  })</pre> | <pre>{<br>  "region": "",<br>  "role_arn": "",<br>  "s3_bucket_id": ""<br>}</pre> | no |
 | <a name="input_azure_config"></a> [azure\_config](#input\_azure\_config) | AWS specific configuration | <pre>object({<br>    subscription_id           = string,<br>    resource_group            = string,<br>    client_id                 = string,<br>    resource_id               = string,<br>    storage_account_name      = string,<br>    storage_account_container = string<br>  })</pre> | <pre>{<br>  "client_id": "",<br>  "resource_group": "",<br>  "resource_id": "",<br>  "storage_account_container": "",<br>  "storage_account_name": "",<br>  "subscription_id": "",<br>  "tenant_id": ""<br>}</pre> | no |
 | <a name="input_cloud_provider"></a> [cloud\_provider](#input\_cloud\_provider) | Cloud provider to use. | `string` | `"azure"` | no |
+| <a name="input_prometheus_enabled"></a> [prometheus\_enabled](#input\_prometheus\_enabled) | Should a ServiceMonitor be created | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/kubernetes/velero/main.tf
+++ b/modules/kubernetes/velero/main.tf
@@ -22,7 +22,7 @@ terraform {
 resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
-      name = "velero"
+      name                = "velero"
       "xkf.xenit.io/kind" = "platform"
     }
     name = "velero"
@@ -36,9 +36,9 @@ resource "helm_release" "velero" {
   namespace  = kubernetes_namespace.this.metadata[0].name
   version    = "2.16.0"
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
-    cloud_provider = var.cloud_provider,
-    azure_config   = var.azure_config,
-    aws_config     = var.aws_config,
+    cloud_provider     = var.cloud_provider,
+    azure_config       = var.azure_config,
+    aws_config         = var.aws_config,
     prometheus_enabled = var.prometheus_enabled
   })]
 }

--- a/modules/kubernetes/velero/main.tf
+++ b/modules/kubernetes/velero/main.tf
@@ -19,18 +19,11 @@ terraform {
   }
 }
 
-locals {
-  values = templatefile("${path.module}/templates/values.yaml.tpl", {
-    cloud_provider = var.cloud_provider,
-    azure_config   = var.azure_config
-    aws_config     = var.aws_config
-  })
-}
-
 resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
       name = "velero"
+      "xkf.xenit.io/kind" = "platform"
     }
     name = "velero"
   }
@@ -42,7 +35,12 @@ resource "helm_release" "velero" {
   name       = "velero"
   namespace  = kubernetes_namespace.this.metadata[0].name
   version    = "2.16.0"
-  values     = [local.values]
+  values = [templatefile("${path.module}/templates/values.yaml.tpl", {
+    cloud_provider = var.cloud_provider,
+    azure_config   = var.azure_config,
+    aws_config     = var.aws_config,
+    prometheus_enabled = var.prometheus_enabled
+  })]
 }
 
 resource "helm_release" "velero_extras" {

--- a/modules/kubernetes/velero/templates/values.yaml.tpl
+++ b/modules/kubernetes/velero/templates/values.yaml.tpl
@@ -1,3 +1,14 @@
+metrics:
+  enabled: ${prometheus_enabled}
+  podAnnotations: {}
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8085"
+    prometheus.io/path: "/metrics"
+  serviceMonitor:
+    enabled: ${prometheus_enabled}
+    additionalLabels:
+      xkf.xenit.io/monitoring: platform
+
 %{ if cloud_provider == "azure" }
 configuration:
   provider: "azure"

--- a/modules/kubernetes/velero/variables.tf
+++ b/modules/kubernetes/velero/variables.tf
@@ -1,3 +1,9 @@
+variable "prometheus_enabled" {
+  description = "Should a ServiceMonitor be created"
+  type        = bool
+  default     = false
+}
+
 variable "cloud_provider" {
   description = "Cloud provider to use."
   type        = string


### PR DESCRIPTION
Adds `PodMonitor`and `ServiceMonitor`resources to most of the kubernetes modules. There may be some module that has been missed but this is a good starting point to get things going.

Additionally all namespaces have received the label `xkf.xenit.io/kind` with the value of `platform` or `tenant` to simplify creating selectors for specific namespaces.