### PR TITLE
Ignore azurerm update

### DIFF
--- a/modules/azure/aks-global/main.tf
+++ b/modules/azure/aks-global/main.tf
@@ -8,6 +8,7 @@ terraform {
   required_version = "0.15.3"
 
   required_providers {
+    #tf-latest-version:ignore
     azurerm = {
       version = "2.61.0"
       source  = "hashicorp/azurerm"

--- a/modules/azure/aks/main.tf
+++ b/modules/azure/aks/main.tf
@@ -8,6 +8,7 @@ terraform {
   required_version = "0.15.3"
 
   required_providers {
+    #tf-latest-version:ignore
     azurerm = {
       version = "2.61.0"
       source  = "hashicorp/azurerm"

--- a/modules/azure/azure-pipelines-agent-vmss/main.tf
+++ b/modules/azure/azure-pipelines-agent-vmss/main.tf
@@ -12,6 +12,7 @@ terraform {
   required_version = "0.15.3"
 
   required_providers {
+    #tf-latest-version:ignore
     azurerm = {
       version = "2.61.0"
       source  = "hashicorp/azurerm"

--- a/modules/azure/core/main.tf
+++ b/modules/azure/core/main.tf
@@ -8,6 +8,7 @@ terraform {
   required_version = "0.15.3"
 
   required_providers {
+    #tf-latest-version:ignore
     azurerm = {
       version = "2.61.0"
       source  = "hashicorp/azurerm"

--- a/modules/azure/github-runner/main.tf
+++ b/modules/azure/github-runner/main.tf
@@ -6,7 +6,7 @@
   * ## GitHub Runner Configuration
   *
   * Setup a GitHub App according to the documentation for [XenitAB/github-runner](https://github.com/XenitAB/github-runner).
-  * 
+  *
   * Setup an image using Packer according [github-runner](https://github.com/XenitAB/packer-templates/tree/main/templates/azure/github-runner) in [XenitAB/packer-templates](https://github.com/XenitAB/packer-templates).
   */
 
@@ -14,6 +14,7 @@ terraform {
   required_version = "0.15.3"
 
   required_providers {
+    #tf-latest-version:ignore
     azurerm = {
       version = "2.61.0"
       source  = "hashicorp/azurerm"

--- a/modules/azure/governance-global/main.tf
+++ b/modules/azure/governance-global/main.tf
@@ -8,6 +8,7 @@ terraform {
   required_version = "0.15.3"
 
   required_providers {
+    #tf-latest-version:ignore
     azurerm = {
       version = "2.61.0"
       source  = "hashicorp/azurerm"

--- a/modules/azure/governance-regional/main.tf
+++ b/modules/azure/governance-regional/main.tf
@@ -8,6 +8,7 @@ terraform {
   required_version = "0.15.3"
 
   required_providers {
+    #tf-latest-version:ignore
     azurerm = {
       version = "2.61.0"
       source  = "hashicorp/azurerm"

--- a/modules/azure/governance/main.tf
+++ b/modules/azure/governance/main.tf
@@ -10,6 +10,7 @@ terraform {
   required_version = "0.15.3"
 
   required_providers {
+    #tf-latest-version:ignore
     azurerm = {
       version = "2.61.0"
       source  = "hashicorp/azurerm"

--- a/modules/azure/hub/main.tf
+++ b/modules/azure/hub/main.tf
@@ -12,6 +12,7 @@ terraform {
   required_version = "0.15.3"
 
   required_providers {
+    #tf-latest-version:ignore
     azurerm = {
       version = "2.61.0"
       source  = "hashicorp/azurerm"

--- a/modules/kubernetes/aks-core/main.tf
+++ b/modules/kubernetes/aks-core/main.tf
@@ -8,6 +8,7 @@ terraform {
   required_version = "0.15.3"
 
   required_providers {
+    #tf-latest-version:ignore
     azurerm = {
       version = "2.61.0"
       source  = "hashicorp/azurerm"

--- a/modules/kubernetes/loki/main.tf
+++ b/modules/kubernetes/loki/main.tf
@@ -12,6 +12,7 @@ terraform {
   required_version = "0.15.3"
 
   required_providers {
+    #tf-latest-version:ignore
     azurerm = {
       version = "2.61.0"
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
There is currently a bug in azurerm version 2.62.0.
https://github.com/terraform-providers/terraform-provider-azurerm/issues/12060

We need to ignore updates of the provider until it is fixed and released. Generally new azurerm versions are released on fridays so this should be kept at least until then.