### PR TITLE
Update flux and external-dns to handle blue green deployments.

### DIFF
--- a/modules/aws/core/README.md
+++ b/modules/aws/core/README.md
@@ -7,13 +7,13 @@ This module is used to configure a standard public/private VPC and accompanying 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 0.15.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.54.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.55.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.54.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.55.0 |
 
 ## Modules
 
@@ -23,25 +23,25 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_eip.public](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/eip) | resource |
-| [aws_internet_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/internet_gateway) | resource |
-| [aws_nat_gateway.public](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/nat_gateway) | resource |
-| [aws_route.peering_accepter](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/route) | resource |
-| [aws_route.peering_requester](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/route) | resource |
-| [aws_route.private](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/route) | resource |
-| [aws_route.public](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/route) | resource |
-| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/route53_zone) | resource |
-| [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/route_table) | resource |
-| [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/route_table) | resource |
-| [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/route_table_association) | resource |
-| [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/route_table_association) | resource |
-| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/subnet) | resource |
-| [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/subnet) | resource |
-| [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/vpc) | resource |
-| [aws_vpc_peering_connection.this](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/vpc_peering_connection) | resource |
-| [aws_vpc_peering_connection_accepter.peer](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/vpc_peering_connection_accepter) | resource |
-| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/data-sources/availability_zones) | data source |
-| [aws_vpc_peering_connection.this](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/data-sources/vpc_peering_connection) | data source |
+| [aws_eip.public](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/eip) | resource |
+| [aws_internet_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/internet_gateway) | resource |
+| [aws_nat_gateway.public](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/nat_gateway) | resource |
+| [aws_route.peering_accepter](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/route) | resource |
+| [aws_route.peering_requester](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/route) | resource |
+| [aws_route.private](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/route) | resource |
+| [aws_route.public](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/route) | resource |
+| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/route53_zone) | resource |
+| [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/route_table) | resource |
+| [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/route_table) | resource |
+| [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/route_table_association) | resource |
+| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/subnet) | resource |
+| [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/subnet) | resource |
+| [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/vpc) | resource |
+| [aws_vpc_peering_connection.this](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/vpc_peering_connection) | resource |
+| [aws_vpc_peering_connection_accepter.peer](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/vpc_peering_connection_accepter) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/data-sources/availability_zones) | data source |
+| [aws_vpc_peering_connection.this](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/data-sources/vpc_peering_connection) | data source |
 
 ## Inputs
 

--- a/modules/aws/core/main.tf
+++ b/modules/aws/core/main.tf
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.54.0"
+      version = "3.55.0"
     }
   }
 }

--- a/modules/aws/eks-global/README.md
+++ b/modules/aws/eks-global/README.md
@@ -3,14 +3,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 0.15.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.54.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.55.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 1.6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.54.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.55.0 |
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 1.6.0 |
 
 ## Modules
@@ -21,21 +21,21 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_iam_policy.eks_admin](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/iam_policy) | resource |
-| [aws_iam_role.eks_admin](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.eks_cluster](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.eks_node_group](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/iam_role) | resource |
-| [aws_kms_key.eks_encryption](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/kms_key) | resource |
-| [aws_kms_key.velero](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/kms_key) | resource |
-| [aws_s3_bucket.velero](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/s3_bucket) | resource |
+| [aws_iam_policy.eks_admin](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/iam_policy) | resource |
+| [aws_iam_role.eks_admin](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.eks_cluster](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.eks_node_group](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/iam_role) | resource |
+| [aws_kms_key.eks_encryption](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/kms_key) | resource |
+| [aws_kms_key.velero](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/kms_key) | resource |
+| [aws_s3_bucket.velero](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/s3_bucket) | resource |
 | [azuread_group.cluster_admin](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
 | [azuread_group.cluster_view](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
 | [azuread_group.edit](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
 | [azuread_group.view](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/data-sources/caller_identity) | data source |
-| [aws_iam_policy_document.eks_admin_assume](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.eks_admin_permission](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/data-sources/region) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.eks_admin_assume](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.eks_admin_permission](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/modules/aws/eks-global/main.tf
+++ b/modules/aws/eks-global/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.54.0"
+      version = "3.55.0"
     }
     azuread = {
       version = "1.6.0"

--- a/modules/aws/eks/README.md
+++ b/modules/aws/eks/README.md
@@ -68,6 +68,7 @@
 
 | Name | Description |
 |------|-------------|
+| <a name="output_aws_eks_core_dns_addon"></a> [aws\_eks\_core\_dns\_addon](#output\_aws\_eks\_core\_dns\_addon) | Core DNS addon |
 | <a name="output_cert_manager_config"></a> [cert\_manager\_config](#output\_cert\_manager\_config) | Configuration for Cert Manager |
 | <a name="output_cluster_autoscaler_config"></a> [cluster\_autoscaler\_config](#output\_cluster\_autoscaler\_config) | Configuration for Cluster Autoscaler |
 | <a name="output_external_dns_config"></a> [external\_dns\_config](#output\_external\_dns\_config) | Configuration for External DNS |

--- a/modules/aws/eks/README.md
+++ b/modules/aws/eks/README.md
@@ -3,7 +3,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 0.15.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.54.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.55.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | 3.1.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | 3.1.0 |
 
@@ -11,8 +11,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.54.0 |
-| <a name="provider_aws.eks_admin"></a> [aws.eks\_admin](#provider\_aws.eks\_admin) | 3.54.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.55.0 |
+| <a name="provider_aws.eks_admin"></a> [aws.eks\_admin](#provider\_aws.eks\_admin) | 3.55.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.1.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 3.1.0 |
 
@@ -30,23 +30,23 @@
 
 | Name | Type |
 |------|------|
-| [aws_eks_addon.core_dns](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/eks_addon) | resource |
-| [aws_eks_addon.kube_proxy](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/eks_addon) | resource |
-| [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/eks_cluster) | resource |
-| [aws_eks_node_group.this](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/eks_node_group) | resource |
-| [aws_iam_openid_connect_provider.this](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/iam_openid_connect_provider) | resource |
-| [aws_launch_template.eks_node_group](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/launch_template) | resource |
+| [aws_eks_addon.core_dns](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/eks_addon) | resource |
+| [aws_eks_addon.kube_proxy](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/eks_addon) | resource |
+| [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/eks_cluster) | resource |
+| [aws_eks_node_group.this](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/eks_node_group) | resource |
+| [aws_iam_openid_connect_provider.this](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/iam_openid_connect_provider) | resource |
+| [aws_launch_template.eks_node_group](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/launch_template) | resource |
 | [null_resource.update_eks_cni](https://registry.terraform.io/providers/hashicorp/null/3.1.0/docs/resources/resource) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/data-sources/caller_identity) | data source |
-| [aws_eks_cluster_auth.this](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/data-sources/eks_cluster_auth) | data source |
-| [aws_iam_policy_document.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.external_dns](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.velero](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.xenit](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/data-sources/region) | data source |
-| [aws_subnet.cluster](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/data-sources/subnet) | data source |
-| [aws_subnet.node](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/data-sources/subnet) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/data-sources/caller_identity) | data source |
+| [aws_eks_cluster_auth.this](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/data-sources/eks_cluster_auth) | data source |
+| [aws_iam_policy_document.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.external_dns](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.velero](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.xenit](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/data-sources/region) | data source |
+| [aws_subnet.cluster](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/data-sources/subnet) | data source |
+| [aws_subnet.node](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/data-sources/subnet) | data source |
 | [tls_certificate.thumbprint](https://registry.terraform.io/providers/hashicorp/tls/3.1.0/docs/data-sources/certificate) | data source |
 
 ## Inputs

--- a/modules/aws/eks/README.md
+++ b/modules/aws/eks/README.md
@@ -68,7 +68,6 @@
 
 | Name | Description |
 |------|-------------|
-| <a name="output_aws_eks_core_dns_addon"></a> [aws\_eks\_core\_dns\_addon](#output\_aws\_eks\_core\_dns\_addon) | Core DNS addon |
 | <a name="output_cert_manager_config"></a> [cert\_manager\_config](#output\_cert\_manager\_config) | Configuration for Cert Manager |
 | <a name="output_cluster_autoscaler_config"></a> [cluster\_autoscaler\_config](#output\_cluster\_autoscaler\_config) | Configuration for Cluster Autoscaler |
 | <a name="output_external_dns_config"></a> [external\_dns\_config](#output\_external\_dns\_config) | Configuration for External DNS |

--- a/modules/aws/eks/eks.tf
+++ b/modules/aws/eks/eks.tf
@@ -57,6 +57,8 @@ resource "aws_eks_addon" "kube_proxy" {
   addon_name   = "kube-proxy"
 
   tags = local.global_tags
+
+  depends_on = [aws_eks_node_group.this]
 }
 
 resource "aws_eks_addon" "core_dns" {
@@ -64,6 +66,8 @@ resource "aws_eks_addon" "core_dns" {
   addon_name   = "coredns"
 
   tags = local.global_tags
+
+  depends_on = [aws_eks_node_group.this]
 }
 
 data "tls_certificate" "thumbprint" {

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.54.0"
+      version = "3.55.0"
       # Need both providers, one is default and the other is
       # to create the eks cluster and get auth token
       configuration_aliases = [aws.eks_admin]

--- a/modules/aws/eks/outputs.tf
+++ b/modules/aws/eks/outputs.tf
@@ -5,6 +5,12 @@ output "kube_config" {
     host                   = aws_eks_cluster.this.endpoint
     cluster_ca_certificate = base64decode(aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token
+
+    # Ugly workaround to force the addons to be installed before starting with the core module
+    dummy_data = {
+      core_dns      = aws_eks_addon.core_dns
+      aws_eks_addon = aws_eks_addon.kube_proxy
+    }
   }
 }
 

--- a/modules/aws/eks/outputs.tf
+++ b/modules/aws/eks/outputs.tf
@@ -6,14 +6,6 @@ output "kube_config" {
     cluster_ca_certificate = base64decode(aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token
   }
-
-  # Due to the way EKS works there is no way that other actions against the cluster
-  # will work unless the critical addons are in a healthy state.
-  depends_on = [
-    aws_eks_addon.kube_proxy,
-    aws_eks_addon.core_dns,
-    aws_eks_node_group.this,
-  ]
 }
 
 output "cluster_autoscaler_config" {

--- a/modules/aws/eks/outputs.tf
+++ b/modules/aws/eks/outputs.tf
@@ -49,8 +49,3 @@ output "xenit_config" {
     role_arn = module.xenit.role_arn
   }
 }
-
-output "aws_eks_core_dns_addon" {
-  description = "Core DNS addon"
-  value       = aws_eks_addon.core_dns
-}

--- a/modules/aws/eks/outputs.tf
+++ b/modules/aws/eks/outputs.tf
@@ -43,3 +43,8 @@ output "xenit_config" {
     role_arn = module.xenit.role_arn
   }
 }
+
+output "aws_eks_core_dns_addon" {
+  description = "Core DNS addon"
+  value       = aws_eks_addon.core_dns
+}

--- a/modules/aws/eks/outputs.tf
+++ b/modules/aws/eks/outputs.tf
@@ -6,6 +6,14 @@ output "kube_config" {
     cluster_ca_certificate = base64decode(aws_eks_cluster.this.certificate_authority[0].data)
     token                  = data.aws_eks_cluster_auth.this.token
   }
+
+  # Due to the way EKS works there is no way that other actions against the cluster
+  # will work unless the critical addons are in a healthy state.
+  depends_on = [
+    aws_eks_addon.kube_proxy,
+    aws_eks_addon.core_dns,
+    aws_eks_node_group.this,
+  ]
 }
 
 output "cluster_autoscaler_config" {

--- a/modules/aws/eks/templates/update-eks-cni.sh.tpl
+++ b/modules/aws/eks/templates/update-eks-cni.sh.tpl
@@ -1,5 +1,5 @@
 TMPDIR=$(mktemp -d) && \
-KUBECONFIG="$TMPDIR/config" && \
+export KUBECONFIG="$TMPDIR/config" && \
 kubectl config set clusters.cluster-admin.server ${api_server_url} && \
 kubectl config set clusters.cluster-admin.certificate-authority-data ${b64_cluster_ca} && \
 kubectl config set users.cluster-admin.token ${token} && \

--- a/modules/aws/irsa/README.md
+++ b/modules/aws/irsa/README.md
@@ -9,13 +9,13 @@ to assume the specific role.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 0.15.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.54.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.55.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.54.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.55.0 |
 
 ## Modules
 
@@ -25,10 +25,10 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_iam_policy.permissions](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/iam_policy) | resource |
-| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.permissions](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_policy_document.assume](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy.permissions](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/iam_policy) | resource |
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.permissions](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_policy_document.assume](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 

--- a/modules/aws/irsa/main.tf
+++ b/modules/aws/irsa/main.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.54.0"
+      version = "3.55.0"
     }
   }
 }

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -61,7 +61,7 @@ module "fluxcd_v1_azure_devops" {
   azure_devops_org    = var.fluxcd_v1_config.azure_devops.org
   flux_status_enabled = var.fluxcd_v1_config.flux_status_enabled
   branch              = var.fluxcd_v1_config.branch
-  cluster_id       = "${var.location_short}-${var.environment}-${var.name}${var.aks_name_suffix}"
+  environment         = var.environment
   namespaces = [for ns in var.namespaces : {
     name = ns.name
     flux = ns.flux
@@ -81,7 +81,8 @@ module "fluxcd_v2_azure_devops" {
   azure_devops_pat  = var.fluxcd_v2_config.azure_devops.pat
   azure_devops_org  = var.fluxcd_v2_config.azure_devops.org
   azure_devops_proj = var.fluxcd_v2_config.azure_devops.proj
-  cluster_id       = "${var.location_short}-${var.environment}-${var.name}${var.aks_name_suffix}"
+  environment       = var.environment
+  cluster_id        = "${var.location_short}-${var.environment}-${var.name}${var.aks_name_suffix}"
   namespaces = [for ns in var.namespaces : {
     name = ns.name
     flux = {
@@ -105,6 +106,7 @@ module "fluxcd_v2_github" {
 
   github_owner = var.fluxcd_v2_config.github.owner
   environment  = var.environment
+  cluster_id   = "${var.location_short}-${var.environment}-${var.name}${var.aks_name_suffix}"
   namespaces = [for ns in var.namespaces : {
     name = ns.name
     flux = {

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -61,7 +61,7 @@ module "fluxcd_v1_azure_devops" {
   azure_devops_org    = var.fluxcd_v1_config.azure_devops.org
   flux_status_enabled = var.fluxcd_v1_config.flux_status_enabled
   branch              = var.fluxcd_v1_config.branch
-  environment         = var.environment
+  cluster_id       = "${var.location_short}-${var.environment}-${var.name}${var.aks_name_suffix}"
   namespaces = [for ns in var.namespaces : {
     name = ns.name
     flux = ns.flux
@@ -81,7 +81,7 @@ module "fluxcd_v2_azure_devops" {
   azure_devops_pat  = var.fluxcd_v2_config.azure_devops.pat
   azure_devops_org  = var.fluxcd_v2_config.azure_devops.org
   azure_devops_proj = var.fluxcd_v2_config.azure_devops.proj
-  environment       = var.environment
+  cluster_id       = "${var.location_short}-${var.environment}-${var.name}${var.aks_name_suffix}"
   namespaces = [for ns in var.namespaces : {
     name = ns.name
     flux = {

--- a/modules/kubernetes/eks-core/README.md
+++ b/modules/kubernetes/eks-core/README.md
@@ -7,7 +7,7 @@ This module is used to configure EKS clusters.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 0.15.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.54.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.55.0 |
 | <a name="requirement_flux"></a> [flux](#requirement\_flux) | 0.2.2 |
 | <a name="requirement_github"></a> [github](#requirement\_github) | 4.13.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.2.0 |
@@ -19,7 +19,7 @@ This module is used to configure EKS clusters.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.54.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.55.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.2.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.4.1 |
 
@@ -67,8 +67,8 @@ This module is used to configure EKS clusters.
 | [kubernetes_role_binding.sa_helm_release](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.view](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/role_binding) | resource |
 | [kubernetes_service_account.tenant](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/service_account) | resource |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/data-sources/region) | data source |
-| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/3.54.0/docs/data-sources/route53_zone) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/data-sources/region) | data source |
+| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/3.55.0/docs/data-sources/route53_zone) | data source |
 
 ## Inputs
 

--- a/modules/kubernetes/eks-core/main.tf
+++ b/modules/kubernetes/eks-core/main.tf
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.54.0"
+      version = "3.55.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/kubernetes/eks-core/modules.tf
+++ b/modules/kubernetes/eks-core/modules.tf
@@ -137,7 +137,7 @@ module "external_dns" {
   source = "../../kubernetes/external-dns"
 
   dns_provider = "aws"
-  txt_owner_id = var.environment # TODO: Add "name" definition to eks-core as well
+  txt_owner_id = "${var.environment}-${var.name}${var.aks_name_suffix}"
   aws_config = {
     region   = data.aws_region.current.name
     role_arn = var.external_dns_config.role_arn

--- a/modules/kubernetes/eks-core/modules.tf
+++ b/modules/kubernetes/eks-core/modules.tf
@@ -47,7 +47,7 @@ module "fluxcd_v2_azure_devops" {
   azure_devops_pat  = var.fluxcd_v2_config.azure_devops.pat
   azure_devops_org  = var.fluxcd_v2_config.azure_devops.org
   azure_devops_proj = var.fluxcd_v2_config.azure_devops.proj
-  environment       = var.environment
+  cluster_id       = "${data.aws_region.current.name}-${var.environment}-${var.name}${var.eks_name_suffix}"
   namespaces = [for ns in var.namespaces : {
     name = ns.name
     flux = {
@@ -70,7 +70,7 @@ module "fluxcd_v2_github" {
   source = "../../kubernetes/fluxcd-v2-github"
 
   github_owner = var.fluxcd_v2_config.github.owner
-  environment  = var.environment
+  cluster_id       = "${data.aws_region.current.name}-${var.environment}-${var.name}${var.eks_name_suffix}"
   namespaces = [for ns in var.namespaces : {
     name = ns.name
     flux = {
@@ -137,7 +137,7 @@ module "external_dns" {
   source = "../../kubernetes/external-dns"
 
   dns_provider = "aws"
-  txt_owner_id = "${var.environment}-${var.name}${var.aks_name_suffix}"
+  txt_owner_id = "${var.environment}-${var.name}${var.eks_name_suffix}"
   aws_config = {
     region   = data.aws_region.current.name
     role_arn = var.external_dns_config.role_arn

--- a/modules/kubernetes/eks-core/modules.tf
+++ b/modules/kubernetes/eks-core/modules.tf
@@ -47,7 +47,8 @@ module "fluxcd_v2_azure_devops" {
   azure_devops_pat  = var.fluxcd_v2_config.azure_devops.pat
   azure_devops_org  = var.fluxcd_v2_config.azure_devops.org
   azure_devops_proj = var.fluxcd_v2_config.azure_devops.proj
-  cluster_id       = "${data.aws_region.current.name}-${var.environment}-${var.name}${var.eks_name_suffix}"
+  environment       = var.environment
+  cluster_id        = "${data.aws_region.current.name}-${var.environment}-${var.name}${var.eks_name_suffix}"
   namespaces = [for ns in var.namespaces : {
     name = ns.name
     flux = {
@@ -70,7 +71,8 @@ module "fluxcd_v2_github" {
   source = "../../kubernetes/fluxcd-v2-github"
 
   github_owner = var.fluxcd_v2_config.github.owner
-  cluster_id       = "${data.aws_region.current.name}-${var.environment}-${var.name}${var.eks_name_suffix}"
+  environment  = var.environment
+  cluster_id   = "${data.aws_region.current.name}-${var.environment}-${var.name}${var.eks_name_suffix}"
   namespaces = [for ns in var.namespaces : {
     name = ns.name
     flux = {

--- a/modules/kubernetes/fluxcd-v2-azdo/README.md
+++ b/modules/kubernetes/fluxcd-v2-azdo/README.md
@@ -18,7 +18,7 @@ the bootstrap configuration.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 0.15.3 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | 0.4.0 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | 0.5.0 |
 | <a name="requirement_flux"></a> [flux](#requirement\_flux) | 0.2.2 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.2.0 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | 1.11.3 |
@@ -29,7 +29,7 @@ the bootstrap configuration.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuredevops"></a> [azuredevops](#provider\_azuredevops) | 0.4.0 |
+| <a name="provider_azuredevops"></a> [azuredevops](#provider\_azuredevops) | 0.5.0 |
 | <a name="provider_flux"></a> [flux](#provider\_flux) | 0.2.2 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.2.0 |
 | <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | 1.11.3 |
@@ -43,17 +43,17 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azuredevops_git_repository_file.cluster_tenants](https://registry.terraform.io/providers/xenitab/azuredevops/0.4.0/docs/resources/git_repository_file) | resource |
-| [azuredevops_git_repository_file.install](https://registry.terraform.io/providers/xenitab/azuredevops/0.4.0/docs/resources/git_repository_file) | resource |
-| [azuredevops_git_repository_file.kustomize](https://registry.terraform.io/providers/xenitab/azuredevops/0.4.0/docs/resources/git_repository_file) | resource |
-| [azuredevops_git_repository_file.sync](https://registry.terraform.io/providers/xenitab/azuredevops/0.4.0/docs/resources/git_repository_file) | resource |
-| [azuredevops_git_repository_file.tenant](https://registry.terraform.io/providers/xenitab/azuredevops/0.4.0/docs/resources/git_repository_file) | resource |
+| [azuredevops_git_repository_file.cluster_tenants](https://registry.terraform.io/providers/xenitab/azuredevops/0.5.0/docs/resources/git_repository_file) | resource |
+| [azuredevops_git_repository_file.install](https://registry.terraform.io/providers/xenitab/azuredevops/0.5.0/docs/resources/git_repository_file) | resource |
+| [azuredevops_git_repository_file.kustomize](https://registry.terraform.io/providers/xenitab/azuredevops/0.5.0/docs/resources/git_repository_file) | resource |
+| [azuredevops_git_repository_file.sync](https://registry.terraform.io/providers/xenitab/azuredevops/0.5.0/docs/resources/git_repository_file) | resource |
+| [azuredevops_git_repository_file.tenant](https://registry.terraform.io/providers/xenitab/azuredevops/0.5.0/docs/resources/git_repository_file) | resource |
 | [helm_release.azdo_proxy](https://registry.terraform.io/providers/hashicorp/helm/2.2.0/docs/resources/release) | resource |
 | [kubectl_manifest.install](https://registry.terraform.io/providers/gavinbunney/kubectl/1.11.3/docs/resources/manifest) | resource |
 | [kubectl_manifest.sync](https://registry.terraform.io/providers/gavinbunney/kubectl/1.11.3/docs/resources/manifest) | resource |
 | [kubernetes_namespace.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/namespace) | resource |
-| [azuredevops_git_repository.cluster](https://registry.terraform.io/providers/xenitab/azuredevops/0.4.0/docs/data-sources/git_repository) | data source |
-| [azuredevops_project.this](https://registry.terraform.io/providers/xenitab/azuredevops/0.4.0/docs/data-sources/project) | data source |
+| [azuredevops_git_repository.cluster](https://registry.terraform.io/providers/xenitab/azuredevops/0.5.0/docs/data-sources/git_repository) | data source |
+| [azuredevops_project.this](https://registry.terraform.io/providers/xenitab/azuredevops/0.5.0/docs/data-sources/project) | data source |
 | [flux_install.this](https://registry.terraform.io/providers/fluxcd/flux/0.2.2/docs/data-sources/install) | data source |
 | [flux_sync.this](https://registry.terraform.io/providers/fluxcd/flux/0.2.2/docs/data-sources/sync) | data source |
 | [kubectl_file_documents.install](https://registry.terraform.io/providers/gavinbunney/kubectl/1.11.3/docs/data-sources/file_documents) | data source |

--- a/modules/kubernetes/fluxcd-v2-azdo/README.md
+++ b/modules/kubernetes/fluxcd-v2-azdo/README.md
@@ -67,6 +67,7 @@ No modules.
 | <a name="input_azure_devops_pat"></a> [azure\_devops\_pat](#input\_azure\_devops\_pat) | PAT to authenticate with Azure DevOps | `string` | n/a | yes |
 | <a name="input_azure_devops_proj"></a> [azure\_devops\_proj](#input\_azure\_devops\_proj) | Azure DevOps project for bootstrap repository | `string` | n/a | yes |
 | <a name="input_branch"></a> [branch](#input\_branch) | Branch to point source controller towards | `string` | `"main"` | no |
+| <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | Unique identifier of the cluster across regions and instances. | `string` | n/a | yes |
 | <a name="input_cluster_repo"></a> [cluster\_repo](#input\_cluster\_repo) | Name of cluster repository | `string` | `"fleet-infra"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name of the cluster | `string` | n/a | yes |
 | <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | The namespaces to configure flux with | <pre>list(<br>    object({<br>      name = string<br>      flux = object({<br>        enabled     = bool<br>        create_crds = bool<br>        org         = string<br>        proj        = string<br>        repo        = string<br>      })<br>    })<br>  )</pre> | n/a | yes |

--- a/modules/kubernetes/fluxcd-v2-azdo/README.md
+++ b/modules/kubernetes/fluxcd-v2-azdo/README.md
@@ -18,7 +18,7 @@ the bootstrap configuration.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 0.15.3 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | 0.3.0 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | 0.4.0 |
 | <a name="requirement_flux"></a> [flux](#requirement\_flux) | 0.2.2 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.2.0 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | 1.11.3 |
@@ -29,7 +29,7 @@ the bootstrap configuration.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuredevops"></a> [azuredevops](#provider\_azuredevops) | 0.3.0 |
+| <a name="provider_azuredevops"></a> [azuredevops](#provider\_azuredevops) | 0.4.0 |
 | <a name="provider_flux"></a> [flux](#provider\_flux) | 0.2.2 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.2.0 |
 | <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | 1.11.3 |
@@ -43,17 +43,17 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azuredevops_git_repository_file.cluster_tenants](https://registry.terraform.io/providers/xenitab/azuredevops/0.3.0/docs/resources/git_repository_file) | resource |
-| [azuredevops_git_repository_file.install](https://registry.terraform.io/providers/xenitab/azuredevops/0.3.0/docs/resources/git_repository_file) | resource |
-| [azuredevops_git_repository_file.kustomize](https://registry.terraform.io/providers/xenitab/azuredevops/0.3.0/docs/resources/git_repository_file) | resource |
-| [azuredevops_git_repository_file.sync](https://registry.terraform.io/providers/xenitab/azuredevops/0.3.0/docs/resources/git_repository_file) | resource |
-| [azuredevops_git_repository_file.tenant](https://registry.terraform.io/providers/xenitab/azuredevops/0.3.0/docs/resources/git_repository_file) | resource |
+| [azuredevops_git_repository_file.cluster_tenants](https://registry.terraform.io/providers/xenitab/azuredevops/0.4.0/docs/resources/git_repository_file) | resource |
+| [azuredevops_git_repository_file.install](https://registry.terraform.io/providers/xenitab/azuredevops/0.4.0/docs/resources/git_repository_file) | resource |
+| [azuredevops_git_repository_file.kustomize](https://registry.terraform.io/providers/xenitab/azuredevops/0.4.0/docs/resources/git_repository_file) | resource |
+| [azuredevops_git_repository_file.sync](https://registry.terraform.io/providers/xenitab/azuredevops/0.4.0/docs/resources/git_repository_file) | resource |
+| [azuredevops_git_repository_file.tenant](https://registry.terraform.io/providers/xenitab/azuredevops/0.4.0/docs/resources/git_repository_file) | resource |
 | [helm_release.azdo_proxy](https://registry.terraform.io/providers/hashicorp/helm/2.2.0/docs/resources/release) | resource |
 | [kubectl_manifest.install](https://registry.terraform.io/providers/gavinbunney/kubectl/1.11.3/docs/resources/manifest) | resource |
 | [kubectl_manifest.sync](https://registry.terraform.io/providers/gavinbunney/kubectl/1.11.3/docs/resources/manifest) | resource |
 | [kubernetes_namespace.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/namespace) | resource |
-| [azuredevops_git_repository.cluster](https://registry.terraform.io/providers/xenitab/azuredevops/0.3.0/docs/data-sources/git_repository) | data source |
-| [azuredevops_project.this](https://registry.terraform.io/providers/xenitab/azuredevops/0.3.0/docs/data-sources/project) | data source |
+| [azuredevops_git_repository.cluster](https://registry.terraform.io/providers/xenitab/azuredevops/0.4.0/docs/data-sources/git_repository) | data source |
+| [azuredevops_project.this](https://registry.terraform.io/providers/xenitab/azuredevops/0.4.0/docs/data-sources/project) | data source |
 | [flux_install.this](https://registry.terraform.io/providers/fluxcd/flux/0.2.2/docs/data-sources/install) | data source |
 | [flux_sync.this](https://registry.terraform.io/providers/fluxcd/flux/0.2.2/docs/data-sources/sync) | data source |
 | [kubectl_file_documents.install](https://registry.terraform.io/providers/gavinbunney/kubectl/1.11.3/docs/data-sources/file_documents) | data source |

--- a/modules/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/main.tf
@@ -29,7 +29,7 @@ terraform {
     }
     azuredevops = {
       source  = "xenitab/azuredevops"
-      version = "0.3.0"
+      version = "0.4.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/main.tf
@@ -99,13 +99,13 @@ data "azuredevops_git_repository" "cluster" {
 }
 
 data "flux_install" "this" {
-  target_path = "clusters/${var.environment}"
+  target_path = "clusters/${var.cluster_id}"
 }
 
 data "flux_sync" "this" {
   url                = "${local.azdo_proxy_url}/${var.azure_devops_org}/${var.azure_devops_proj}/_git/${var.cluster_repo}"
   branch             = var.branch
-  target_path        = "clusters/${var.environment}"
+  target_path        = "clusters/${var.cluster_id}"
   git_implementation = "libgit2"
 }
 
@@ -168,9 +168,9 @@ resource "azuredevops_git_repository_file" "kustomize" {
 
 resource "azuredevops_git_repository_file" "cluster_tenants" {
   repository_id = data.azuredevops_git_repository.cluster.id
-  file          = "clusters/${var.environment}/tenants.yaml"
+  file          = "clusters/${var.cluster_id}/tenants.yaml"
   content = templatefile("${path.module}/templates/cluster-tenants.yaml", {
-    environment = var.environment
+    cluster_id = var.cluster_id
   })
   branch              = "refs/heads/${var.branch}"
   overwrite_on_create = true
@@ -186,12 +186,12 @@ resource "azuredevops_git_repository_file" "tenant" {
 
   repository_id = data.azuredevops_git_repository.cluster.id
   branch        = "refs/heads/${var.branch}"
-  file          = "tenants/${var.environment}/${each.key}.yaml"
+  file          = "tenants/${var.cluster_id}/${each.key}.yaml"
   content = templatefile("${path.module}/templates/tenant.yaml", {
     repo        = "${local.azdo_proxy_url}/${var.azure_devops_org}/${each.value.flux.proj}/_git/${each.value.flux.repo}"
     branch      = var.branch,
     name        = each.key,
-    environment = var.environment,
+    cluster_id = var.cluster_id,
     create_crds = each.value.flux.create_crds
   })
   overwrite_on_create = true

--- a/modules/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/main.tf
@@ -29,7 +29,7 @@ terraform {
     }
     azuredevops = {
       source  = "xenitab/azuredevops"
-      version = "0.4.0"
+      version = "0.5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/main.tf
@@ -191,7 +191,7 @@ resource "azuredevops_git_repository_file" "tenant" {
     repo        = "${local.azdo_proxy_url}/${var.azure_devops_org}/${each.value.flux.proj}/_git/${each.value.flux.repo}"
     branch      = var.branch,
     name        = each.key,
-    cluster_id = var.cluster_id,
+    environment = var.environment,
     create_crds = each.value.flux.create_crds
   })
   overwrite_on_create = true

--- a/modules/kubernetes/fluxcd-v2-azdo/templates/cluster-tenants.yaml
+++ b/modules/kubernetes/fluxcd-v2-azdo/templates/cluster-tenants.yaml
@@ -8,6 +8,6 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
-  path: ./tenants/${environment}
+  path: ./tenants/${cluster_id}
   prune: true
   validation: client

--- a/modules/kubernetes/fluxcd-v2-azdo/templates/tenant.yaml
+++ b/modules/kubernetes/fluxcd-v2-azdo/templates/tenant.yaml
@@ -46,7 +46,7 @@ metadata:
 spec:
   serviceAccountName: flux
   interval: 5m
-  path: ./tenant/${environment}
+  path: ./tenant/${cluster_id}
   sourceRef:
     kind: GitRepository
     name: ${name}

--- a/modules/kubernetes/fluxcd-v2-azdo/templates/tenant.yaml
+++ b/modules/kubernetes/fluxcd-v2-azdo/templates/tenant.yaml
@@ -46,7 +46,7 @@ metadata:
 spec:
   serviceAccountName: flux
   interval: 5m
-  path: ./tenant/${cluster_id}
+  path: ./tenant/${environment}
   sourceRef:
     kind: GitRepository
     name: ${name}

--- a/modules/kubernetes/fluxcd-v2-azdo/variables.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/variables.tf
@@ -14,6 +14,11 @@ variable "azure_devops_proj" {
   type        = string
 }
 
+variable "environment" {
+  description = "Environment name of the cluster"
+  type        = string
+}
+
 variable "cluster_id" {
   description = "Unique identifier of the cluster across regions and instances."
   type        = string

--- a/modules/kubernetes/fluxcd-v2-azdo/variables.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/variables.tf
@@ -14,8 +14,8 @@ variable "azure_devops_proj" {
   type        = string
 }
 
-variable "environment" {
-  description = "Environment name of the cluster"
+variable "cluster_id" {
+  description = "Unique identifier of the cluster across regions and instances."
   type        = string
 }
 

--- a/modules/kubernetes/fluxcd-v2-github/README.md
+++ b/modules/kubernetes/fluxcd-v2-github/README.md
@@ -68,6 +68,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_branch"></a> [branch](#input\_branch) | Branch to point source controller towards | `string` | `"main"` | no |
+| <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | Environment name of the cluster | `string` | n/a | yes |
 | <a name="input_cluster_repo"></a> [cluster\_repo](#input\_cluster\_repo) | Name of cluster repository | `string` | `"fleet-infra"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name of the cluster | `string` | n/a | yes |
 | <a name="input_github_owner"></a> [github\_owner](#input\_github\_owner) | Owner of GitHub repositories | `string` | n/a | yes |

--- a/modules/kubernetes/fluxcd-v2-github/main.tf
+++ b/modules/kubernetes/fluxcd-v2-github/main.tf
@@ -73,18 +73,18 @@ resource "tls_private_key" "cluster" {
 }
 
 data "flux_install" "this" {
-  target_path = "clusters/${var.environment}"
+  target_path = "clusters/${var.cluster_id}"
 }
 
 data "flux_sync" "this" {
   url         = "ssh://git@github.com/${var.github_owner}/${var.cluster_repo}.git"
-  target_path = "clusters/${var.environment}"
+  target_path = "clusters/${var.cluster_id}"
   branch      = var.branch
   interval    = 1
 }
 
 resource "github_repository_deploy_key" "cluster" {
-  title      = "flux-${var.environment}"
+  title      = "flux-${var.cluster_id}"
   repository = data.github_repository.cluster.name
   key        = tls_private_key.cluster.public_key_openssh
   read_only  = true
@@ -154,9 +154,9 @@ resource "kubernetes_secret" "cluster" {
 resource "github_repository_file" "cluster_tenants" {
   repository = data.github_repository.cluster.name
   branch     = var.branch
-  file       = "clusters/${var.environment}/tenants.yaml"
+  file       = "clusters/${var.cluster_id}/tenants.yaml"
   content = templatefile("${path.module}/templates/cluster-tenants.yaml", {
-    environment = var.environment
+    cluster_id = var.cluster_id
   })
   overwrite_on_create = true
 }
@@ -190,7 +190,7 @@ resource "github_repository_deploy_key" "tenant" {
     if ns.flux.enabled
   }
 
-  title      = "flux-${var.environment}"
+  title      = "flux-${var.cluster_id}"
   repository = data.github_repository.tenant[each.key].name
   key        = tls_private_key.tenant[each.key].public_key_openssh
   read_only  = true
@@ -225,12 +225,12 @@ resource "github_repository_file" "tenant" {
 
   repository = data.github_repository.cluster.name
   branch     = var.branch
-  file       = "tenants/${var.environment}/${each.key}.yaml"
+  file       = "tenants/${var.cluster_id}/${each.key}.yaml"
   content = templatefile("${path.module}/templates/tenant.yaml", {
     repo        = "ssh://git@github.com/${data.github_repository.tenant[each.key].full_name}.git",
     branch      = var.branch,
     name        = each.key,
-    environment = var.environment,
+    cluster_id = var.cluster_id,
   })
   overwrite_on_create = true
 }

--- a/modules/kubernetes/fluxcd-v2-github/main.tf
+++ b/modules/kubernetes/fluxcd-v2-github/main.tf
@@ -230,7 +230,7 @@ resource "github_repository_file" "tenant" {
     repo        = "ssh://git@github.com/${data.github_repository.tenant[each.key].full_name}.git",
     branch      = var.branch,
     name        = each.key,
-    cluster_id = var.cluster_id,
+    environment = var.environment,
   })
   overwrite_on_create = true
 }

--- a/modules/kubernetes/fluxcd-v2-github/templates/cluster-tenants.yaml
+++ b/modules/kubernetes/fluxcd-v2-github/templates/cluster-tenants.yaml
@@ -8,6 +8,6 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
-  path: ./tenants/${environment}
+  path: ./tenants/${cluster_id}
   prune: true
   validation: client

--- a/modules/kubernetes/fluxcd-v2-github/templates/tenant.yaml
+++ b/modules/kubernetes/fluxcd-v2-github/templates/tenant.yaml
@@ -45,7 +45,7 @@ metadata:
 spec:
   serviceAccountName: ${name}
   interval: 5m
-  path: ./tenant/${cluster_id}
+  path: ./tenant/${environment}
   sourceRef:
     kind: GitRepository
     name: ${name}

--- a/modules/kubernetes/fluxcd-v2-github/templates/tenant.yaml
+++ b/modules/kubernetes/fluxcd-v2-github/templates/tenant.yaml
@@ -45,7 +45,7 @@ metadata:
 spec:
   serviceAccountName: ${name}
   interval: 5m
-  path: ./tenant/${environment}
+  path: ./tenant/${cluster_id}
   sourceRef:
     kind: GitRepository
     name: ${name}

--- a/modules/kubernetes/fluxcd-v2-github/variables.tf
+++ b/modules/kubernetes/fluxcd-v2-github/variables.tf
@@ -3,6 +3,11 @@ variable "github_owner" {
   type        = string
 }
 
+variable "environment" {
+  description = "Environment name of the cluster"
+  type        = string
+}
+
 variable "cluster_id" {
   description = "Environment name of the cluster"
   type        = string

--- a/modules/kubernetes/fluxcd-v2-github/variables.tf
+++ b/modules/kubernetes/fluxcd-v2-github/variables.tf
@@ -3,7 +3,7 @@ variable "github_owner" {
   type        = string
 }
 
-variable "environment" {
+variable "cluster_id" {
   description = "Environment name of the cluster"
   type        = string
 }

--- a/validation/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/validation/kubernetes/fluxcd-v2-azdo/main.tf
@@ -7,5 +7,6 @@ module "fluxcd_v2_azdo" {
   azure_devops_org  = "foo"
   azure_devops_proj = "bar"
   environment       = "dev"
+  cluster_id        = "foobar"
   namespaces        = []
 }

--- a/validation/kubernetes/fluxcd-v2-github/main.tf
+++ b/validation/kubernetes/fluxcd-v2-github/main.tf
@@ -5,5 +5,6 @@ module "fluxcd_v2" {
 
   github_owner = "foo"
   environment  = "dev"
+  cluster_id   = "foobar"
   namespaces   = []
 }


### PR DESCRIPTION
This change fixes the owner id in eks-core for external-dns, and the cluster directories for fluxv2. The changes in fluxv2 is required so that two clusters do not attempt to write to the same directory.