### PR TITLE
Prometheus set queue config in remote write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#454](https://github.com/XenitAB/terraform-modules/pull/454) Set prometheus remote write queue config,
+  lowering default max shards and increasing default min back off.
+
 ### Fixed
 
 - [#451](https://github.com/XenitAB/terraform-modules/pull/451) Set revision history for all certificates to limit the amount of certificate requests.

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/templates/prometheus.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/templates/prometheus.yaml
@@ -47,6 +47,9 @@ spec:
       headers:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      queueConfig:
+        maxShards: 1500
+        minBackoff: 100ms
   {{- end }}
   {{- if .Values.volumeClaim.enabled }}
   storage:


### PR DESCRIPTION
This to be nicer to thanos receiver when sending data to it.
We can wait a few extra miliseconds for this data to come to the receiver, as long as it comes.