### PR TITLE
Allow scale down for nodes with local storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#432](https://github.com/XenitAB/terraform-modules/pull/432) Add deletion protection to Flux components to prevent unwanted removal of critical components.
 - [#439](https://github.com/XenitAB/terraform-modules/pull/439) Add information about Azure AD Graph deprecation.
+- [#440](https://github.com/XenitAB/terraform-modules/pull/440) Allow scale down for nodes with local storage.
 
 ## 2021.10.3
 

--- a/modules/azure/aks/aks.tf
+++ b/modules/azure/aks/aks.tf
@@ -9,15 +9,8 @@ resource "azurerm_kubernetes_cluster" "this" {
   api_server_authorized_ip_ranges = var.aks_authorized_ips
 
   auto_scaler_profile {
-    balance_similar_node_groups      = false
-    max_graceful_termination_sec     = 600
-    scale_down_delay_after_add       = "10m"
-    scale_down_delay_after_delete    = "10s"
-    scale_down_delay_after_failure   = "3m"
-    scan_interval                    = "10s"
-    scale_down_unneeded              = "10m"
-    scale_down_unready               = "20m"
-    scale_down_utilization_threshold = "0.5"
+    # Pods should not depend on local storage like EmptyDir or HostPath
+    skip_nodes_with_local_storage = false
   }
 
   default_node_pool {
@@ -61,11 +54,6 @@ resource "azurerm_kubernetes_cluster" "this" {
     ssh_key {
       key_data = var.ssh_public_key
     }
-  }
-
-  auto_scaler_profile {
-    # Pods should not depend on local storage like EmptyDir or HostPath
-    skip_nodes_with_local_storage = false
   }
 
   lifecycle {

--- a/modules/azure/aks/aks.tf
+++ b/modules/azure/aks/aks.tf
@@ -63,6 +63,11 @@ resource "azurerm_kubernetes_cluster" "this" {
     }
   }
 
+  auto_scaler_profile {
+    # Pods should not depend on local storage like EmptyDir or HostPath
+    skip_nodes_with_local_storage = false
+  }
+
   lifecycle {
     ignore_changes = [
       default_node_pool[0].node_count

--- a/modules/kubernetes/cluster-autoscaler/templates/values.yaml.tpl
+++ b/modules/kubernetes/cluster-autoscaler/templates/values.yaml.tpl
@@ -30,3 +30,6 @@ rbac:
     annotations:
       eks.amazonaws.com/role-arn: ${aws_config.role_arn}
 %{ endif }
+
+extraArgs:
+  skip-nodes-with-local-storage: false


### PR DESCRIPTION
This fix allows the autoscaler in EKS and AKS to scale down nodes with local storage. Without this the autoscaler will rarely scale down nodes. Users should not expect local storage to always be available so this should not cause any issues.