### PR TITLE
Enable CIDR definition in EKS clusters

### DIFF
--- a/modules/aws/eks/README.md
+++ b/modules/aws/eks/README.md
@@ -55,6 +55,7 @@
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_kms_key_arn"></a> [aws\_kms\_key\_arn](#input\_aws\_kms\_key\_arn) | eks secrets customer master key | `string` | n/a | yes |
 | <a name="input_cluster_role_arn"></a> [cluster\_role\_arn](#input\_cluster\_role\_arn) | IAM role to attach to EKS cluster | `string` | n/a | yes |
+| <a name="input_eks_authorized_ips"></a> [eks\_authorized\_ips](#input\_eks\_authorized\_ips) | Authorized IPs to access EKS API | `list(string)` | n/a | yes |
 | <a name="input_eks_config"></a> [eks\_config](#input\_eks\_config) | The EKS Config | <pre>object({<br>    kubernetes_version = string<br>    cidr_block         = string<br>    node_groups = list(object({<br>      name            = string<br>      release_version = string<br>      min_size        = number<br>      max_size        = number<br>      instance_types  = list(string)<br>    }))<br>  })</pre> | n/a | yes |
 | <a name="input_eks_name_suffix"></a> [eks\_name\_suffix](#input\_eks\_name\_suffix) | The suffix for the eks clusters | `number` | `1` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment name to use for the deploy | `string` | n/a | yes |

--- a/modules/aws/eks/eks.tf
+++ b/modules/aws/eks/eks.tf
@@ -37,7 +37,9 @@ resource "aws_eks_cluster" "this" { #tfsec:ignore:AWS067
   version  = var.eks_config.kubernetes_version
 
   vpc_config {
-    subnet_ids = [for s in data.aws_subnet.cluster : s.id] #tfsec:ignore:AWS069 tfsec:ignore:AWS068
+    subnet_ids              = [for s in data.aws_subnet.cluster : s.id] #tfsec:ignore:AWS069 tfsec:ignore:AWS068
+    endpoint_private_access = true
+    public_access_cidrs     = var.eks_authorized_ips #tfsec:ignore:AWS068
   }
 
   encryption_config {

--- a/modules/aws/eks/variables.tf
+++ b/modules/aws/eks/variables.tf
@@ -14,6 +14,11 @@ variable "eks_name_suffix" {
   default     = 1
 }
 
+variable "eks_authorized_ips" {
+  description = "Authorized IPs to access EKS API"
+  type        = list(string)
+}
+
 variable "eks_config" {
   description = "The EKS Config"
   type = object({

--- a/validation/aws/eks/main.tf
+++ b/validation/aws/eks/main.tf
@@ -20,6 +20,8 @@ module "eks" {
   environment     = "dev"
   name            = "eks"
   eks_name_suffix = 1
+
+  eks_authorized_ips = ["0.0.0.0/0"]
   eks_config = {
     kubernetes_version = "1.20.4"
     cidr_block         = "10.0.16.0/20"


### PR DESCRIPTION
Enable private endpoints on the EKS cluster,
this way the cluster can communicate inside the VPC when communicating internally.