### PR TITLE
Add agent.apm.hostPort to datadog configuration

### DIFF
--- a/modules/kubernetes/datadog/charts/datadog-extras/templates/datadogagent.yaml
+++ b/modules/kubernetes/datadog/charts/datadog-extras/templates/datadogagent.yaml
@@ -22,6 +22,7 @@ spec:
       logsConfigContainerCollectAll: true
     apm:
       enabled: true
+      hostPort: 8126
     env:
       - name: DD_CONTAINER_EXCLUDE_LOGS
         value: "name:datadog-agent"


### PR DESCRIPTION
Host port seems to be the main supported way to receive apm traces to the apm agent.

It seems to be the recommended configuration here: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=operator

And will be the default configuration from next release (v0.7.0): https://github.com/DataDog/datadog-operator/pull/338