### PR TITLE
Automatically close stale issues and PRs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,7 +7,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: '0 4 * * *'
+    - cron: '0 4 * * *'
 
 jobs:
   stale:
@@ -18,19 +18,19 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v3
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: >
-          This issue hasn't been updated for a while, marking as stale, 
-          please respond within the next 7 days to remove this label.
-        stale-pr-message: >
-          This PR hasn't been updated for a while, marking as stale.
-        stale-issue-label: stale
-        stale-pr-label: stale
-        days-before-stale: 90
-        days-before-close: 7
-        exempt-issue-labels: accepted
-        exempt-pr-labels: accepted
-        remove-issue-stale-when-updated: true
-        remove-pr-stale-when-updated: true
+      - uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: >
+            This issue hasn't been updated for a while, marking as stale,
+            please respond within the next 7 days to remove this label.
+          stale-pr-message: >
+            This PR hasn't been updated for a while, marking as stale.
+          stale-issue-label: stale
+          stale-pr-label: stale
+          days-before-stale: 90
+          days-before-close: 7
+          exempt-issue-labels: accepted
+          exempt-pr-labels: accepted
+          remove-issue-stale-when-updated: true
+          remove-pr-stale-when-updated: true


### PR DESCRIPTION
GitHub action to mark issues and PRs as stale after 90 days on inactivity unless they are labelled `accepted`.

Fixes #119.