### PR TITLE
Set revision history to all created cert manager certifiates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+
+- [#451](https://github.com/XenitAB/terraform-modules/pull/451) Set revision history for all certificates to limit the amount of certificate requests.
+
 ## 2021.11.2
 
 ### Changed

--- a/modules/kubernetes/ingress-nginx/charts/ingress-nginx-extras/Chart.yaml
+++ b/modules/kubernetes/ingress-nginx/charts/ingress-nginx-extras/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ingress-nginx-extras
 description: Creates extra resources for ingress-nginx
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.16.0"

--- a/modules/kubernetes/ingress-nginx/charts/ingress-nginx-extras/templates/certificate.yaml
+++ b/modules/kubernetes/ingress-nginx/charts/ingress-nginx-extras/templates/certificate.yaml
@@ -4,10 +4,11 @@ kind: Certificate
 metadata:
   name: ingress-nginx
 spec:
+  secretName: ingress-nginx
+  revisionHistoryLimit: 3
   dnsNames:
     - '*.{{ .Values.defaultCertificate.dnsZone }}'
   issuerRef:
     kind: ClusterIssuer
     name: letsencrypt
-  secretName: ingress-nginx
 {{- end }}

--- a/modules/kubernetes/linkerd/charts/linkerd-extras/Chart.yaml
+++ b/modules/kubernetes/linkerd/charts/linkerd-extras/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: linkerd-extras
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.1.0

--- a/modules/kubernetes/linkerd/charts/linkerd-extras/templates/linkerd-identity-issuer.yaml
+++ b/modules/kubernetes/linkerd/charts/linkerd-extras/templates/linkerd-identity-issuer.yaml
@@ -4,6 +4,7 @@ metadata:
   name: linkerd-identity-issuer
 spec:
   secretName: linkerd-identity-issuer
+  revisionHistoryLimit: 3
   duration: 8h
   renewBefore: 4h
   issuerRef:

--- a/modules/kubernetes/linkerd/charts/linkerd-extras/templates/linkerd-proxy-injector.yaml
+++ b/modules/kubernetes/linkerd/charts/linkerd-extras/templates/linkerd-proxy-injector.yaml
@@ -4,6 +4,7 @@ metadata:
   name: linkerd-proxy-injector
 spec:
   secretName: linkerd-proxy-injector-k8s-tls
+  revisionHistoryLimit: 3
   duration: 8h
   renewBefore: 4h
   issuerRef:

--- a/modules/kubernetes/linkerd/charts/linkerd-extras/templates/linkerd-sp-validator.yaml
+++ b/modules/kubernetes/linkerd/charts/linkerd-extras/templates/linkerd-sp-validator.yaml
@@ -4,6 +4,7 @@ metadata:
   name: linkerd-sp-validator
 spec:
   secretName: linkerd-sp-validator-k8s-tls
+  revisionHistoryLimit: 3
   duration: 8h
   renewBefore: 4h
   issuerRef:


### PR DESCRIPTION
This change sets a value for a Certificate revision history. This value controls how CertificateRequests are kept. The default value is nil, meaning CertificateRequests will never be cleaned up. Letsencrypt certificates dont really have this problem as they are only renewed every 3 months. However linkerd certificates will produce a lot of CertificateRequests as thos Certificates are renewed multiple times a day.

A logical reasoning would be that a reasonable default value would be set by the controller, but it seems like this will never happen.

Reference to the cert manager docs.
https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.Certificate