### PR TITLE
Remove aws-calico link from kubernetes docs

### DIFF
--- a/modules/kubernetes/README.md
+++ b/modules/kubernetes/README.md
@@ -29,5 +29,4 @@ This directory contains all the Kubernetes Terraform modules.
 - [`xenit`](xenit/README.md)
 - [`linkerd`](linkerd/README.md)
 - [`goldpinger`](goldpinger/README.md)
-- [`aws-calico`](aws-calico/README.md)
 - [`cluster-autoscaler`](cluster-autoscaler/README.md)


### PR DESCRIPTION
Link destination does not exist, causing issues for docusaurus