### PR TITLE
Remove update ignore for ingress healthz

### DIFF
--- a/modules/kubernetes/ingress-healthz/main.tf
+++ b/modules/kubernetes/ingress-healthz/main.tf
@@ -31,7 +31,6 @@ resource "kubernetes_namespace" "this" {
   }
 }
 
-#tf-latest-version:ignore
 resource "helm_release" "ingress_healthz" {
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "nginx"


### PR DESCRIPTION
Issue has now been fixed in bitnami chart so we should be able to update again.