### PR TITLE
Update azdo proxy to latest version

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -55,6 +55,7 @@ jobs:
               exit 1
           fi
           tar xzvf terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz terraform-docs
+          rm terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz
           mkdir -p ~/.local/bin/
           mv ./terraform-docs ~/.local/bin/terraform-docs
       - name: Run docs
@@ -63,7 +64,6 @@ jobs:
           make docs
       - name: Check if working tree is dirty
         run: |
-          set -ex
           if [[ $(git status --porcelain) ]]; then
             git diff
             echo 'run make docs and commit changes'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -54,10 +54,9 @@ jobs:
               echo "Downloaded checksum (${DOWNLOAD_TERRAFORM_DOCS_SHA}) for terraform-docs does not match expected value: ${TERRAFORM_DOCS_SHA}"
               exit 1
           fi
-          tar xzvf terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz
+          tar xzvf terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz terraform-docs
           mkdir -p ~/.local/bin/
           mv ./terraform-docs ~/.local/bin/terraform-docs
-          rm LICENSE README.md
       - name: Run docs
         run: |
           export PATH=${PATH}:~/.local/bin

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -45,18 +45,19 @@ jobs:
         uses: actions/checkout@master
       - name: Setup terraform-docs
         env:
-          TERRAFORM_DOCS_VERSION: "v0.12.1"
-          TERRAFORM_DOCS_SHA: "32c0611a33a9c83857240ce2095287a5329564f26acd04818da5156192ecf401"
+          TERRAFORM_DOCS_VERSION: "v0.14.1"
+          TERRAFORM_DOCS_SHA: "f0a46b13c126f06eba44178f901bb7b6b5f61a8b89e07a88988c6f45e5fcce19"
         run: |
-          curl -Lo ./terraform-docs https://github.com/terraform-docs/terraform-docs/releases/download/${TERRAFORM_DOCS_VERSION}/terraform-docs-${TERRAFORM_DOCS_VERSION}-$(uname | tr '[:upper:]' '[:lower:]')-amd64
-          DOWNLOAD_TERRAFORM_DOCS_SHA=$(openssl sha1 -sha256 terraform-docs | awk '{print $2}')
+          wget https://github.com/terraform-docs/terraform-docs/releases/download/${TERRAFORM_DOCS_VERSION}/terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz
+          DOWNLOAD_TERRAFORM_DOCS_SHA=$(openssl sha1 -sha256 terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz | awk '{print $2}')
           if [[ "${TERRAFORM_DOCS_SHA}" != "${DOWNLOAD_TERRAFORM_DOCS_SHA}" ]]; then
               echo "Downloaded checksum (${DOWNLOAD_TERRAFORM_DOCS_SHA}) for terraform-docs does not match expected value: ${TERRAFORM_DOCS_SHA}"
               exit 1
           fi
-          chmod +x ./terraform-docs
+          tar xzvf terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz
           mkdir -p ~/.local/bin/
           mv ./terraform-docs ~/.local/bin/terraform-docs
+          rm LICENSE README.md
       - name: Run docs
         run: |
           export PATH=${PATH}:~/.local/bin

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -63,6 +63,7 @@ jobs:
           make docs
       - name: Check if working tree is dirty
         run: |
+          set -ex
           if [[ $(git status --porcelain) ]]; then
             git diff
             echo 'run make docs and commit changes'

--- a/.github/workflows/latest-version.yaml
+++ b/.github/workflows/latest-version.yaml
@@ -51,7 +51,7 @@ jobs:
               echo "Downloaded checksum (${DOWNLOAD_TERRAFORM_DOCS_SHA}) for terraform-docs does not match expected value: ${TERRAFORM_DOCS_SHA}"
               exit 1
           fi
-          tar xzvf terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz
+          tar xzvf terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz terraform-docs
           mkdir -p ~/.local/bin/
           mv ./terraform-docs ~/.local/bin/terraform-docs
 

--- a/.github/workflows/latest-version.yaml
+++ b/.github/workflows/latest-version.yaml
@@ -54,7 +54,6 @@ jobs:
           tar xzvf terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz
           mkdir -p ~/.local/bin/
           mv ./terraform-docs ~/.local/bin/terraform-docs
-          rm LICENSE README.md
 
       - name: Run docs
         run: |

--- a/.github/workflows/latest-version.yaml
+++ b/.github/workflows/latest-version.yaml
@@ -42,18 +42,19 @@ jobs:
 
       - name: Setup terraform-docs
         env:
-          TERRAFORM_DOCS_VERSION: "v0.12.1"
-          TERRAFORM_DOCS_SHA: "32c0611a33a9c83857240ce2095287a5329564f26acd04818da5156192ecf401"
+          TERRAFORM_DOCS_VERSION: "v0.14.1"
+          TERRAFORM_DOCS_SHA: "f0a46b13c126f06eba44178f901bb7b6b5f61a8b89e07a88988c6f45e5fcce19"
         run: |
-          curl -Lo ./terraform-docs https://github.com/terraform-docs/terraform-docs/releases/download/${TERRAFORM_DOCS_VERSION}/terraform-docs-${TERRAFORM_DOCS_VERSION}-$(uname | tr '[:upper:]' '[:lower:]')-amd64
-          DOWNLOAD_TERRAFORM_DOCS_SHA=$(openssl sha1 -sha256 terraform-docs | awk '{print $2}')
+          wget https://github.com/terraform-docs/terraform-docs/releases/download/${TERRAFORM_DOCS_VERSION}/terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz
+          DOWNLOAD_TERRAFORM_DOCS_SHA=$(openssl sha1 -sha256 terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz | awk '{print $2}')
           if [[ "${TERRAFORM_DOCS_SHA}" != "${DOWNLOAD_TERRAFORM_DOCS_SHA}" ]]; then
               echo "Downloaded checksum (${DOWNLOAD_TERRAFORM_DOCS_SHA}) for terraform-docs does not match expected value: ${TERRAFORM_DOCS_SHA}"
               exit 1
           fi
-          chmod +x ./terraform-docs
+          tar xzvf terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz
           mkdir -p ~/.local/bin/
           mv ./terraform-docs ~/.local/bin/terraform-docs
+          rm LICENSE README.md
 
       - name: Run docs
         run: |

--- a/.github/workflows/latest-version.yaml
+++ b/.github/workflows/latest-version.yaml
@@ -52,6 +52,7 @@ jobs:
               exit 1
           fi
           tar xzvf terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz terraform-docs
+          rm terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz
           mkdir -p ~/.local/bin/
           mv ./terraform-docs ~/.local/bin/terraform-docs
 

--- a/modules/kubernetes/aks-core/README.md
+++ b/modules/kubernetes/aks-core/README.md
@@ -27,25 +27,25 @@ This module is used to create AKS clusters.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aad_pod_identity"></a> [aad\_pod\_identity](#module\_aad\_pod\_identity) | ../../kubernetes/aad-pod-identity |  |
-| <a name="module_azad_kube_proxy"></a> [azad\_kube\_proxy](#module\_azad\_kube\_proxy) | ../../kubernetes/azad-kube-proxy |  |
-| <a name="module_cert_manager"></a> [cert\_manager](#module\_cert\_manager) | ../../kubernetes/cert-manager |  |
-| <a name="module_csi_secrets_store_provider_azure"></a> [csi\_secrets\_store\_provider\_azure](#module\_csi\_secrets\_store\_provider\_azure) | ../../kubernetes/csi-secrets-store-provider-azure |  |
-| <a name="module_datadog"></a> [datadog](#module\_datadog) | ../../kubernetes/datadog |  |
-| <a name="module_external_dns"></a> [external\_dns](#module\_external\_dns) | ../../kubernetes/external-dns |  |
-| <a name="module_falco"></a> [falco](#module\_falco) | ../../kubernetes/falco |  |
-| <a name="module_fluxcd_v1_azure_devops"></a> [fluxcd\_v1\_azure\_devops](#module\_fluxcd\_v1\_azure\_devops) | ../../kubernetes/fluxcd-v1 |  |
-| <a name="module_fluxcd_v2_azure_devops"></a> [fluxcd\_v2\_azure\_devops](#module\_fluxcd\_v2\_azure\_devops) | ../../kubernetes/fluxcd-v2-azdo |  |
-| <a name="module_fluxcd_v2_github"></a> [fluxcd\_v2\_github](#module\_fluxcd\_v2\_github) | ../../kubernetes/fluxcd-v2-github |  |
-| <a name="module_goldpinger"></a> [goldpinger](#module\_goldpinger) | ../../kubernetes/goldpinger |  |
-| <a name="module_ingress_healthz"></a> [ingress\_healthz](#module\_ingress\_healthz) | ../../kubernetes/ingress-healthz |  |
-| <a name="module_ingress_nginx"></a> [ingress\_nginx](#module\_ingress\_nginx) | ../../kubernetes/ingress-nginx |  |
-| <a name="module_linkerd"></a> [linkerd](#module\_linkerd) | ../../kubernetes/linkerd |  |
-| <a name="module_opa_gatekeeper"></a> [opa\_gatekeeper](#module\_opa\_gatekeeper) | ../../kubernetes/opa-gatekeeper |  |
-| <a name="module_prometheus"></a> [prometheus](#module\_prometheus) | ../../kubernetes/prometheus |  |
-| <a name="module_reloader"></a> [reloader](#module\_reloader) | ../../kubernetes/reloader |  |
-| <a name="module_velero"></a> [velero](#module\_velero) | ../../kubernetes/velero |  |
-| <a name="module_xenit"></a> [xenit](#module\_xenit) | ../../kubernetes/xenit |  |
+| <a name="module_aad_pod_identity"></a> [aad\_pod\_identity](#module\_aad\_pod\_identity) | ../../kubernetes/aad-pod-identity | n/a |
+| <a name="module_azad_kube_proxy"></a> [azad\_kube\_proxy](#module\_azad\_kube\_proxy) | ../../kubernetes/azad-kube-proxy | n/a |
+| <a name="module_cert_manager"></a> [cert\_manager](#module\_cert\_manager) | ../../kubernetes/cert-manager | n/a |
+| <a name="module_csi_secrets_store_provider_azure"></a> [csi\_secrets\_store\_provider\_azure](#module\_csi\_secrets\_store\_provider\_azure) | ../../kubernetes/csi-secrets-store-provider-azure | n/a |
+| <a name="module_datadog"></a> [datadog](#module\_datadog) | ../../kubernetes/datadog | n/a |
+| <a name="module_external_dns"></a> [external\_dns](#module\_external\_dns) | ../../kubernetes/external-dns | n/a |
+| <a name="module_falco"></a> [falco](#module\_falco) | ../../kubernetes/falco | n/a |
+| <a name="module_fluxcd_v1_azure_devops"></a> [fluxcd\_v1\_azure\_devops](#module\_fluxcd\_v1\_azure\_devops) | ../../kubernetes/fluxcd-v1 | n/a |
+| <a name="module_fluxcd_v2_azure_devops"></a> [fluxcd\_v2\_azure\_devops](#module\_fluxcd\_v2\_azure\_devops) | ../../kubernetes/fluxcd-v2-azdo | n/a |
+| <a name="module_fluxcd_v2_github"></a> [fluxcd\_v2\_github](#module\_fluxcd\_v2\_github) | ../../kubernetes/fluxcd-v2-github | n/a |
+| <a name="module_goldpinger"></a> [goldpinger](#module\_goldpinger) | ../../kubernetes/goldpinger | n/a |
+| <a name="module_ingress_healthz"></a> [ingress\_healthz](#module\_ingress\_healthz) | ../../kubernetes/ingress-healthz | n/a |
+| <a name="module_ingress_nginx"></a> [ingress\_nginx](#module\_ingress\_nginx) | ../../kubernetes/ingress-nginx | n/a |
+| <a name="module_linkerd"></a> [linkerd](#module\_linkerd) | ../../kubernetes/linkerd | n/a |
+| <a name="module_opa_gatekeeper"></a> [opa\_gatekeeper](#module\_opa\_gatekeeper) | ../../kubernetes/opa-gatekeeper | n/a |
+| <a name="module_prometheus"></a> [prometheus](#module\_prometheus) | ../../kubernetes/prometheus | n/a |
+| <a name="module_reloader"></a> [reloader](#module\_reloader) | ../../kubernetes/reloader | n/a |
+| <a name="module_velero"></a> [velero](#module\_velero) | ../../kubernetes/velero | n/a |
+| <a name="module_xenit"></a> [xenit](#module\_xenit) | ../../kubernetes/xenit | n/a |
 
 ## Resources
 

--- a/modules/kubernetes/eks-core/README.md
+++ b/modules/kubernetes/eks-core/README.md
@@ -25,14 +25,14 @@ This module is used to configure EKS clusters.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cert_manager"></a> [cert\_manager](#module\_cert\_manager) | ../../kubernetes/cert-manager |  |
-| <a name="module_external_dns"></a> [external\_dns](#module\_external\_dns) | ../../kubernetes/external-dns |  |
-| <a name="module_external_secrets"></a> [external\_secrets](#module\_external\_secrets) | ../../kubernetes/external-secrets |  |
-| <a name="module_fluxcd_v2_github"></a> [fluxcd\_v2\_github](#module\_fluxcd\_v2\_github) | ../../kubernetes/fluxcd-v2-github |  |
-| <a name="module_ingress_nginx"></a> [ingress\_nginx](#module\_ingress\_nginx) | ../../kubernetes/ingress-nginx |  |
-| <a name="module_kyverno"></a> [kyverno](#module\_kyverno) | ../../kubernetes/kyverno |  |
-| <a name="module_opa_gatekeeper"></a> [opa\_gatekeeper](#module\_opa\_gatekeeper) | ../../kubernetes/opa-gatekeeper |  |
-| <a name="module_velero"></a> [velero](#module\_velero) | ../../kubernetes/velero |  |
+| <a name="module_cert_manager"></a> [cert\_manager](#module\_cert\_manager) | ../../kubernetes/cert-manager | n/a |
+| <a name="module_external_dns"></a> [external\_dns](#module\_external\_dns) | ../../kubernetes/external-dns | n/a |
+| <a name="module_external_secrets"></a> [external\_secrets](#module\_external\_secrets) | ../../kubernetes/external-secrets | n/a |
+| <a name="module_fluxcd_v2_github"></a> [fluxcd\_v2\_github](#module\_fluxcd\_v2\_github) | ../../kubernetes/fluxcd-v2-github | n/a |
+| <a name="module_ingress_nginx"></a> [ingress\_nginx](#module\_ingress\_nginx) | ../../kubernetes/ingress-nginx | n/a |
+| <a name="module_kyverno"></a> [kyverno](#module\_kyverno) | ../../kubernetes/kyverno | n/a |
+| <a name="module_opa_gatekeeper"></a> [opa\_gatekeeper](#module\_opa\_gatekeeper) | ../../kubernetes/opa-gatekeeper | n/a |
+| <a name="module_velero"></a> [velero](#module\_velero) | ../../kubernetes/velero | n/a |
 
 ## Resources
 

--- a/modules/kubernetes/fluxcd-v2-azdo/README.md
+++ b/modules/kubernetes/fluxcd-v2-azdo/README.md
@@ -34,7 +34,6 @@ the bootstrap configuration.
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.1.2 |
 | <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | 1.11.1 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.3.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 
 ## Modules
 
@@ -53,10 +52,6 @@ No modules.
 | [kubectl_manifest.install](https://registry.terraform.io/providers/gavinbunney/kubectl/1.11.1/docs/resources/manifest) | resource |
 | [kubectl_manifest.sync](https://registry.terraform.io/providers/gavinbunney/kubectl/1.11.1/docs/resources/manifest) | resource |
 | [kubernetes_namespace.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.3.0/docs/resources/namespace) | resource |
-| [kubernetes_secret.cluster](https://registry.terraform.io/providers/hashicorp/kubernetes/2.3.0/docs/resources/secret) | resource |
-| [kubernetes_secret.tenant](https://registry.terraform.io/providers/hashicorp/kubernetes/2.3.0/docs/resources/secret) | resource |
-| [random_password.cluster](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/password) | resource |
-| [random_password.tenant](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/password) | resource |
 | [azuredevops_git_repository.cluster](https://registry.terraform.io/providers/xenitab/azuredevops/0.3.0/docs/data-sources/git_repository) | data source |
 | [azuredevops_project.this](https://registry.terraform.io/providers/xenitab/azuredevops/0.3.0/docs/data-sources/project) | data source |
 | [flux_install.this](https://registry.terraform.io/providers/fluxcd/flux/0.1.8/docs/data-sources/install) | data source |

--- a/modules/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/main.tf
@@ -75,7 +75,7 @@ resource "helm_release" "azdo_proxy" {
   chart      = "azdo-proxy"
   name       = "azdo-proxy"
   namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "v0.4.0-rc1"
+  version    = "v0.4.0"
   values = [templatefile("${path.module}/templates/azdo-proxy-values.yaml.tpl", {
     azure_devops_pat  = var.azure_devops_pat,
     azure_devops_org  = var.azure_devops_org,

--- a/modules/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/main.tf
@@ -37,7 +37,7 @@ terraform {
     }
     kubectl = {
       source  = "gavinbunney/kubectl"
-      version = "1.11.1"
+      version = "1.10.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -76,18 +76,18 @@ resource "helm_release" "azdo_proxy" {
   name       = "azdo-proxy"
   namespace  = kubernetes_namespace.this.metadata[0].name
   version    = "v0.4.0-rc1"
-  values = [templatefile("${path.module}/templates/azdo-proxy-values.yaml.tpl", {
-    azure_devops_pat  = var.azure_devops_pat,
-    azure_devops_org  = var.azure_devops_org,
-    azure_devops_proj = var.azure_devops_proj,
-    cluster_repo      = var.cluster_repo,
-    tenants = [for ns in var.namespaces : {
-      project : ns.flux.proj
-      repo : ns.flux.repo
-      namespace : ns.name
-      }
-      if ns.flux.enabled
-    ],
+  values     = [templatefile("${path.module}/templates/azdo-proxy-values.yaml.tpl", {
+      azure_devops_pat  = var.azure_devops_pat,
+      azure_devops_org  = var.azure_devops_org,
+      azure_devops_proj = var.azure_devops_proj,
+      cluster_repo      = var.cluster_repo,
+      tenants = [for ns in var.namespaces : {
+          project : ns.flux.proj
+          repo : ns.flux.repo
+          namespace: ns.name
+        }
+        if ns.flux.enabled
+      ],
     })
   ]
 }

--- a/modules/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/main.tf
@@ -76,19 +76,18 @@ resource "helm_release" "azdo_proxy" {
   name       = "azdo-proxy"
   namespace  = kubernetes_namespace.this.metadata[0].name
   version    = "v0.4.0-rc1"
-  values     = [
-    azdo_proxy_values = templatefile("${path.module}/templates/azdo-proxy-values.yaml.tpl", {
-      azure_devops_pat  = var.azure_devops_pat,
-      azure_devops_org  = var.azure_devops_org,
-      azure_devops_proj = var.azure_devops_proj,
-      cluster_repo      = var.cluster_repo,
-      tenants = [for ns in var.namespaces : {
-          project : ns.flux.proj
-          repo : ns.flux.repo
-          namespace: ns.name
-        }
-        if ns.flux.enabled
-      ]
+  values = [templatefile("${path.module}/templates/azdo-proxy-values.yaml.tpl", {
+    azure_devops_pat  = var.azure_devops_pat,
+    azure_devops_org  = var.azure_devops_org,
+    azure_devops_proj = var.azure_devops_proj,
+    cluster_repo      = var.cluster_repo,
+    tenants = [for ns in var.namespaces : {
+      project : ns.flux.proj
+      repo : ns.flux.repo
+      namespace : ns.name
+      }
+      if ns.flux.enabled
+    ],
     })
   ]
 }

--- a/modules/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/main.tf
@@ -82,14 +82,13 @@ resource "helm_release" "azdo_proxy" {
     azure_devops_proj = var.azure_devops_proj,
     cluster_repo      = var.cluster_repo,
     tenants = [for ns in var.namespaces : {
-      project : ns.flux.proj
-      repo : ns.flux.repo
-      namespace : ns.name
+      project: ns.flux.proj
+      repo: ns.flux.repo
+      namespace: ns.name
       }
       if ns.flux.enabled
     ],
-    })
-  ]
+  })]
 }
 
 # Cluster

--- a/modules/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/main.tf
@@ -82,9 +82,9 @@ resource "helm_release" "azdo_proxy" {
     azure_devops_proj = var.azure_devops_proj,
     cluster_repo      = var.cluster_repo,
     tenants = [for ns in var.namespaces : {
-      project: ns.flux.proj
-      repo: ns.flux.repo
-      namespace: ns.name
+      project : ns.flux.proj
+      repo : ns.flux.repo
+      namespace : ns.name
       }
       if ns.flux.enabled
     ],

--- a/modules/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/main.tf
@@ -75,7 +75,7 @@ resource "helm_release" "azdo_proxy" {
   chart      = "azdo-proxy"
   name       = "azdo-proxy"
   namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "v0.4.0"
+  version    = "v0.4.1"
   values = [templatefile("${path.module}/templates/azdo-proxy-values.yaml.tpl", {
     azure_devops_pat  = var.azure_devops_pat,
     azure_devops_org  = var.azure_devops_org,

--- a/modules/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/main.tf
@@ -37,7 +37,7 @@ terraform {
     }
     kubectl = {
       source  = "gavinbunney/kubectl"
-      version = "1.10.0"
+      version = "1.11.1"
     }
     random = {
       source  = "hashicorp/random"
@@ -76,18 +76,18 @@ resource "helm_release" "azdo_proxy" {
   name       = "azdo-proxy"
   namespace  = kubernetes_namespace.this.metadata[0].name
   version    = "v0.4.0-rc1"
-  values     = [templatefile("${path.module}/templates/azdo-proxy-values.yaml.tpl", {
-      azure_devops_pat  = var.azure_devops_pat,
-      azure_devops_org  = var.azure_devops_org,
-      azure_devops_proj = var.azure_devops_proj,
-      cluster_repo      = var.cluster_repo,
-      tenants = [for ns in var.namespaces : {
-          project : ns.flux.proj
-          repo : ns.flux.repo
-          namespace: ns.name
-        }
-        if ns.flux.enabled
-      ],
+  values = [templatefile("${path.module}/templates/azdo-proxy-values.yaml.tpl", {
+    azure_devops_pat  = var.azure_devops_pat,
+    azure_devops_org  = var.azure_devops_org,
+    azure_devops_proj = var.azure_devops_proj,
+    cluster_repo      = var.cluster_repo,
+    tenants = [for ns in var.namespaces : {
+      project : ns.flux.proj
+      repo : ns.flux.repo
+      namespace : ns.name
+      }
+      if ns.flux.enabled
+    ],
     })
   ]
 }

--- a/modules/kubernetes/fluxcd-v2-azdo/templates/azdo-proxy-values.yaml.tpl
+++ b/modules/kubernetes/fluxcd-v2-azdo/templates/azdo-proxy-values.yaml.tpl
@@ -1,5 +1,9 @@
+#image:
+  #tag: v0.4.0-rc1
 image:
-  tag: v0.4.0-rc1
+  repository: phillebaba/azdo-proxy
+  pullPolicy: Always
+  tag: "dev"
 resources:
   requests:
     cpu: 100m

--- a/modules/kubernetes/fluxcd-v2-azdo/templates/azdo-proxy-values.yaml.tpl
+++ b/modules/kubernetes/fluxcd-v2-azdo/templates/azdo-proxy-values.yaml.tpl
@@ -1,6 +1,5 @@
 image:
-  tag: v0.3.6
-replicaCount: 1
+  tag: v0.4.0-rc1
 resources:
   requests:
     cpu: 100m
@@ -9,20 +8,24 @@ resources:
     memory: 256Mi
 config: |
   {
-    "pat": "${azure_devops_pat}",
-    "organization": "${azure_devops_org}",
-    "repositories": [
-      %{ for tenant in tenants ~}
+    "organizations": [
       {
-        "project": "${tenant.project}",
-        "name": "${tenant.repo}",
-        "token": "${tenant.token}"
-      },
-      %{ endfor }
-      {
-        "project": "${azure_devops_proj}",
-        "name": "${cluster_repo}",
-        "token": "${cluster_token}"
+        "name": "${azure_devops_org}",
+        "pat": "${azure_devops_pat}",
+        "repositories": [
+          %{ for tenant in tenants ~}
+          {
+            "project": "${tenant.project}",
+            "name": "${tenant.repo}",
+            "namespaces": ["${tenant.namepsace}"]
+          },
+          %{ endfor }
+          {
+            "project": "${azure_devops_proj}",
+            "name": "${cluster_repo}",
+            "namespaces": ["flux-system"]
+          }
+        ]
       }
     ]
   }

--- a/modules/kubernetes/fluxcd-v2-azdo/templates/azdo-proxy-values.yaml.tpl
+++ b/modules/kubernetes/fluxcd-v2-azdo/templates/azdo-proxy-values.yaml.tpl
@@ -1,5 +1,3 @@
-image:
-  tag: v0.4.0
 networkPolicy:
   enabled: true
 resources:

--- a/modules/kubernetes/fluxcd-v2-azdo/templates/azdo-proxy-values.yaml.tpl
+++ b/modules/kubernetes/fluxcd-v2-azdo/templates/azdo-proxy-values.yaml.tpl
@@ -1,9 +1,7 @@
-#image:
-  #tag: v0.4.0-rc1
 image:
-  repository: phillebaba/azdo-proxy
-  pullPolicy: Always
-  tag: "dev"
+  tag: v0.4.0
+networkPolicy:
+  enabled: true
 resources:
   requests:
     cpu: 100m

--- a/modules/kubernetes/fluxcd-v2-azdo/templates/azdo-proxy-values.yaml.tpl
+++ b/modules/kubernetes/fluxcd-v2-azdo/templates/azdo-proxy-values.yaml.tpl
@@ -17,6 +17,7 @@ config: |
           {
             "project": "${tenant.project}",
             "name": "${tenant.repo}",
+            "namespaces": ["${tenant.namespace}"]
           },
           %{ endfor }
           {

--- a/modules/kubernetes/fluxcd-v2-azdo/templates/azdo-proxy-values.yaml.tpl
+++ b/modules/kubernetes/fluxcd-v2-azdo/templates/azdo-proxy-values.yaml.tpl
@@ -17,13 +17,15 @@ config: |
           {
             "project": "${tenant.project}",
             "name": "${tenant.repo}",
-            "namespaces": ["${tenant.namespace}"]
+            "namespaces": ["${tenant.namespace}"],
+            "secretNameOverride": "flux"
           },
           %{ endfor }
           {
             "project": "${azure_devops_proj}",
             "name": "${cluster_repo}",
-            "namespaces": ["flux-system"]
+            "namespaces": ["flux-system"],
+            "secretNameOverride": "flux-system"
           }
         ]
       }

--- a/modules/kubernetes/fluxcd-v2-azdo/templates/azdo-proxy-values.yaml.tpl
+++ b/modules/kubernetes/fluxcd-v2-azdo/templates/azdo-proxy-values.yaml.tpl
@@ -17,7 +17,6 @@ config: |
           {
             "project": "${tenant.project}",
             "name": "${tenant.repo}",
-            "namespaces": ["${tenant.namepsace}"]
           },
           %{ endfor }
           {

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/templates/monitor.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/templates/monitor.yaml
@@ -149,6 +149,25 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  name: azdo-proxy
+  namespace: flux-system
+  labels:
+    xkf.xenit.io/monitoring: platform
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+  namespaceSelector:
+    matchNames:
+    - flux-system
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: azdo-proxy
+      app.kubernetes.io/name: azdo-proxy
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
   labels:
     xkf.xenit.io/monitoring: platform
   name: ingress-nginx-controller


### PR DESCRIPTION
This change updates azdo proxy to the latest version. The major change is that token generation is no longer done by Terraform but rather in the app. 