### PR TITLE
Remove eks specific kubelet configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#415](https://github.com/XenitAB/terraform-modules/pull/415) Migrate from azdo-proxy to git-auth-proxy and update GitHub FluxV2 module to work with git-auth-proxy.
 - [#418](https://github.com/XenitAB/terraform-modules/pull/418) [Breaking] Update the Flux provider version to 0.4.0. Check the [provider release](https://github.com/fluxcd/terraform-provider-flux/blob/main/CHANGELOG.md#040) for migration instructions.
+
+### Fixed
+
 - [#423](https://github.com/XenitAB/terraform-modules/pull/423) Fix enabling monitors from aks-core and eks-core.
+- [#425](https://github.com/XenitAB/terraform-modules/pull/425) Switch to using https endpoint when scraping kubelet metrics in EKS.
+

--- a/modules/kubernetes/prometheus/main.tf
+++ b/modules/kubernetes/prometheus/main.tf
@@ -40,9 +40,7 @@ resource "helm_release" "prometheus" {
   name       = "prometheus"
   namespace  = kubernetes_namespace.this.metadata[0].name
   version    = "17.2.2"
-  values = [templatefile("${path.module}/templates/values.yaml.tpl", {
-    cloud_provider = var.cloud_provider
-  })]
+  values     = [templatefile("${path.module}/templates/values.yaml.tpl", {})]
 }
 
 resource "helm_release" "metrics_server" {

--- a/modules/kubernetes/prometheus/templates/values.yaml.tpl
+++ b/modules/kubernetes/prometheus/templates/values.yaml.tpl
@@ -48,9 +48,3 @@ prometheusOperator:
 
 prometheus-node-exporter:
   priorityClassName: "platform-high"
-
-%{ if cloud_provider == "aws" }
-kubelet:
-  serviceMonitor:
-    https: false
-%{ endif }


### PR DESCRIPTION
This change fixes so the kubelet service monitor in EKS uses the https port like AKS.