### PR TITLE
Enable default resources in EKS core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+
+- [#445](https://github.com/XenitAB/terraform-modules/pull/445) Re-enable resource limit ranges in EKS.
+
 ## 2021.11.1
 
 ### Changed

--- a/modules/kubernetes/eks-core/README.md
+++ b/modules/kubernetes/eks-core/README.md
@@ -59,6 +59,7 @@ This module is used to configure EKS clusters.
 | [kubernetes_cluster_role_binding.cluster_view](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/cluster_role_binding) | resource |
 | [kubernetes_cluster_role_binding.edit_list_ns](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/cluster_role_binding) | resource |
 | [kubernetes_cluster_role_binding.view_list_ns](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/cluster_role_binding) | resource |
+| [kubernetes_limit_range.tenant](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/limit_range) | resource |
 | [kubernetes_namespace.service_accounts](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/namespace) | resource |
 | [kubernetes_namespace.tenant](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/namespace) | resource |
 | [kubernetes_network_policy.tenant](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/network_policy) | resource |
@@ -97,6 +98,7 @@ This module is used to configure EKS clusters.
 | <a name="input_ingress_config"></a> [ingress\_config](#input\_ingress\_config) | Ingress configuration | <pre>object({<br>    http_snippet           = string<br>    public_private_enabled = bool<br>  })</pre> | <pre>{<br>  "http_snippet": "",<br>  "public_private_enabled": false<br>}</pre> | no |
 | <a name="input_ingress_healthz_enabled"></a> [ingress\_healthz\_enabled](#input\_ingress\_healthz\_enabled) | Should ingress-healthz be enabled | `bool` | `true` | no |
 | <a name="input_ingress_nginx_enabled"></a> [ingress\_nginx\_enabled](#input\_ingress\_nginx\_enabled) | Should Ingress NGINX be enabled | `bool` | `true` | no |
+| <a name="input_kubernetes_default_limit_range"></a> [kubernetes\_default\_limit\_range](#input\_kubernetes\_default\_limit\_range) | Default limit range for tenant namespaces | <pre>object({<br>    default_request = object({<br>      cpu    = string<br>      memory = string<br>    })<br>    default = object({<br>      memory = string<br>    })<br>  })</pre> | <pre>{<br>  "default": {<br>    "memory": "256Mi"<br>  },<br>  "default_request": {<br>    "cpu": "50m",<br>    "memory": "32Mi"<br>  }<br>}</pre> | no |
 | <a name="input_kubernetes_network_policy_default_deny"></a> [kubernetes\_network\_policy\_default\_deny](#input\_kubernetes\_network\_policy\_default\_deny) | If network policies should by default deny cross namespace traffic | `bool` | `false` | no |
 | <a name="input_linkerd_enabled"></a> [linkerd\_enabled](#input\_linkerd\_enabled) | Should linkerd be enabled | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name to use for the deploy | `string` | n/a | yes |

--- a/modules/kubernetes/eks-core/namespace.tf
+++ b/modules/kubernetes/eks-core/namespace.tf
@@ -34,27 +34,27 @@ resource "kubernetes_service_account" "tenant" {
   }
 }
 
-#resource "kubernetes_limit_range" "tenant" {
-#  for_each = { for ns in var.namespaces : ns.name => ns }
-#
-#  metadata {
-#    name      = "default"
-#    namespace = each.key
-#  }
-#
-#  spec {
-#    limit {
-#      type = "Container"
-#      default_request = {
-#        cpu    = var.kubernetes_default_limit_range.default_request.cpu
-#        memory = var.kubernetes_default_limit_range.default_request.memory
-#      }
-#      default = {
-#        memory = var.kubernetes_default_limit_range.default.memory
-#      }
-#    }
-#  }
-#}
+resource "kubernetes_limit_range" "tenant" {
+  for_each = { for ns in var.namespaces : ns.name => ns }
+
+  metadata {
+    name      = "default"
+    namespace = each.key
+  }
+
+  spec {
+    limit {
+      type = "Container"
+      default_request = {
+        cpu    = var.kubernetes_default_limit_range.default_request.cpu
+        memory = var.kubernetes_default_limit_range.default_request.memory
+      }
+      default = {
+        memory = var.kubernetes_default_limit_range.default.memory
+      }
+    }
+  }
+}
 
 # Denys all traffic but except to coredns and inside of namespace.
 resource "kubernetes_network_policy" "tenant" {

--- a/modules/kubernetes/eks-core/variables.tf
+++ b/modules/kubernetes/eks-core/variables.tf
@@ -57,27 +57,27 @@ variable "kubernetes_network_policy_default_deny" {
   default     = false
 }
 
-#variable "kubernetes_default_limit_range" {
-#  description = "Default limit range for tenant namespaces"
-#  type = object({
-#    default_request = object({
-#      cpu    = string
-#      memory = string
-#    })
-#    default = object({
-#      memory = string
-#    })
-#  })
-#  default = {
-#    default_request = {
-#      cpu    = "50m"
-#      memory = "32Mi"
-#    }
-#    default = {
-#      memory = "256Mi"
-#    }
-#  }
-#}
+variable "kubernetes_default_limit_range" {
+  description = "Default limit range for tenant namespaces"
+  type = object({
+    default_request = object({
+      cpu    = string
+      memory = string
+    })
+    default = object({
+      memory = string
+    })
+  })
+  default = {
+    default_request = {
+      cpu    = "50m"
+      memory = "32Mi"
+    }
+    default = {
+      memory = "256Mi"
+    }
+  }
+}
 
 variable "fluxcd_v2_enabled" {
   description = "Should fluxcd-v2 be enabled"


### PR DESCRIPTION
This just enables resource limit ranges for EKS deployments. Not really sure why it was disabled but that does not really matter now anyways. 