### PR TITLE
Bump azad-kube-proxy to enable separate port for metrics and health checks

### DIFF
--- a/modules/kubernetes/azad-kube-proxy/main.tf
+++ b/modules/kubernetes/azad-kube-proxy/main.tf
@@ -136,6 +136,6 @@ resource "helm_release" "azad_kube_proxy" {
   chart      = "azad-kube-proxy"
   name       = "azad-kube-proxy"
   namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "v0.0.24"
+  version    = "v0.0.26"
   values     = [local.values]
 }

--- a/modules/kubernetes/azad-kube-proxy/templates/values.yaml.tpl
+++ b/modules/kubernetes/azad-kube-proxy/templates/values.yaml.tpl
@@ -20,8 +20,6 @@ podEnv:
         key: TENANT_ID
   - name: TLS_ENABLED
     value: "false"
-  - name: PORT
-    value: "8080"
   - name: GROUP_IDENTIFIER
     value: "OBJECTID"
   - name: AZURE_AD_GROUP_PREFIX

--- a/modules/kubernetes/azad-kube-proxy/templates/values.yaml.tpl
+++ b/modules/kubernetes/azad-kube-proxy/templates/values.yaml.tpl
@@ -1,5 +1,6 @@
 application:
   port: 8080
+  metricsPort: 8081
   scheme: HTTP
 
 podEnv:


### PR DESCRIPTION
This PR bumps the version of azad-kube-proxy from `v0.0.24` to `v0.0.26` where the metrics and health checks are now running on a separate port (https://github.com/XenitAB/azad-kube-proxy/pull/298).

It also removes a duplicate environment variable of PORT which is already set by `application.port`.