### PR TITLE
Disable eBPF on AWS

### DIFF
--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -296,6 +296,8 @@ module "falco" {
   }
 
   source = "../../kubernetes/falco"
+
+  cloud_provider = "azure"
 }
 
 # Reloader

--- a/modules/kubernetes/eks-core/modules.tf
+++ b/modules/kubernetes/eks-core/modules.tf
@@ -211,6 +211,8 @@ module "falco" {
   }
 
   source = "../../kubernetes/falco"
+
+  cloud_provider = "aws"
 }
 
 module "reloader" {

--- a/modules/kubernetes/falco/README.md
+++ b/modules/kubernetes/falco/README.md
@@ -33,7 +33,9 @@ No modules.
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cloud_provider"></a> [cloud\_provider](#input\_cloud\_provider) | Cloud provider used for falco | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/kubernetes/falco/main.tf
+++ b/modules/kubernetes/falco/main.tf
@@ -37,8 +37,8 @@ resource "helm_release" "falco" {
   name       = "falco"
   namespace  = kubernetes_namespace.this.metadata[0].name
   version    = "1.15.7"
-  values     = [templatefile("${path.module}/templates/falco-values.yaml.tpl", {
-    provider               = var.cloud_provider
+  values = [templatefile("${path.module}/templates/falco-values.yaml.tpl", {
+    provider = var.cloud_provider
   })]
 }
 

--- a/modules/kubernetes/falco/main.tf
+++ b/modules/kubernetes/falco/main.tf
@@ -37,7 +37,9 @@ resource "helm_release" "falco" {
   name       = "falco"
   namespace  = kubernetes_namespace.this.metadata[0].name
   version    = "1.15.7"
-  values     = [templatefile("${path.module}/templates/falco-values.yaml.tpl", {})]
+  values     = [templatefile("${path.module}/templates/falco-values.yaml.tpl", {
+    provider               = var.cloud_provider
+  })]
 }
 
 resource "helm_release" "falco_exporter" {

--- a/modules/kubernetes/falco/templates/falco-values.yaml.tpl
+++ b/modules/kubernetes/falco/templates/falco-values.yaml.tpl
@@ -5,9 +5,11 @@ auditLog:
 docker:
   enabled: false
 
+%{~ if provider == "aws" ~}
 # Use EBPF instead of kernel module
 ebpf:
   enabled: true
+%{~ endif ~}
 
 falco:
   grpc:

--- a/modules/kubernetes/falco/templates/falco-values.yaml.tpl
+++ b/modules/kubernetes/falco/templates/falco-values.yaml.tpl
@@ -1,11 +1,11 @@
 auditLog:
   enabled: false
 
+%{~ if provider == "azure" ~}
 # AKS does not use docker anymore
 docker:
   enabled: false
 
-%{~ if provider == "azure" ~}
 # Use EBPF instead of kernel module
 ebpf:
   enabled: true

--- a/modules/kubernetes/falco/templates/falco-values.yaml.tpl
+++ b/modules/kubernetes/falco/templates/falco-values.yaml.tpl
@@ -5,7 +5,7 @@ auditLog:
 docker:
   enabled: false
 
-%{~ if provider == "aws" ~}
+%{~ if provider == "azure" ~}
 # Use EBPF instead of kernel module
 ebpf:
   enabled: true

--- a/modules/kubernetes/falco/variables.tf
+++ b/modules/kubernetes/falco/variables.tf
@@ -1,0 +1,4 @@
+variable "cloud_provider" {
+  description = "Cloud provider used for falco"
+  type        = string
+}

--- a/validation/kubernetes/falco/main.tf
+++ b/validation/kubernetes/falco/main.tf
@@ -11,4 +11,6 @@ module "falco" {
     kubernetes = kubernetes
     helm       = helm
   }
+
+  cloud_provider = "bar"
 }


### PR DESCRIPTION
Solves #378, sadly amazon linux kernel don't seem to be new enough to use eBPF but the pre-built kernel should work just fine.