### PR TITLE
Add resource limits on prometheus

### DIFF
--- a/modules/kubernetes/prometheus/templates/values-extras.yaml.tpl
+++ b/modules/kubernetes/prometheus/templates/values-extras.yaml.tpl
@@ -18,4 +18,3 @@ resources:
     cpu: "20m"
   limits:
     memory: "500Mi"
-    cpu: "100m"

--- a/modules/kubernetes/prometheus/templates/values-extras.yaml.tpl
+++ b/modules/kubernetes/prometheus/templates/values-extras.yaml.tpl
@@ -11,3 +11,11 @@ volumeClaim:
   enabled: ${volume_claim_enabled}
   storageClassName: ${volume_claim_storage_class_name}
   size: ${volume_claim_size}
+
+resources:
+  requests:
+    memory: "250Mi"
+    cpu: "20m"
+  limits:
+    memory: "500Mi"
+    cpu: "100m"


### PR DESCRIPTION
These values is currently hard-coded.
It's supposed to only look at XKF features.