### PR TITLE
Add destroy prevention for critical flux components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#432](https://github.com/XenitAB/terraform-modules/pull/432) Add deletion protection to Flux components to prevent unwanted removal of critical components.
+
+
+
 ## 2021.10.3
 
 ### Fixed
 
 - [#431](https://github.com/XenitAB/terraform-modules/pull/431) Downgrade external-dns helm chart to 5.4.8 and external-dns to 0.9.0
+
+
 
 ## 2021.10.2
 

--- a/modules/kubernetes/fluxcd-v2-github/main.tf
+++ b/modules/kubernetes/fluxcd-v2-github/main.tf
@@ -47,18 +47,19 @@ locals {
 }
 
 resource "kubernetes_namespace" "this" {
+  lifecycle {
+    prevent_destroy = true
+    ignore_changes = [
+      metadata[0].labels,
+      metadata[0].annotations,
+    ]
+  }
+
   metadata {
     name = "flux-system"
     labels = {
       name = "flux-system"
     }
-  }
-
-  lifecycle {
-    ignore_changes = [
-      metadata[0].labels,
-      metadata[0].annotations,
-    ]
   }
 }
 
@@ -122,14 +123,22 @@ locals {
 
 resource "kubectl_manifest" "install" {
   depends_on = [kubernetes_namespace.this]
-  for_each   = { for v in local.install : lower(join("/", compact([v.data.apiVersion, v.data.kind, lookup(v.data.metadata, "namespace", ""), v.data.metadata.name]))) => v.content }
-  yaml_body  = each.value
+  lifecycle {
+    prevent_destroy = true
+  }
+  for_each = { for v in local.install : lower(join("/", compact([v.data.apiVersion, v.data.kind, lookup(v.data.metadata, "namespace", ""), v.data.metadata.name]))) => v.content }
+
+  yaml_body = each.value
 }
 
 resource "kubectl_manifest" "sync" {
   depends_on = [kubernetes_namespace.this]
-  for_each   = { for v in local.sync : lower(join("/", compact([v.data.apiVersion, v.data.kind, lookup(v.data.metadata, "namespace", ""), v.data.metadata.name]))) => v.content }
-  yaml_body  = each.value
+  lifecycle {
+    prevent_destroy = true
+  }
+  for_each = { for v in local.sync : lower(join("/", compact([v.data.apiVersion, v.data.kind, lookup(v.data.metadata, "namespace", ""), v.data.metadata.name]))) => v.content }
+
+  yaml_body = each.value
 }
 
 resource "github_repository_file" "install" {


### PR DESCRIPTION
This change protects future issues related to unwanted deletion of critical flux components. Especially deleting CRDs or the flux-system GitRepository and Kustomization should be unwanted.