### PR TITLE
linkerd webhook and expiry

### DIFF
--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -121,6 +121,8 @@ module "aad_pod_identity" {
 
 # linkerd
 module "linkerd" {
+  depends_on = [module.opa_gatekeeper, module.cert_manager]
+
   for_each = {
     for s in ["linkerd"] :
     s => s

--- a/modules/kubernetes/linkerd/README.md
+++ b/modules/kubernetes/linkerd/README.md
@@ -6,7 +6,18 @@ Adds [`linkerd`](https://github.com/linkerd/linkerd2) to a Kubernetes clusters.
 
 ### CLI Installation
 
-To verify that everything is working, install the [linkerd cli](https://linkerd.io/2.10/reference/cli/install/) and run [`linkerd check`](https://linkerd.io/2.10/reference/cli/check/) when connected to the cluster.
+To verify that everything is working, install the [linkerd cli](https://linkerd.io/2.10/reference/cli/install/) and run [`linkerd check`](https://linkerd.io/2.10/reference/cli/check/) when connected to the cluster. This tool can only be used by cluster admins with access to the `linkerd` namespace.
+
+Expected warnings from `linkerd check`:
+
+- issuer cert is valid for at least 60 days
+  - using `cert-manager` and renewing certificates multiple times per day
+- proxy-injector cert is valid for at least 60 days
+  - using `cert-manager` and renewing certificates multiple times per day
+- sp-validator cert is valid for at least 60 days
+  - using `cert-manager` and renewing certificates multiple times per day
+- pod injection disabled on kube-system
+  - a namespaceSelector is added to exclude namespaces containing `control-plane=true`
 
 ### Proxy injection
 

--- a/modules/kubernetes/linkerd/charts/linkerd-extras/Chart.yaml
+++ b/modules/kubernetes/linkerd/charts/linkerd-extras/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: linkerd-extras
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0

--- a/modules/kubernetes/linkerd/charts/linkerd-extras/templates/linkerd-identity-issuer.yaml
+++ b/modules/kubernetes/linkerd/charts/linkerd-extras/templates/linkerd-identity-issuer.yaml
@@ -4,8 +4,8 @@ metadata:
   name: linkerd-identity-issuer
 spec:
   secretName: linkerd-identity-issuer
-  duration: 48h
-  renewBefore: 25h
+  duration: 24h
+  renewBefore: 12h
   issuerRef:
     name: linkerd-trust-anchor
     kind: Issuer

--- a/modules/kubernetes/linkerd/charts/linkerd-extras/templates/linkerd-identity-issuer.yaml
+++ b/modules/kubernetes/linkerd/charts/linkerd-extras/templates/linkerd-identity-issuer.yaml
@@ -4,8 +4,8 @@ metadata:
   name: linkerd-identity-issuer
 spec:
   secretName: linkerd-identity-issuer
-  duration: 24h
-  renewBefore: 12h
+  duration: 8h
+  renewBefore: 4h
   issuerRef:
     name: linkerd-trust-anchor
     kind: Issuer

--- a/modules/kubernetes/linkerd/charts/linkerd-extras/templates/linkerd-proxy-injector.yaml
+++ b/modules/kubernetes/linkerd/charts/linkerd-extras/templates/linkerd-proxy-injector.yaml
@@ -4,8 +4,8 @@ metadata:
   name: linkerd-proxy-injector
 spec:
   secretName: linkerd-proxy-injector-k8s-tls
-  duration: 24h
-  renewBefore: 12h
+  duration: 8h
+  renewBefore: 4h
   issuerRef:
     name: webhook-issuer
     kind: Issuer

--- a/modules/kubernetes/linkerd/charts/linkerd-extras/templates/linkerd-proxy-injector.yaml
+++ b/modules/kubernetes/linkerd/charts/linkerd-extras/templates/linkerd-proxy-injector.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   secretName: linkerd-proxy-injector-k8s-tls
   duration: 24h
-  renewBefore: 1h
+  renewBefore: 12h
   issuerRef:
     name: webhook-issuer
     kind: Issuer

--- a/modules/kubernetes/linkerd/charts/linkerd-extras/templates/linkerd-sp-validator.yaml
+++ b/modules/kubernetes/linkerd/charts/linkerd-extras/templates/linkerd-sp-validator.yaml
@@ -4,8 +4,8 @@ metadata:
   name: linkerd-sp-validator
 spec:
   secretName: linkerd-sp-validator-k8s-tls
-  duration: 24h
-  renewBefore: 12h
+  duration: 8h
+  renewBefore: 4h
   issuerRef:
     name: webhook-issuer
     kind: Issuer

--- a/modules/kubernetes/linkerd/charts/linkerd-extras/templates/linkerd-sp-validator.yaml
+++ b/modules/kubernetes/linkerd/charts/linkerd-extras/templates/linkerd-sp-validator.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   secretName: linkerd-sp-validator-k8s-tls
   duration: 24h
-  renewBefore: 1h
+  renewBefore: 12h
   issuerRef:
     name: webhook-issuer
     kind: Issuer

--- a/modules/kubernetes/linkerd/main.tf
+++ b/modules/kubernetes/linkerd/main.tf
@@ -7,7 +7,18 @@
   * 
   * ### CLI Installation
   *
-  * To verify that everything is working, install the [linkerd cli](https://linkerd.io/2.10/reference/cli/install/) and run [`linkerd check`](https://linkerd.io/2.10/reference/cli/check/) when connected to the cluster.
+  * To verify that everything is working, install the [linkerd cli](https://linkerd.io/2.10/reference/cli/install/) and run [`linkerd check`](https://linkerd.io/2.10/reference/cli/check/) when connected to the cluster. This tool can only be used by cluster admins with access to the `linkerd` namespace.
+  *
+  * Expected warnings from `linkerd check`:
+  *
+  * - issuer cert is valid for at least 60 days
+  *   - using `cert-manager` and renewing certificates multiple times per day
+  * - proxy-injector cert is valid for at least 60 days
+  *   - using `cert-manager` and renewing certificates multiple times per day
+  * - sp-validator cert is valid for at least 60 days
+  *   - using `cert-manager` and renewing certificates multiple times per day
+  * - pod injection disabled on kube-system
+  *   - a namespaceSelector is added to exclude namespaces containing `control-plane=true`
   *
   * ### Proxy injection
   *

--- a/modules/kubernetes/linkerd/main.tf
+++ b/modules/kubernetes/linkerd/main.tf
@@ -75,6 +75,7 @@ resource "kubernetes_namespace" "this" {
       name                                   = "linkerd"
       "xkf.xenit.io/kind"                    = "platform"
       "config.linkerd.io/admission-webhooks" = "disabled"
+      "control-plane"                        = "true"
     }
     name = "linkerd"
   }
@@ -88,6 +89,7 @@ resource "kubernetes_namespace" "cni" {
       "xkf.xenit.io/kind"                    = "platform"
       "config.linkerd.io/admission-webhooks" = "disabled"
       "linkerd.io/cni-resource"              = "true"
+      "control-plane"                        = "true"
     }
 
     annotations = {

--- a/modules/kubernetes/linkerd/templates/values.yaml.tpl
+++ b/modules/kubernetes/linkerd/templates/values.yaml.tpl
@@ -12,10 +12,6 @@ identityTrustAnchorsPEM: |
 proxyInjector:
   namespaceSelector:
     matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
     - key: control-plane
       operator: NotIn
       values:
@@ -27,10 +23,6 @@ proxyInjector:
 profileValidator:
   namespaceSelector:
     matchExpressions:
-    - key: config.linkerd.io/admission-webhooks
-      operator: NotIn
-      values:
-      - disabled
     - key: control-plane
       operator: NotIn
       values:

--- a/modules/kubernetes/linkerd/templates/values.yaml.tpl
+++ b/modules/kubernetes/linkerd/templates/values.yaml.tpl
@@ -10,11 +10,31 @@ identityTrustAnchorsPEM: |
   ${linkerd_trust_anchor_pem}
 
 proxyInjector:
+  namespaceSelector:
+    matchExpressions:
+    - key: config.linkerd.io/admission-webhooks
+      operator: NotIn
+      values:
+      - disabled
+    - key: control-plane
+      operator: NotIn
+      values:
+      - "true"
   externalSecret: true
   caBundle: |
     ${webhook_issuer_pem}
 
 profileValidator:
+  namespaceSelector:
+    matchExpressions:
+    - key: config.linkerd.io/admission-webhooks
+      operator: NotIn
+      values:
+      - disabled
+    - key: control-plane
+      operator: NotIn
+      values:
+      - "true"
   externalSecret: true
   caBundle: |
     ${webhook_issuer_pem}

--- a/modules/kubernetes/linkerd/templates/values.yaml.tpl
+++ b/modules/kubernetes/linkerd/templates/values.yaml.tpl
@@ -21,12 +21,8 @@ profileValidator:
 
 
 #
-# The below is taken from: https://github.com/linkerd/linkerd2/blob/main/charts/linkerd2/values.yaml
+# The below is taken from: https://github.com/linkerd/linkerd2/blob/main/charts/linkerd2/values-ha.yaml
 #
-
-# This values.yaml file contains the values needed to enable HA mode.
-# Usage:
-#   helm install -f values.yaml -f values-ha.yaml
 
 enablePodAntiAffinity: true
 
@@ -62,7 +58,7 @@ heartbeatResources: *controller_resources
 
 # proxy injector configuration
 proxyInjectorResources: *controller_resources
-webhookFailurePolicy: Ignore
+webhookFailurePolicy: Fail
 
 # service profile validator configuration
 spValidatorResources: *controller_resources


### PR DESCRIPTION
Changes:
* `aks-core`: depends_on `cert_manager` and `opa_gatekeeper`
* `linkerd`: align expiry dates
* `linkerd`: set webhookFailurePolicy to hard fail
* `linkerd`: namespaceSelector changed to `control-plane="true"`