### PR TITLE
Change the method of checking changelog updates

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,4 +1,4 @@
-name: "Checking for Expected Latest Version"
+name: changelog
 on:
   pull_request:
       types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,0 +1,10 @@
+name: "Checking for Expected Latest Version"
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dangoslen/changelog-enforcer@v2

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -8,3 +8,5 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: dangoslen/changelog-enforcer@v2
+      with:
+        skipLabels: "ignore-changelog"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,19 +1,6 @@
 name: check
 on: [pull_request]
 jobs:
-  changelog:
-    if: "!contains(github.event.pull_request.labels.*.name, 'ignore-changelog')"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Check if CHANGELOG.md is updated
-        run: |
-          if ! git diff --name-only refs/remotes/origin/$GITHUB_HEAD_REF origin/$GITHUB_BASE_REF | grep -q CHANGELOG.md ; then
-            echo 'Update CHANGELOG.md with PR reference'
-            exit 1
-          fi
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+
 ### Added
 
 - [#437](https://github.com/XenitAB/terraform-modules/pull/437) Add podmonitor for secrets-store-csi-driver
-
-### Changed
-
-- [#467](https://github.com/XenitAB/terraform-modules/pull/467) This is a test entry
 
 ## 2021.11.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-
 ### Added
 
 - [#437](https://github.com/XenitAB/terraform-modules/pull/437) Add podmonitor for secrets-store-csi-driver
+
+### Changed
+
+- [#467](https://github.com/XenitAB/terraform-modules/pull/467) This is a test entry
 
 ## 2021.11.6
 


### PR DESCRIPTION
This change fixes the changelog check for PRs originating from forks. The new checker will also check the content of the changelog to make sure that it is correct.