### PR TITLE
Enable clusterChecksEnabled in datadog

### DIFF
--- a/modules/kubernetes/datadog/charts/datadog-extras/templates/datadogagent.yaml
+++ b/modules/kubernetes/datadog/charts/datadog-extras/templates/datadogagent.yaml
@@ -48,6 +48,9 @@ spec:
     priorityClassName: platform-low
     image:
       name: "gcr.io/datadoghq/cluster-agent:latest"
+    config:
+      clusterChecksEnabled: true
+    replicas: 2
   features:
     kubeStateMetricsCore:
       enabled: true

--- a/modules/kubernetes/datadog/charts/datadog-extras/templates/datadogagent.yaml
+++ b/modules/kubernetes/datadog/charts/datadog-extras/templates/datadogagent.yaml
@@ -50,7 +50,7 @@ spec:
       name: "gcr.io/datadoghq/cluster-agent:latest"
     config:
       clusterChecksEnabled: true
-    replicas: 2
+      logLevel: info
   features:
     kubeStateMetricsCore:
       enabled: true


### PR DESCRIPTION
* Enable metrics to be gatherd about the pods, like number of replicas.
* Set replicas: 2 in the clusterAgent deployment