### PR TITLE
Change linkerd proxy default log format

### DIFF
--- a/modules/kubernetes/linkerd/templates/values.yaml.tpl
+++ b/modules/kubernetes/linkerd/templates/values.yaml.tpl
@@ -40,6 +40,8 @@ enablePodAntiAffinity: true
 
 # proxy configuration
 proxy:
+  # A better default for log collectors that require strucutured data
+  logFormat: json
   resources:
     cpu:
       request: 100m

--- a/modules/kubernetes/linkerd/templates/values.yaml.tpl
+++ b/modules/kubernetes/linkerd/templates/values.yaml.tpl
@@ -40,7 +40,7 @@ enablePodAntiAffinity: true
 
 # proxy configuration
 proxy:
-  # A better default for log collectors that require strucutured data
+  # A better default for log collectors that require structured data
   logFormat: json
   resources:
     cpu:


### PR DESCRIPTION
This is a small change which sets the linkerd proxy to by default output
logs as json instead of plain text. The reasoning is that log collectors
such as datadog prefer structured log data so the majority of users
prefer this behavior instead of plain text. It is still possible to
change the format to plain text with an annotation on the pod.