### PR TITLE
Add group and permissions for ACR reader

### DIFF
--- a/modules/azure/aks-global/README.md
+++ b/modules/azure/aks-global/README.md
@@ -50,6 +50,7 @@ No modules.
 | [azurerm_role_assignment.aad_pod_identity](https://registry.terraform.io/providers/hashicorp/azurerm/2.57.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.acr_pull](https://registry.terraform.io/providers/hashicorp/azurerm/2.57.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.acr_push](https://registry.terraform.io/providers/hashicorp/azurerm/2.57.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.acr_reader](https://registry.terraform.io/providers/hashicorp/azurerm/2.57.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.aks](https://registry.terraform.io/providers/hashicorp/azurerm/2.57.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.external_dns_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/2.57.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.external_dns_msi](https://registry.terraform.io/providers/hashicorp/azurerm/2.57.0/docs/resources/role_assignment) | resource |
@@ -68,6 +69,7 @@ No modules.
 | [tls_private_key.ssh_key](https://registry.terraform.io/providers/hashicorp/tls/3.1.0/docs/resources/private_key) | resource |
 | [azuread_group.acr_pull](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/data-sources/group) | data source |
 | [azuread_group.acr_push](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/data-sources/group) | data source |
+| [azuread_group.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/data-sources/group) | data source |
 | [azuread_group.resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/data-sources/group) | data source |
 | [azuread_group.resource_group_owner](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/data-sources/group) | data source |
 | [azuread_group.resource_group_reader](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/data-sources/group) | data source |

--- a/modules/azure/aks-global/acr.tf
+++ b/modules/azure/aks-global/acr.tf
@@ -1,3 +1,5 @@
+# More info about Azure Container Registry Roles can be found here: https://docs.microsoft.com/en-us/azure/container-registry/container-registry-roles
+
 # Create Azure Container Registry
 resource "azurerm_container_registry" "acr" {
   name                = "acr${var.environment}${var.location_short}${var.name}${var.unique_suffix}"
@@ -26,6 +28,11 @@ data "azuread_group" "acr_push" {
   display_name = "${var.aks_group_name_prefix}${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}acrpush"
 }
 
+# Add data source for the Azure AD Group for AcrReader
+data "azuread_group" "acr_reader" {
+  display_name = "${var.aks_group_name_prefix}${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}acrreader"
+}
+
 # Assign AcrPull permissions to the Azure AD Group for AcrPull
 resource "azurerm_role_assignment" "acr_pull" {
   scope                = azurerm_container_registry.acr.id
@@ -38,4 +45,11 @@ resource "azurerm_role_assignment" "acr_push" {
   scope                = azurerm_container_registry.acr.id
   role_definition_name = "AcrPush"
   principal_id         = data.azuread_group.acr_push.id
+}
+
+# Assign Reader permissions to the Azure AD Group for AcrReader
+resource "azurerm_role_assignment" "acr_push" {
+  scope                = azurerm_container_registry.acr.id
+  role_definition_name = "Reader"
+  principal_id         = data.azuread_group.acr_reader.id
 }

--- a/modules/azure/aks-global/acr.tf
+++ b/modules/azure/aks-global/acr.tf
@@ -48,7 +48,7 @@ resource "azurerm_role_assignment" "acr_push" {
 }
 
 # Assign Reader permissions to the Azure AD Group for AcrReader
-resource "azurerm_role_assignment" "acr_push" {
+resource "azurerm_role_assignment" "acr_reader" {
   scope                = azurerm_container_registry.acr.id
   role_definition_name = "Reader"
   principal_id         = data.azuread_group.acr_reader.id

--- a/modules/azure/governance-global/README.md
+++ b/modules/azure/governance-global/README.md
@@ -35,6 +35,7 @@ No modules.
 | [azuread_application_password.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/resources/application_password) | resource |
 | [azuread_group.acr_pull](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/resources/group) | resource |
 | [azuread_group.acr_push](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/resources/group) | resource |
+| [azuread_group.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/resources/group) | resource |
 | [azuread_group.rg_contributor](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/resources/group) | resource |
 | [azuread_group.rg_owner](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/resources/group) | resource |
 | [azuread_group.rg_reader](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/resources/group) | resource |
@@ -45,6 +46,9 @@ No modules.
 | [azuread_group_member.acr_contributor](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/resources/group_member) | resource |
 | [azuread_group_member.acr_owner](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/resources/group_member) | resource |
 | [azuread_group_member.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/resources/group_member) | resource |
+| [azuread_group_member.acr_reader_rg_contributor](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/resources/group_member) | resource |
+| [azuread_group_member.acr_reader_rg_owner](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/resources/group_member) | resource |
+| [azuread_group_member.acr_reader_rg_reader](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/resources/group_member) | resource |
 | [azuread_group_member.acr_spn](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/resources/group_member) | resource |
 | [azuread_group_member.sub_all_contributor](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/resources/group_member) | resource |
 | [azuread_group_member.sub_all_owner](https://registry.terraform.io/providers/hashicorp/azuread/1.4.0/docs/resources/group_member) | resource |

--- a/modules/azure/governance-global/delegate-acr.tf
+++ b/modules/azure/governance-global/delegate-acr.tf
@@ -82,7 +82,7 @@ resource "azuread_group_member" "acr_reader" {
 }
 
 # Grant ACR Reader permissions to the resource group owners
-resource "azuread_group_member" "acr_viewer_rg_owner" {
+resource "azuread_group_member" "acr_reader_rg_owner" {
   for_each = {
     for rg in var.resource_group_configs :
     rg.common_name => rg
@@ -93,7 +93,7 @@ resource "azuread_group_member" "acr_viewer_rg_owner" {
 }
 
 # Grant ACR Reader permissions to the resource group contributors
-resource "azuread_group_member" "acr_viewer_rg_contributor" {
+resource "azuread_group_member" "acr_reader_rg_contributor" {
   for_each = {
     for rg in var.resource_group_configs :
     rg.common_name => rg
@@ -104,7 +104,7 @@ resource "azuread_group_member" "acr_viewer_rg_contributor" {
 }
 
 # Grant ACR Reader permissions to the resource group readers
-resource "azuread_group_member" "acr_viewer_rg_reader" {
+resource "azuread_group_member" "acr_reader_rg_reader" {
   for_each = {
     for rg in var.resource_group_configs :
     rg.common_name => rg

--- a/modules/azure/governance-global/delegate-acr.tf
+++ b/modules/azure/governance-global/delegate-acr.tf
@@ -1,3 +1,6 @@
+# More info about Azure Container Registry Roles can be found here: https://docs.microsoft.com/en-us/azure/container-registry/container-registry-roles
+
+# ACR Push Azure AD group will grant push and pull permissions to the Container Registry
 resource "azuread_group" "acr_push" {
   for_each = {
     for s in ["delegate_acr"] :
@@ -9,6 +12,7 @@ resource "azuread_group" "acr_push" {
   prevent_duplicate_names = true
 }
 
+# ACR Pull Azure AD group will grant pull permissions to the Container Registry
 resource "azuread_group" "acr_pull" {
   for_each = {
     for s in ["delegate_acr"] :
@@ -20,6 +24,19 @@ resource "azuread_group" "acr_pull" {
   prevent_duplicate_names = true
 }
 
+# ACR Reader Azure AD group will grant ARM (to view Container Registry in Azure Portal) and pull permissions to the Container Registry
+resource "azuread_group" "acr_reader" {
+  for_each = {
+    for s in ["delegate_acr"] :
+    s => s
+    if var.delegate_acr
+  }
+
+  display_name            = "${var.aks_group_name_prefix}${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}acrreader"
+  prevent_duplicate_names = true
+}
+
+# Grant ACR Push permissions to the resource group service principal
 resource "azuread_group_member" "acr_spn" {
   for_each = {
     for rg in var.resource_group_configs :
@@ -30,6 +47,7 @@ resource "azuread_group_member" "acr_spn" {
   member_object_id = azuread_service_principal.aad_sp[each.key].object_id
 }
 
+# Grant ACR Push permissions to the resource group owners
 resource "azuread_group_member" "acr_owner" {
   for_each = {
     for rg in var.resource_group_configs :
@@ -40,6 +58,7 @@ resource "azuread_group_member" "acr_owner" {
   member_object_id = azuread_group.rg_owner[each.key].id
 }
 
+# Grant ACR Push permissions to the resource group contributors
 resource "azuread_group_member" "acr_contributor" {
   for_each = {
     for rg in var.resource_group_configs :
@@ -50,6 +69,8 @@ resource "azuread_group_member" "acr_contributor" {
   member_object_id = azuread_group.rg_contributor[each.key].id
 }
 
+# Grant ACR Pull permissions to the resource group readers
+# This is now redundant since ACR Reader also grants Pull permissions, but kept for backward compatibility
 resource "azuread_group_member" "acr_reader" {
   for_each = {
     for rg in var.resource_group_configs :
@@ -57,5 +78,38 @@ resource "azuread_group_member" "acr_reader" {
     if rg.delegate_aks == true && var.delegate_acr
   }
   group_object_id  = azuread_group.acr_pull["delegate_acr"].id
+  member_object_id = azuread_group.rg_reader[each.key].id
+}
+
+# Grant ACR Reader permissions to the resource group owners
+resource "azuread_group_member" "acr_viewer_rg_owner" {
+  for_each = {
+    for rg in var.resource_group_configs :
+    rg.common_name => rg
+    if rg.delegate_aks == true && var.delegate_acr
+  }
+  group_object_id  = azuread_group.acr_reader["delegate_acr"].id
+  member_object_id = azuread_group.rg_owner[each.key].id
+}
+
+# Grant ACR Reader permissions to the resource group contributors
+resource "azuread_group_member" "acr_viewer_rg_contributor" {
+  for_each = {
+    for rg in var.resource_group_configs :
+    rg.common_name => rg
+    if rg.delegate_aks == true && var.delegate_acr
+  }
+  group_object_id  = azuread_group.acr_reader["delegate_acr"].id
+  member_object_id = azuread_group.rg_contributor[each.key].id
+}
+
+# Grant ACR Reader permissions to the resource group readers
+resource "azuread_group_member" "acr_viewer_rg_reader" {
+  for_each = {
+    for rg in var.resource_group_configs :
+    rg.common_name => rg
+    if rg.delegate_aks == true && var.delegate_acr
+  }
+  group_object_id  = azuread_group.acr_reader["delegate_acr"].id
   member_object_id = azuread_group.rg_reader[each.key].id
 }


### PR DESCRIPTION
Grants permission to members of resource groups to view Container Registry in Azure Portal.

Fixes #249