### PR TITLE
Set container security context for ingress-healthz

### DIFF
--- a/modules/kubernetes/ingress-healthz/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-healthz/templates/values.yaml.tpl
@@ -7,6 +7,19 @@ resources:
   limits:
     memory: 128Mi
 
+containerSecurityContext:
+  enabled: true
+  runAsUser: 1001
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+    - NET_RAW
+  # Work around until PR gets merged
+  # https://github.com/bitnami/charts/pull/6101
+  sysctls: null
+
 service:
   type: ClusterIP
 


### PR DESCRIPTION
Removes the need to rely on mutation webhooks for setting a correct security context.