### PR TITLE
Remove version pinning from flux

### DIFF
--- a/modules/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/main.tf
@@ -106,7 +106,6 @@ resource "random_password" "cluster" {
 
 data "flux_install" "this" {
   target_path = "clusters/${var.environment}"
-  version     = "v0.10.0"
 }
 
 data "flux_sync" "this" {


### PR DESCRIPTION
The flux provider pins the flux version by default now, so there is no need to do this in the module also.