### PR TITLE
ingress-nginx fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#432](https://github.com/XenitAB/terraform-modules/pull/432) Add deletion protection to Flux components to prevent unwanted removal of critical components.
 - [#439](https://github.com/XenitAB/terraform-modules/pull/439) Add information about Azure AD Graph deprecation.
 - [#440](https://github.com/XenitAB/terraform-modules/pull/440) Allow scale down for nodes with local storage.
+- [#442](https://github.com/XenitAB/terraform-modules/pull/440) ingress-nginx fixes: adds datadog tracing and x-forwarded-for to services.
 
 ## 2021.10.3
 

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -60,7 +60,7 @@ controller:
     %{~ if datadog_enabled ~}
     ad.datadoghq.com/controller.check_names: '["nginx_ingress_controller"]'
     ad.datadoghq.com/controller.init_configs: '[{}]'
-    ad.datadoghq.com/controller.instances: '[{"prometheus_url": "http://%%host%%:10254/metrics"}]'
+    ad.datadoghq.com/controller.instances: '[{"prometheus_url": "http://%%host%%:%%port_metrics%%/metrics"}]'
     %{~ endif ~}
     %{~ if linkerd_enabled ~}
     linkerd.io/inject: "ingress"

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -35,6 +35,7 @@ controller:
     ${key}: "${value}"
     %{~ endfor ~}
     server-tokens: "false"
+    use-forwarded-headers: "true"
     %{~ if http_snippet != "" ~}
     http-snippet: |
       ${http_snippet}

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -36,6 +36,10 @@ controller:
     %{~ endfor ~}
     server-tokens: "false"
     use-forwarded-headers: "true"
+    %{~ if datadog_enabled ~}
+    datadog-collector-host: "$HOST_IP"
+    enable-opentracing: "true"
+    %{~ endif ~}
     %{~ if http_snippet != "" ~}
     http-snippet: |
       ${http_snippet}
@@ -64,6 +68,15 @@ controller:
     # https://github.com/linkerd/linkerd2/issues/3334#issuecomment-565135188
     config.linkerd.io/skip-inbound-ports: "80,443"
     %{~ endif ~}
+  %{~ endif ~}
+
+  %{~ if datadog_enabled ~}
+  extraEnvs:
+  - name: HOST_IP
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: status.hostIP
   %{~ endif ~}
 
   metrics:


### PR DESCRIPTION
This PR enables tracing for datadog as well as adds `x-forwarded-for` header to services.