### PR TITLE
Decrease max shards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+
+- [#459](https://github.com/XenitAB/terraform-modules/pull/459) Decrease Prometheus remote write max shards to reduce concurrent requests.
+
 ## 2021.11.4
 
 ### Fixed

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10
+version: 0.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/templates/prometheus.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/templates/prometheus.yaml
@@ -49,8 +49,11 @@ spec:
       {{- end }}
       # Setting according to others observation
       # https://github.com/prometheus/prometheus/pull/9634
+      # Check docs for more information about settings
+      # https://prometheus.io/docs/practices/remote_write/
       queueConfig:
         maxBackoff: 5s
+        maxShards: 100
   {{- end }}
   {{- if .Values.volumeClaim.enabled }}
   storage:


### PR DESCRIPTION
This change decreases the max shards from the default 200 to 100. The reasoning for this is to reduce the risk of sending a large amount of requests when remote write starts to fail. By reducing the max shard count we reduce the concurrency for each Prometheus instance.