### PR TITLE
Remove goldpinger from aks and eks core and deprecated goldping module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#461](https://github.com/XenitAB/terraform-modules/pull/461) Set resource request for Prometheus and update remote write config.
 - [#460](https://github.com/XenitAB/terraform-modules/pull/460) Increase gatekeeper-audit memory request.
 
+### Deprecated
+
+- [#456](https://github.com/XenitAB/terraform-modules/pull/456) Deprecate goldpinger and remove it from aks-core and eks-core.
+
 ## 2021.11.4
 
 ### Fixed

--- a/modules/kubernetes/README.md
+++ b/modules/kubernetes/README.md
@@ -26,7 +26,6 @@ This directory contains all the Kubernetes Terraform modules.
 - [`ingress-healthz`](ingress-healthz/README.md)
 - [`xenit`](xenit/README.md)
 - [`linkerd`](linkerd/README.md)
-- [`goldpinger`](goldpinger/README.md)
 - [`cluster-autoscaler`](cluster-autoscaler/README.md)
 - [`starboard`](starboard/README.md)
 - [`new-relic`](new-relic/README.md)
@@ -35,6 +34,7 @@ This directory contains all the Kubernetes Terraform modules.
 
 - [`external-secrets`](external-secrets/README.md)
 - [`kyverno`](kyverno/README.md)
+- [`goldpinger`](goldpinger/README.md)
 
 ## Style Guide
 

--- a/modules/kubernetes/aks-core/README.md
+++ b/modules/kubernetes/aks-core/README.md
@@ -38,7 +38,6 @@ This module is used to create AKS clusters.
 | <a name="module_fluxcd_v1_azure_devops"></a> [fluxcd\_v1\_azure\_devops](#module\_fluxcd\_v1\_azure\_devops) | ../../kubernetes/fluxcd-v1 | n/a |
 | <a name="module_fluxcd_v2_azure_devops"></a> [fluxcd\_v2\_azure\_devops](#module\_fluxcd\_v2\_azure\_devops) | ../../kubernetes/fluxcd-v2-azdo | n/a |
 | <a name="module_fluxcd_v2_github"></a> [fluxcd\_v2\_github](#module\_fluxcd\_v2\_github) | ../../kubernetes/fluxcd-v2-github | n/a |
-| <a name="module_goldpinger"></a> [goldpinger](#module\_goldpinger) | ../../kubernetes/goldpinger | n/a |
 | <a name="module_ingress_healthz"></a> [ingress\_healthz](#module\_ingress\_healthz) | ../../kubernetes/ingress-healthz | n/a |
 | <a name="module_ingress_nginx"></a> [ingress\_nginx](#module\_ingress\_nginx) | ../../kubernetes/ingress-nginx | n/a |
 | <a name="module_linkerd"></a> [linkerd](#module\_linkerd) | ../../kubernetes/linkerd | n/a |
@@ -101,7 +100,6 @@ This module is used to create AKS clusters.
 | <a name="input_fluxcd_v1_enabled"></a> [fluxcd\_v1\_enabled](#input\_fluxcd\_v1\_enabled) | Should fluxcd-v1 be enabled | `bool` | `false` | no |
 | <a name="input_fluxcd_v2_config"></a> [fluxcd\_v2\_config](#input\_fluxcd\_v2\_config) | Configuration for fluxcd-v2 | <pre>object({<br>    type = string<br>    github = object({<br>      org             = string<br>      app_id          = number<br>      installation_id = number<br>      private_key     = string<br>    })<br>    azure_devops = object({<br>      pat  = string<br>      org  = string<br>      proj = string<br>    })<br>  })</pre> | n/a | yes |
 | <a name="input_fluxcd_v2_enabled"></a> [fluxcd\_v2\_enabled](#input\_fluxcd\_v2\_enabled) | Should fluxcd-v2 be enabled | `bool` | `true` | no |
-| <a name="input_goldpinger_enabled"></a> [goldpinger\_enabled](#input\_goldpinger\_enabled) | Should goldpinger be enabled | `bool` | `true` | no |
 | <a name="input_ingress_config"></a> [ingress\_config](#input\_ingress\_config) | Ingress configuration | <pre>object({<br>    http_snippet           = string<br>    public_private_enabled = bool<br>  })</pre> | <pre>{<br>  "http_snippet": "",<br>  "public_private_enabled": false<br>}</pre> | no |
 | <a name="input_ingress_healthz_enabled"></a> [ingress\_healthz\_enabled](#input\_ingress\_healthz\_enabled) | Should ingress-healthz be enabled | `bool` | `true` | no |
 | <a name="input_ingress_nginx_enabled"></a> [ingress\_nginx\_enabled](#input\_ingress\_nginx\_enabled) | Should Ingress NGINX be enabled | `bool` | `true` | no |

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -30,7 +30,6 @@ locals {
     "falco",
     "flux-system",
     "gatekeeper-system",
-    "goldpinger",
     "ingress-healthz",
     "ingress-nginx",
     "kube-node-lease",
@@ -418,7 +417,6 @@ module "prometheus" {
   falco_enabled                            = var.falco_enabled
   opa_gatekeeper_enabled                   = var.opa_gatekeeper_enabled
   linkerd_enabled                          = var.linkerd_enabled
-  goldpinger_enabled                       = var.goldpinger_enabled
   flux_enabled                             = var.fluxcd_v2_enabled
   csi_secrets_store_provider_azure_enabled = var.csi_secrets_store_provider_azure_enabled
   aad_pod_identity_enabled                 = var.aad_pod_identity_enabled
@@ -447,20 +445,6 @@ module "xenit" {
   }
   thanos_receiver_fqdn = var.xenit_config.thanos_receiver
   loki_api_fqdn        = var.xenit_config.loki_api
-}
-
-module "goldpinger" {
-  depends_on = [module.opa_gatekeeper, module.linkerd]
-
-  for_each = {
-    for s in ["goldpinger"] :
-    s => s
-    if var.goldpinger_enabled
-  }
-
-  source = "../../kubernetes/goldpinger"
-
-  linkerd_enabled = var.linkerd_enabled
 }
 
 # starboard

--- a/modules/kubernetes/aks-core/variables.tf
+++ b/modules/kubernetes/aks-core/variables.tf
@@ -395,12 +395,6 @@ variable "linkerd_enabled" {
   default     = false
 }
 
-variable "goldpinger_enabled" {
-  description = "Should goldpinger be enabled"
-  type        = bool
-  default     = true
-}
-
 variable "starboard_enabled" {
   description = "Should Starboard be enabled"
   type        = bool

--- a/modules/kubernetes/eks-core/README.md
+++ b/modules/kubernetes/eks-core/README.md
@@ -36,7 +36,6 @@ This module is used to configure EKS clusters.
 | <a name="module_falco"></a> [falco](#module\_falco) | ../../kubernetes/falco | n/a |
 | <a name="module_fluxcd_v2_azure_devops"></a> [fluxcd\_v2\_azure\_devops](#module\_fluxcd\_v2\_azure\_devops) | ../../kubernetes/fluxcd-v2-azdo | n/a |
 | <a name="module_fluxcd_v2_github"></a> [fluxcd\_v2\_github](#module\_fluxcd\_v2\_github) | ../../kubernetes/fluxcd-v2-github | n/a |
-| <a name="module_goldpinger"></a> [goldpinger](#module\_goldpinger) | ../../kubernetes/goldpinger | n/a |
 | <a name="module_ingress_healthz"></a> [ingress\_healthz](#module\_ingress\_healthz) | ../../kubernetes/ingress-healthz | n/a |
 | <a name="module_ingress_nginx"></a> [ingress\_nginx](#module\_ingress\_nginx) | ../../kubernetes/ingress-nginx | n/a |
 | <a name="module_linkerd"></a> [linkerd](#module\_linkerd) | ../../kubernetes/linkerd | n/a |
@@ -96,7 +95,6 @@ This module is used to configure EKS clusters.
 | <a name="input_falco_enabled"></a> [falco\_enabled](#input\_falco\_enabled) | Should Falco be enabled | `bool` | `false` | no |
 | <a name="input_fluxcd_v2_config"></a> [fluxcd\_v2\_config](#input\_fluxcd\_v2\_config) | Configuration for fluxcd-v2 | <pre>object({<br>    type = string<br>    github = object({<br>      org             = string<br>      app_id          = number<br>      installation_id = number<br>      private_key     = string<br>    })<br>    azure_devops = object({<br>      pat  = string<br>      org  = string<br>      proj = string<br>    })<br>  })</pre> | n/a | yes |
 | <a name="input_fluxcd_v2_enabled"></a> [fluxcd\_v2\_enabled](#input\_fluxcd\_v2\_enabled) | Should fluxcd-v2 be enabled | `bool` | `true` | no |
-| <a name="input_goldpinger_enabled"></a> [goldpinger\_enabled](#input\_goldpinger\_enabled) | Should goldpinger be enabled | `bool` | `true` | no |
 | <a name="input_ingress_config"></a> [ingress\_config](#input\_ingress\_config) | Ingress configuration | <pre>object({<br>    http_snippet           = string<br>    public_private_enabled = bool<br>  })</pre> | <pre>{<br>  "http_snippet": "",<br>  "public_private_enabled": false<br>}</pre> | no |
 | <a name="input_ingress_healthz_enabled"></a> [ingress\_healthz\_enabled](#input\_ingress\_healthz\_enabled) | Should ingress-healthz be enabled | `bool` | `true` | no |
 | <a name="input_ingress_nginx_enabled"></a> [ingress\_nginx\_enabled](#input\_ingress\_nginx\_enabled) | Should Ingress NGINX be enabled | `bool` | `true` | no |

--- a/modules/kubernetes/eks-core/modules.tf
+++ b/modules/kubernetes/eks-core/modules.tf
@@ -23,7 +23,6 @@ locals {
     "external-dns",
     "falco,flux-system",
     "gatekeeper-system",
-    "goldpinger",
     "ingress-healthz",
     "ingress-nginx",
     "kube-node-lease",
@@ -309,7 +308,6 @@ module "prometheus" {
   falco_enabled                          = var.falco_enabled
   opa_gatekeeper_enabled                 = var.opa_gatekeeper_enabled
   linkerd_enabled                        = var.linkerd_enabled
-  goldpinger_enabled                     = var.goldpinger_enabled
   flux_enabled                           = var.fluxcd_v2_enabled
   csi_secrets_store_provider_aws_enabled = var.csi_secrets_store_provider_aws_enabled
   azad_kube_proxy_enabled                = var.azad_kube_proxy_enabled
@@ -382,20 +380,6 @@ module "xenit" {
   }
   thanos_receiver_fqdn = var.xenit_config.thanos_receiver
   loki_api_fqdn        = var.xenit_config.loki_api
-}
-
-module "goldpinger" {
-  depends_on = [module.opa_gatekeeper, module.linkerd]
-
-  for_each = {
-    for s in ["goldpinger"] :
-    s => s
-    if var.goldpinger_enabled
-  }
-
-  source = "../../kubernetes/goldpinger"
-
-  linkerd_enabled = var.linkerd_enabled
 }
 
 module "new_relic" {

--- a/modules/kubernetes/eks-core/variables.tf
+++ b/modules/kubernetes/eks-core/variables.tf
@@ -315,12 +315,6 @@ variable "linkerd_enabled" {
   default     = false
 }
 
-variable "goldpinger_enabled" {
-  description = "Should goldpinger be enabled"
-  type        = bool
-  default     = true
-}
-
 variable "csi_secrets_store_provider_aws_enabled" {
   description = "Should csi-secrets-store-provider-aws be enabled"
   type        = bool

--- a/modules/kubernetes/falco/templates/falco-values.yaml.tpl
+++ b/modules/kubernetes/falco/templates/falco-values.yaml.tpl
@@ -45,7 +45,6 @@ customRules:
         (container.image.repository = "docker.io/bitnami/external-dns") or
         (container.image.repository = "squat/configmap-to-disk") or
         (container.image.repository = "stakater/reloader") or
-        (container.image.repository = "bloomberg/goldpinger") or
         (container.image.repository = "gcr.io/datadoghq/agent")
 
   # Applications which spawn a docker or kubectl client

--- a/modules/kubernetes/goldpinger/README.md
+++ b/modules/kubernetes/goldpinger/README.md
@@ -1,4 +1,4 @@
-# Goldpinger
+# Goldpinger [Deprecated]
 
 Adds [`Goldpinger`](https://github.com/bloomberg/goldpinger) to a Kubernetes clusters.
 

--- a/modules/kubernetes/goldpinger/main.tf
+++ b/modules/kubernetes/goldpinger/main.tf
@@ -1,5 +1,5 @@
 /**
-  * # Goldpinger
+  * # Goldpinger [Deprecated]
   *
   * Adds [`Goldpinger`](https://github.com/bloomberg/goldpinger) to a Kubernetes clusters.
   */
@@ -31,6 +31,7 @@ resource "kubernetes_namespace" "this" {
 
 # Official Helm repo is deprecated to using fork.
 # https://github.com/bloomberg/goldpinger/issues/93
+#tf-latest-version:ignore
 resource "helm_release" "goldpinger" {
   repository = "https://okgolove.github.io/helm-charts/"
   chart      = "goldpinger"

--- a/modules/kubernetes/prometheus/README.md
+++ b/modules/kubernetes/prometheus/README.md
@@ -45,7 +45,6 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment in which the prometheus instance is deployed | `string` | n/a | yes |
 | <a name="input_falco_enabled"></a> [falco\_enabled](#input\_falco\_enabled) | Should Falco be enabled | `bool` | `false` | no |
 | <a name="input_flux_enabled"></a> [flux\_enabled](#input\_flux\_enabled) | Should flux-system be enabled | `bool` | `false` | no |
-| <a name="input_goldpinger_enabled"></a> [goldpinger\_enabled](#input\_goldpinger\_enabled) | Should goldpinger be enabled | `bool` | `false` | no |
 | <a name="input_kube_state_metrics_namepsaces"></a> [kube\_state\_metrics\_namepsaces](#input\_kube\_state\_metrics\_namepsaces) | Comma-separated list of namespaces to be enabled. To get metrics from all namespaces use '' | `string` | n/a | yes |
 | <a name="input_linkerd_enabled"></a> [linkerd\_enabled](#input\_linkerd\_enabled) | Should linkerd be enabled | `bool` | `false` | no |
 | <a name="input_namespace_selector"></a> [namespace\_selector](#input\_namespace\_selector) | Kind labels to look for in namespaces | `list(string)` | <pre>[<br>  "platform"<br>]</pre> | no |

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/templates/monitor.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/templates/monitor.yaml
@@ -294,27 +294,6 @@ spec:
     matchLabels:
       component: prometheus
 {{- end }}
-{{- if .Values.enabledMonitors.goldpinger }}
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: goldpinger
-  namespace: goldpinger
-  labels:
-    xkf.xenit.io/monitoring: platform
-spec:
-  endpoints:
-  - interval: 30s
-    port: http
-  namespaceSelector:
-    matchNames:
-    - goldpinger
-  selector:
-    matchLabels:
-      app.kubernetes.io/instance: goldpinger
-      app.kubernetes.io/name: goldpinger
-{{- end }}
 {{- if .Values.enabledMonitors.azadKubeProxy }}
 ---
 apiVersion: monitoring.coreos.com/v1

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/values.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/values.yaml
@@ -59,7 +59,6 @@ enabledMonitors:
   falco: false
   opaGatekeeper: false
   linkerd: false
-  goldpinger: false
   flux: false
   aadPodIdentity: false
   csiSecretsStorProviderAzure: false

--- a/modules/kubernetes/prometheus/main.tf
+++ b/modules/kubernetes/prometheus/main.tf
@@ -86,7 +86,6 @@ resource "helm_release" "prometheus_extras" {
     falco_enabled                            = var.falco_enabled
     opa_gatekeeper_enabled                   = var.opa_gatekeeper_enabled
     linkerd_enabled                          = var.linkerd_enabled
-    goldpinger_enabled                       = var.goldpinger_enabled
     flux_enabled                             = var.flux_enabled
     aad_pod_identity_enabled                 = var.aad_pod_identity_enabled
     csi_secrets_store_provider_azure_enabled = var.csi_secrets_store_provider_azure_enabled

--- a/modules/kubernetes/prometheus/templates/values-extras.yaml.tpl
+++ b/modules/kubernetes/prometheus/templates/values-extras.yaml.tpl
@@ -58,7 +58,6 @@ enabledMonitors:
   falco: ${falco_enabled}
   opaGatekeeper: ${opa_gatekeeper_enabled}
   linkerd: ${linkerd_enabled}
-  goldpinger: ${goldpinger_enabled}
   flux: ${flux_enabled}
   aadPodIdentity: ${aad_pod_identity_enabled}
   csiSecretsStorProviderAzure: ${csi_secrets_store_provider_azure_enabled}

--- a/modules/kubernetes/prometheus/variables.tf
+++ b/modules/kubernetes/prometheus/variables.tf
@@ -86,12 +86,6 @@ variable "linkerd_enabled" {
   default     = false
 }
 
-variable "goldpinger_enabled" {
-  description = "Should goldpinger be enabled"
-  type        = bool
-  default     = false
-}
-
 variable "flux_enabled" {
   description = "Should flux-system be enabled"
   type        = bool


### PR DESCRIPTION
I have for a while been seeing a lot of false positives from goldpinger that just dont make sense. Personally I do not see a need for goldpinger as it does not do the job it advertises well. I think it is best to just remove goldping as nobody relies on it as a health metrics. One less daemonset in our clusters.