### PR TITLE
Add ingress nginx name override and internal setting

### DIFF
--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -130,7 +130,8 @@ module "ingress_nginx" {
 
   source = "../../kubernetes/ingress-nginx"
 
-  http_snippet = var.ingress_config.http_snippet
+  cloud_provider = "azure"
+  http_snippet   = var.ingress_config.http_snippet
 }
 
 # External DNS

--- a/modules/kubernetes/eks-core/modules.tf
+++ b/modules/kubernetes/eks-core/modules.tf
@@ -65,6 +65,8 @@ module "ingress_nginx" {
   }
 
   source = "../../kubernetes/ingress-nginx"
+
+  cloud_provider = "aws"
 }
 
 # External DNS

--- a/modules/kubernetes/ingress-nginx/README.md
+++ b/modules/kubernetes/ingress-nginx/README.md
@@ -32,7 +32,10 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cloud_provider"></a> [cloud\_provider](#input\_cloud\_provider) | Cloud provider used for load balancer | `string` | n/a | yes |
 | <a name="input_http_snippet"></a> [http\_snippet](#input\_http\_snippet) | Configure helm ingress http-snippet | `string` | `""` | no |
+| <a name="input_internal_load_balancer"></a> [internal\_load\_balancer](#input\_internal\_load\_balancer) | If true ingress controller will create a non public load balancer | `bool` | `false` | no |
+| <a name="input_name_override"></a> [name\_override](#input\_name\_override) | Name of ingress controller and ingress class | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/kubernetes/ingress-nginx/main.tf
+++ b/modules/kubernetes/ingress-nginx/main.tf
@@ -37,5 +37,9 @@ resource "helm_release" "ingress_nginx" {
   version    = "3.29.0"
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     http_snippet = var.http_snippet,
+    name_override = var.name_override != "" ? var.name_override : null
+    provider = var.cloud_provider
+    ingress_class = join(",", compact(["nginx", var.name_override]))
+    internal_load_balancer = var.internal_load_balancer
   })]
 }

--- a/modules/kubernetes/ingress-nginx/main.tf
+++ b/modules/kubernetes/ingress-nginx/main.tf
@@ -37,7 +37,7 @@ resource "helm_release" "ingress_nginx" {
   version    = "3.29.0"
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     http_snippet = var.http_snippet,
-    name_override = var.name_override != "" ? var.name_override : null,
+    name_override = var.name_override,
     provider = var.cloud_provider,
     ingress_class = join(",", compact(["nginx", var.name_override])),
     internal_load_balancer = var.internal_load_balancer,

--- a/modules/kubernetes/ingress-nginx/main.tf
+++ b/modules/kubernetes/ingress-nginx/main.tf
@@ -36,10 +36,10 @@ resource "helm_release" "ingress_nginx" {
   namespace  = kubernetes_namespace.this.metadata[0].name
   version    = "3.29.0"
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
-    http_snippet = var.http_snippet,
-    name_override = var.name_override,
-    provider = var.cloud_provider,
-    ingress_class = join("-", compact(["nginx", var.name_override])),
+    http_snippet           = var.http_snippet,
+    name_override          = var.name_override,
+    provider               = var.cloud_provider,
+    ingress_class          = join("-", compact(["nginx", var.name_override])),
     internal_load_balancer = var.internal_load_balancer,
   })]
 }

--- a/modules/kubernetes/ingress-nginx/main.tf
+++ b/modules/kubernetes/ingress-nginx/main.tf
@@ -22,7 +22,7 @@ terraform {
 resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
-      name                = "ingress-nginx"
+      name                = join("-", compact(["ingress-nginx", var.name_override]))
       "xkf.xenit.io/kind" = "platform"
     }
     name = "ingress-nginx"
@@ -37,9 +37,9 @@ resource "helm_release" "ingress_nginx" {
   version    = "3.29.0"
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     http_snippet = var.http_snippet,
-    name_override = var.name_override != "" ? var.name_override : null
-    provider = var.cloud_provider
-    ingress_class = join(",", compact(["nginx", var.name_override]))
-    internal_load_balancer = var.internal_load_balancer
+    name_override = var.name_override != "" ? var.name_override : null,
+    provider = var.cloud_provider,
+    ingress_class = join(",", compact(["nginx", var.name_override])),
+    internal_load_balancer = var.internal_load_balancer,
   })]
 }

--- a/modules/kubernetes/ingress-nginx/main.tf
+++ b/modules/kubernetes/ingress-nginx/main.tf
@@ -25,7 +25,7 @@ resource "kubernetes_namespace" "this" {
       name                = join("-", compact(["ingress-nginx", var.name_override]))
       "xkf.xenit.io/kind" = "platform"
     }
-    name = "ingress-nginx"
+    name = join("-", compact(["ingress-nginx", var.name_override]))
   }
 }
 

--- a/modules/kubernetes/ingress-nginx/main.tf
+++ b/modules/kubernetes/ingress-nginx/main.tf
@@ -39,7 +39,7 @@ resource "helm_release" "ingress_nginx" {
     http_snippet = var.http_snippet,
     name_override = var.name_override,
     provider = var.cloud_provider,
-    ingress_class = join(",", compact(["nginx", var.name_override])),
+    ingress_class = join("-", compact(["nginx", var.name_override])),
     internal_load_balancer = var.internal_load_balancer,
   })]
 }

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -15,5 +15,5 @@ ingressClass: ${ingress_class}
 %{ if internal_load_balancer }
 service:
   annotations:
-    service.beta.kubernetes.io/${provider}-load-balancer-internal: "true"
+    "service.beta.kubernetes.io/${provider}-load-balancer-internal": "true"
 %{ endif }

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -12,8 +12,8 @@ controller:
 nameOverride: ${name_override}
 ingressClass: ${ingress_class}
 
-%{ if provider == "aws" && internal_load_balancer }
+%{ if internal_load_balancer }
 service:
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-internal
+    service.beta.kubernetes.io/${provider}-load-balancer-internal: "true"
 %{ endif }

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -15,5 +15,5 @@ ingressClass: ${ingress_class}
 %{ if internal_load_balancer }
 service:
   annotations:
-    "service.beta.kubernetes.io/${provider}-load-balancer-internal": "true"
+    service.beta.kubernetes.io/${provider}-load-balancer-internal: true
 %{ endif }

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -8,3 +8,12 @@ controller:
     http-snippet: |
       ${http_snippet}
     %{ endif }
+
+nameOverride: ${name_override}
+ingressClass: ${ingress_class}
+
+%{ if provider == "aws" && internal_load_balancer }
+service:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal
+%{ endif }

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -1,19 +1,20 @@
+nameOverride: ${name_override}
+
 controller:
   replicaCount: 3
+
+  ingressClass: ${ingress_class}
+
   service:
     externalTrafficPolicy: Local
+    %{ if internal_load_balancer }
+      annotations:
+        service.beta.kubernetes.io/${provider}-load-balancer-internal: true
+    %{ endif }
+
   config:
     server-tokens: "false"
     %{ if http_snippet != "" }
     http-snippet: |
       ${http_snippet}
     %{ endif }
-
-nameOverride: ${name_override}
-ingressClass: ${ingress_class}
-
-%{ if internal_load_balancer }
-service:
-  annotations:
-    service.beta.kubernetes.io/${provider}-load-balancer-internal: true
-%{ endif }

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -8,8 +8,8 @@ controller:
   service:
     externalTrafficPolicy: Local
     %{ if internal_load_balancer }
-      annotations:
-        service.beta.kubernetes.io/${provider}-load-balancer-internal: true
+    annotations:
+      service.beta.kubernetes.io/${provider}-load-balancer-internal: true
     %{ endif }
 
   config:

--- a/modules/kubernetes/ingress-nginx/variables.tf
+++ b/modules/kubernetes/ingress-nginx/variables.tf
@@ -1,18 +1,18 @@
 variable "name_override" {
   description = "Name of ingress controller and ingress class"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "cloud_provider" {
   description = "Cloud provider used for load balancer"
-  type = string
+  type        = string
 }
 
 variable "internal_load_balancer" {
   description = "If true ingress controller will create a non public load balancer"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 variable "http_snippet" {

--- a/modules/kubernetes/ingress-nginx/variables.tf
+++ b/modules/kubernetes/ingress-nginx/variables.tf
@@ -1,3 +1,20 @@
+variable "name_override" {
+  description = "Name of ingress controller and ingress class"
+  type = string
+  default = ""
+}
+
+variable "cloud_provider" {
+  description = "Cloud provider used for load balancer"
+  type = string
+}
+
+variable "internal_load_balancer" {
+  description = "If true ingress controller will create a non public load balancer"
+  type = bool
+  default = false
+}
+
 variable "http_snippet" {
   description = "Configure helm ingress http-snippet"
   type        = string

--- a/validation/kubernetes/ingress-nginx/main.tf
+++ b/validation/kubernetes/ingress-nginx/main.tf
@@ -12,5 +12,6 @@ module "ingress_nginx" {
     helm       = helm
   }
 
+  cloud_provider = "bar"
   http_snippet = "foo"
 }


### PR DESCRIPTION
Adds options to set name override, which is appended to the end of the name, and internal lb settings.

This is to enable public/private ingress use cases. The name override will be used in the namespace, deployment name, and ingress class. If nothing is set the behavior will be the same as before.

