### PR TITLE
Revert nginx helm chart version

### DIFF
--- a/modules/kubernetes/ingress-healthz/main.tf
+++ b/modules/kubernetes/ingress-healthz/main.tf
@@ -31,12 +31,13 @@ resource "kubernetes_namespace" "this" {
   }
 }
 
+#tf-latest-version:ignore
 resource "helm_release" "ingress_healthz" {
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "nginx"
   name       = "ingress-healthz"
   namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "9.3.7"
+  version    = "9.3.6"
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     environment     = var.environment
     dns_zone        = var.dns_zone


### PR DESCRIPTION
Latest version of the nginx helm charts breaks pod disruption budgets. This reverts and freezes the version until it is fixed.
bitnami/charts/pull/6910