### PR TITLE
Make aad pod id tolerate all taints

### DIFF
--- a/modules/kubernetes/aad-pod-identity/README.md
+++ b/modules/kubernetes/aad-pod-identity/README.md
@@ -34,7 +34,6 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_aad_pod_identity"></a> [aad\_pod\_identity](#input\_aad\_pod\_identity) | Configuration for aad pod identity | <pre>map(object({<br>    id        = string<br>    client_id = string<br>  }))</pre> | n/a | yes |
 | <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | Namespaces to create AzureIdentity and AzureIdentityBindings in. | <pre>list(<br>    object({<br>      name = string<br>    })<br>  )</pre> | n/a | yes |
-| <a name="input_tolerate_all_taints"></a> [tolerate\_all\_taints](#input\_tolerate\_all\_taints) | If true the nmi daemonset will schedule on all nodes no matter the taints on the nodes. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/kubernetes/aad-pod-identity/main.tf
+++ b/modules/kubernetes/aad-pod-identity/main.tf
@@ -37,8 +37,7 @@ resource "helm_release" "aad_pod_identity" {
   version    = "4.0.0"
   namespace  = kubernetes_namespace.this.metadata[0].name
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
-    namespaces          = var.namespaces,
-    aad_pod_identity    = var.aad_pod_identity
-    tolerate_all_taints = var.tolerate_all_taints
+    namespaces       = var.namespaces,
+    aad_pod_identity = var.aad_pod_identity
   })]
 }

--- a/modules/kubernetes/aad-pod-identity/templates/values.yaml.tpl
+++ b/modules/kubernetes/aad-pod-identity/templates/values.yaml.tpl
@@ -10,11 +10,7 @@ nmi:
   priorityClassName: "platform-high"
 
   tolerations:
-  - key: "CriticalAddonsOnly"
-    operator: "Exists"
-  %{ if tolerate_all_taints }
   - operator: "Exists"
-  %{ endif }
 
 azureIdentities:
 %{ for namespace in namespaces ~}

--- a/modules/kubernetes/aad-pod-identity/variables.tf
+++ b/modules/kubernetes/aad-pod-identity/variables.tf
@@ -14,9 +14,3 @@ variable "namespaces" {
     })
   )
 }
-
-variable "tolerate_all_taints" {
-  description = "If true the nmi daemonset will schedule on all nodes no matter the taints on the nodes."
-  type        = bool
-  default     = false
-}


### PR DESCRIPTION
It was easier to always tolerate all taints rather than make it an option.