### PR TITLE
Add podmonitor for secrets-store-csi-driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+
+### Added
+
+- [#437](https://github.com/XenitAB/terraform-modules/pull/437) Add podmonitor for secrets-store-csi-driver
+
 ## 2021.11.6
 
 ### Added

--- a/modules/kubernetes/csi-secrets-store-provider-aws/charts/csi-secrets-store-provider-aws/Chart.yaml
+++ b/modules/kubernetes/csi-secrets-store-provider-aws/charts/csi-secrets-store-provider-aws/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/csi-secrets-store-provider-aws/charts/csi-secrets-store-provider-aws/Chart.yaml
+++ b/modules/kubernetes/csi-secrets-store-provider-aws/charts/csi-secrets-store-provider-aws/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.12
+version: 0.1.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/templates/monitor.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/templates/monitor.yaml
@@ -312,3 +312,37 @@ spec:
     - path: /metrics
       port: metrics
 {{- end }}
+{{- if .Values.enabledMonitors.csiSecretsStorProviderAzure }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: csi-secrets-store-driver-azure
+  namespace: csi-secrets-store-provider-azure
+  labels:
+    xkf.xenit.io/monitoring: platform
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: csi-secrets-store-provider-azure
+      app.kubernetes.io/name: csi-secrets-store-provider-azure
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics
+{{- end }}
+{{- if .Values.enabledMonitors.csiSecretsStorProviderAws }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: csi-secrets-store-driver-aws
+  namespace: csi-secrets-store-provider-aws
+  labels:
+    xkf.xenit.io/monitoring: platform
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: csi-secrets-store-provider-aws
+      app.kubernetes.io/name: csi-secrets-store-provider-aws
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics
+{{- end }}


### PR DESCRIPTION
Closes #356

Enables podmonitor for Prometheus to monitor "secrets-store-csi-driver" for both Azure and AWS.