### PR TITLE
Set max history for helm releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#469](https://github.com/XenitAB/terraform-modules/pull/469) Remove deprecated modules azure/governance, kubernetes/external-secrets, and kubernetes/kyverno.
 
+### Changed
+
+- [#470](https://github.com/XenitAB/terraform-modules/pull/470) Set max history for Helm releases to reduce the amount of secrets created.
+
 ## 2021.11.7
 
 ### Added

--- a/modules/kubernetes/aad-pod-identity/main.tf
+++ b/modules/kubernetes/aad-pod-identity/main.tf
@@ -31,11 +31,12 @@ resource "kubernetes_namespace" "this" {
 
 #tf-latest-version:ignore
 resource "helm_release" "aad_pod_identity" {
-  repository = "https://raw.githubusercontent.com/Azure/aad-pod-identity/master/charts"
-  chart      = "aad-pod-identity"
-  name       = "aad-pod-identity"
-  version    = "4.0.0"
-  namespace  = kubernetes_namespace.this.metadata[0].name
+  repository  = "https://raw.githubusercontent.com/Azure/aad-pod-identity/master/charts"
+  chart       = "aad-pod-identity"
+  name        = "aad-pod-identity"
+  version     = "4.0.0"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     namespaces       = var.namespaces,
     aad_pod_identity = var.aad_pod_identity

--- a/modules/kubernetes/aks-core/aks-core-extras.tf
+++ b/modules/kubernetes/aks-core/aks-core-extras.tf
@@ -10,7 +10,8 @@
 # `kubectl get pods --all-namespaces -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,PRIORITY:.spec.priorityClassName`
 
 resource "helm_release" "aks_core_extras" {
-  chart     = "${path.module}/charts/aks-core-extras"
-  name      = "aks-core-extras-extras"
-  namespace = "default"
+  chart       = "${path.module}/charts/aks-core-extras"
+  name        = "aks-core-extras-extras"
+  namespace   = "default"
+  max_history = 3
 }

--- a/modules/kubernetes/azad-kube-proxy/main.tf
+++ b/modules/kubernetes/azad-kube-proxy/main.tf
@@ -110,11 +110,12 @@ resource "kubernetes_secret" "this" {
 }
 
 resource "helm_release" "azad_kube_proxy" {
-  depends_on = [kubernetes_secret.this]
-  repository = "https://xenitab.github.io/azad-kube-proxy"
-  chart      = "azad-kube-proxy"
-  name       = "azad-kube-proxy"
-  namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "v0.0.30"
-  values     = [local.values]
+  depends_on  = [kubernetes_secret.this]
+  repository  = "https://xenitab.github.io/azad-kube-proxy"
+  chart       = "azad-kube-proxy"
+  name        = "azad-kube-proxy"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "v0.0.30"
+  max_history = 3
+  values      = [local.values]
 }

--- a/modules/kubernetes/cert-manager/main.tf
+++ b/modules/kubernetes/cert-manager/main.tf
@@ -34,11 +34,12 @@ resource "kubernetes_namespace" "this" {
 }
 
 resource "helm_release" "cert_manager" {
-  repository = "https://charts.jetstack.io"
-  chart      = "cert-manager"
-  name       = "cert-manager"
-  namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "v1.5.1"
+  repository  = "https://charts.jetstack.io"
+  chart       = "cert-manager"
+  name        = "cert-manager"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "v1.5.1"
+  max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     provider   = var.cloud_provider,
     aws_config = var.aws_config,
@@ -48,9 +49,10 @@ resource "helm_release" "cert_manager" {
 resource "helm_release" "cert_manager_extras" {
   depends_on = [helm_release.cert_manager]
 
-  chart     = "${path.module}/charts/cert-manager-extras"
-  name      = "cert-manager-extras"
-  namespace = kubernetes_namespace.this.metadata[0].name
+  chart       = "${path.module}/charts/cert-manager-extras"
+  name        = "cert-manager-extras"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  max_history = 3
 
   set {
     name  = "notificationEmail"

--- a/modules/kubernetes/cluster-autoscaler/main.tf
+++ b/modules/kubernetes/cluster-autoscaler/main.tf
@@ -34,11 +34,12 @@ resource "kubernetes_namespace" "this" {
 }
 
 resource "helm_release" "cluster_autoscaler" {
-  repository = "https://kubernetes.github.io/autoscaler"
-  chart      = "cluster-autoscaler"
-  name       = "cluster-autoscaler"
-  namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "9.10.7"
+  repository  = "https://kubernetes.github.io/autoscaler"
+  chart       = "cluster-autoscaler"
+  name        = "cluster-autoscaler"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "9.10.7"
+  max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     provider     = var.cloud_provider,
     cluster_name = var.cluster_name

--- a/modules/kubernetes/csi-secrets-store-provider-aws/main.tf
+++ b/modules/kubernetes/csi-secrets-store-provider-aws/main.tf
@@ -30,11 +30,12 @@ resource "kubernetes_namespace" "this" {
 }
 
 resource "helm_release" "csi_secrets_store_driver" {
-  name       = "secrets-store-csi-driver"
-  repository = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts"
-  chart      = "secrets-store-csi-driver"
-  version    = "0.2.0"
-  namespace  = kubernetes_namespace.this.metadata[0].name
+  name        = "secrets-store-csi-driver"
+  repository  = "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts"
+  chart       = "secrets-store-csi-driver"
+  version     = "0.2.0"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  max_history = 3
 
   set {
     name  = "linux.metricsAddr"
@@ -65,7 +66,8 @@ resource "helm_release" "csi_secrets_store_driver" {
 resource "helm_release" "csi_secrets_store_provider_aws" {
   depends_on = [helm_release.csi_secrets_store_driver]
 
-  chart     = "${path.module}/charts/csi-secrets-store-provider-aws"
-  name      = "csi-secrets-store-provider-aws"
-  namespace = kubernetes_namespace.this.metadata[0].name
+  chart       = "${path.module}/charts/csi-secrets-store-provider-aws"
+  name        = "csi-secrets-store-provider-aws"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  max_history = 3
 }

--- a/modules/kubernetes/csi-secrets-store-provider-azure/main.tf
+++ b/modules/kubernetes/csi-secrets-store-provider-azure/main.tf
@@ -30,10 +30,11 @@ resource "kubernetes_namespace" "this" {
 }
 
 resource "helm_release" "csi_secrets_store_provider_azure" {
-  repository = "https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts"
-  chart      = "csi-secrets-store-provider-azure"
-  version    = "0.2.1"
-  name       = "csi-secrets-store-provider-azure"
-  namespace  = kubernetes_namespace.this.metadata[0].name
-  values     = [templatefile("${path.module}/templates/values.yaml.tpl", {})]
+  repository  = "https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts"
+  chart       = "csi-secrets-store-provider-azure"
+  version     = "0.2.1"
+  name        = "csi-secrets-store-provider-azure"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  max_history = 3
+  values      = [templatefile("${path.module}/templates/values.yaml.tpl", {})]
 }

--- a/modules/kubernetes/datadog/main.tf
+++ b/modules/kubernetes/datadog/main.tf
@@ -45,12 +45,13 @@ resource "kubernetes_namespace" "this" {
 }
 
 resource "helm_release" "datadog_operator" {
-  repository = "https://helm.datadoghq.com"
-  chart      = "datadog-operator"
-  name       = "datadog-operator"
-  namespace  = kubernetes_namespace.this.metadata[0].name
+  repository  = "https://helm.datadoghq.com"
+  chart       = "datadog-operator"
+  name        = "datadog-operator"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "0.7.0"
+  max_history = 3
 
-  version = "0.7.0"
   set {
     name  = "apiKey"
     value = var.api_key
@@ -68,8 +69,9 @@ resource "helm_release" "datadog_operator" {
 resource "helm_release" "datadog_extras" {
   depends_on = [helm_release.datadog_operator]
 
-  chart     = "${path.module}/charts/datadog-extras"
-  name      = "datadog-extras"
-  namespace = kubernetes_namespace.this.metadata[0].name
-  values    = [local.values]
+  chart       = "${path.module}/charts/datadog-extras"
+  name        = "datadog-extras"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  max_history = 3
+  values      = [local.values]
 }

--- a/modules/kubernetes/eks-core/aks-core-extras.tf
+++ b/modules/kubernetes/eks-core/aks-core-extras.tf
@@ -10,7 +10,8 @@
 # `kubectl get pods --all-namespaces -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,PRIORITY:.spec.priorityClassName`
 
 resource "helm_release" "aks_core_extras" {
-  chart     = "${path.module}/charts/aks-core-extras"
-  name      = "aks-core-extras-extras"
-  namespace = "default"
+  chart       = "${path.module}/charts/aks-core-extras"
+  name        = "aks-core-extras-extras"
+  namespace   = "default"
+  max_history = 3
 }

--- a/modules/kubernetes/external-dns/main.tf
+++ b/modules/kubernetes/external-dns/main.tf
@@ -33,11 +33,12 @@ resource "kubernetes_namespace" "this" {
 }
 
 resource "helm_release" "external_dns" {
-  repository = "https://charts.bitnami.com/bitnami"
-  chart      = "external-dns"
-  name       = "external-dns"
-  namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "5.4.8"
+  repository  = "https://charts.bitnami.com/bitnami"
+  chart       = "external-dns"
+  name        = "external-dns"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "5.4.8"
+  max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     provider     = var.dns_provider,
     sources      = var.sources,
@@ -50,9 +51,10 @@ resource "helm_release" "external_dns" {
 resource "helm_release" "external_dns_extras" {
   depends_on = [helm_release.external_dns]
 
-  chart     = "${path.module}/charts/external-dns-extras"
-  name      = "external-dns-extras"
-  namespace = kubernetes_namespace.this.metadata[0].name
+  chart       = "${path.module}/charts/external-dns-extras"
+  name        = "external-dns-extras"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  max_history = 3
 
   set {
     name  = "resourceID"

--- a/modules/kubernetes/falco/main.tf
+++ b/modules/kubernetes/falco/main.tf
@@ -32,21 +32,23 @@ resource "kubernetes_namespace" "this" {
 }
 
 resource "helm_release" "falco" {
-  repository = "https://falcosecurity.github.io/charts"
-  chart      = "falco"
-  name       = "falco"
-  namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "1.15.7"
+  repository  = "https://falcosecurity.github.io/charts"
+  chart       = "falco"
+  name        = "falco"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "1.15.7"
+  max_history = 3
   values = [templatefile("${path.module}/templates/falco-values.yaml.tpl", {
     provider = var.cloud_provider
   })]
 }
 
 resource "helm_release" "falco_exporter" {
-  repository = "https://falcosecurity.github.io/charts"
-  chart      = "falco-exporter"
-  name       = "falco-exporter"
-  namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "0.5.2"
-  values     = [templatefile("${path.module}/templates/falco-exporter-values.yaml.tpl", {})]
+  repository  = "https://falcosecurity.github.io/charts"
+  chart       = "falco-exporter"
+  name        = "falco-exporter"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "0.5.2"
+  max_history = 3
+  values      = [templatefile("${path.module}/templates/falco-exporter-values.yaml.tpl", {})]
 }

--- a/modules/kubernetes/fluxcd-v1/main.tf
+++ b/modules/kubernetes/fluxcd-v1/main.tf
@@ -112,11 +112,12 @@ resource "kubernetes_secret" "azdo_proxy" {
 
 #tf-latest-version:ignore
 resource "helm_release" "azdo_proxy" {
-  repository = "https://xenitab.github.io/azdo-proxy/"
-  chart      = "azdo-proxy"
-  version    = "v0.3.2"
-  name       = kubernetes_namespace.azdo_proxy.metadata[0].name
-  namespace  = kubernetes_namespace.azdo_proxy.metadata[0].name
+  repository  = "https://xenitab.github.io/azdo-proxy/"
+  chart       = "azdo-proxy"
+  version     = "v0.3.2"
+  name        = kubernetes_namespace.azdo_proxy.metadata[0].name
+  namespace   = kubernetes_namespace.azdo_proxy.metadata[0].name
+  max_history = 3
 
   set {
     name  = "configSecretName"
@@ -131,10 +132,11 @@ resource "helm_release" "fluxcd" {
     if ns.flux.enabled
   }
 
-  name      = "${each.key}-fluxcd"
-  chart     = "${path.module}/charts/flux"
-  version   = "v1.7.0"
-  namespace = each.key
+  name        = "${each.key}-fluxcd"
+  chart       = "${path.module}/charts/flux"
+  version     = "v1.7.0"
+  namespace   = each.key
+  max_history = 3
 
   values = [
     templatefile("${path.module}/templates/fluxcd-values.yaml.tpl", {
@@ -174,11 +176,12 @@ resource "helm_release" "helm_operator" {
     ns.name => ns
   }
 
-  repository = "https://charts.fluxcd.io"
-  chart      = "helm-operator"
-  version    = "1.4.0"
-  name       = "helm-operator"
-  namespace  = each.key
+  repository  = "https://charts.fluxcd.io"
+  chart       = "helm-operator"
+  version     = "1.4.0"
+  name        = "helm-operator"
+  namespace   = each.key
+  max_history = 3
 
   values = [templatefile("${path.module}/templates/helm-operator-values.yaml.tpl", { namespace = each.key })]
 

--- a/modules/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/main.tf
@@ -65,11 +65,12 @@ resource "kubernetes_namespace" "this" {
 
 # Git Auth Proxy
 resource "helm_release" "git_auth_proxy" {
-  repository = "https://xenitab.github.io/git-auth-proxy/"
-  chart      = "git-auth-proxy"
-  name       = "git-auth-proxy"
-  namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "v0.5.2"
+  repository  = "https://xenitab.github.io/git-auth-proxy/"
+  chart       = "git-auth-proxy"
+  name        = "git-auth-proxy"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "v0.5.2"
+  max_history = 3
   values = [templatefile("${path.module}/templates/git-auth-proxy-values.yaml.tpl", {
     azure_devops_pat  = var.azure_devops_pat,
     azure_devops_org  = var.azure_devops_org,

--- a/modules/kubernetes/fluxcd-v2-github/main.tf
+++ b/modules/kubernetes/fluxcd-v2-github/main.tf
@@ -65,11 +65,12 @@ resource "kubernetes_namespace" "this" {
 
 # Git Auth Proxy
 resource "helm_release" "git_auth_proxy" {
-  repository = "https://xenitab.github.io/git-auth-proxy/"
-  chart      = "git-auth-proxy"
-  name       = "git-auth-proxy"
-  namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "v0.5.2"
+  repository  = "https://xenitab.github.io/git-auth-proxy/"
+  chart       = "git-auth-proxy"
+  name        = "git-auth-proxy"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "v0.5.2"
+  max_history = 3
   values = [templatefile("${path.module}/templates/git-auth-proxy-values.yaml.tpl", {
     github_org      = var.github_org
     app_id          = tonumber(var.github_app_id)

--- a/modules/kubernetes/ingress-healthz/main.tf
+++ b/modules/kubernetes/ingress-healthz/main.tf
@@ -32,11 +32,12 @@ resource "kubernetes_namespace" "this" {
 }
 
 resource "helm_release" "ingress_healthz" {
-  repository = "https://charts.bitnami.com/bitnami"
-  chart      = "nginx"
-  name       = "ingress-healthz"
-  namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "9.5.10"
+  repository  = "https://charts.bitnami.com/bitnami"
+  chart       = "nginx"
+  name        = "ingress-healthz"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "9.5.10"
+  max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     environment     = var.environment
     dns_zone        = var.dns_zone

--- a/modules/kubernetes/ingress-nginx/main.tf
+++ b/modules/kubernetes/ingress-nginx/main.tf
@@ -36,11 +36,12 @@ resource "helm_release" "ingress_nginx" {
     if var.public_private_enabled == false
   }
 
-  repository = "https://kubernetes.github.io/ingress-nginx"
-  chart      = "ingress-nginx"
-  name       = "ingress-nginx"
-  namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "3.35.0"
+  repository  = "https://kubernetes.github.io/ingress-nginx"
+  chart       = "ingress-nginx"
+  name        = "ingress-nginx"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "3.35.0"
+  max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     http_snippet           = var.http_snippet
     provider               = var.cloud_provider
@@ -66,11 +67,12 @@ resource "helm_release" "ingress_nginx_public" {
     if var.public_private_enabled
   }
 
-  repository = "https://kubernetes.github.io/ingress-nginx"
-  chart      = "ingress-nginx"
-  name       = "ingress-nginx-public"
-  namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "3.35.0"
+  repository  = "https://kubernetes.github.io/ingress-nginx"
+  chart       = "ingress-nginx"
+  name        = "ingress-nginx-public"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "3.35.0"
+  max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     http_snippet           = var.http_snippet
     provider               = var.cloud_provider
@@ -96,11 +98,12 @@ resource "helm_release" "ingress_nginx_private" {
     if var.public_private_enabled
   }
 
-  repository = "https://kubernetes.github.io/ingress-nginx"
-  chart      = "ingress-nginx"
-  name       = "ingress-nginx-private"
-  namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "3.35.0"
+  repository  = "https://kubernetes.github.io/ingress-nginx"
+  chart       = "ingress-nginx"
+  name        = "ingress-nginx-private"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "3.35.0"
+  max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     http_snippet           = var.http_snippet
     provider               = var.cloud_provider
@@ -120,9 +123,10 @@ resource "helm_release" "ingress_nginx_private" {
 }
 
 resource "helm_release" "ingress_nginx_extras" {
-  chart     = "${path.module}/charts/ingress-nginx-extras"
-  name      = "ingress-nginx-extras"
-  namespace = kubernetes_namespace.this.metadata[0].name
+  chart       = "${path.module}/charts/ingress-nginx-extras"
+  name        = "ingress-nginx-extras"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  max_history = 3
 
   set {
     name  = "defaultCertificate.enabled"

--- a/modules/kubernetes/linkerd/main.tf
+++ b/modules/kubernetes/linkerd/main.tf
@@ -195,11 +195,12 @@ resource "kubernetes_secret" "webhook_issuer_tls" {
 # Tmp use edge version until 2.11.0 is released where we will get the helm chart feature we need.
 #tf-latest-version:ignore
 resource "helm_release" "linkerd_cni" {
-  repository = "https://helm.linkerd.io/edge"
-  chart      = "linkerd2-cni"
-  name       = "linkerd-cni"
-  namespace  = kubernetes_namespace.cni.metadata[0].name
-  version    = "21.7.5"
+  repository  = "https://helm.linkerd.io/edge"
+  chart       = "linkerd2-cni"
+  name        = "linkerd-cni"
+  namespace   = kubernetes_namespace.cni.metadata[0].name
+  version     = "21.7.5"
+  max_history = 3
 
   values = [
     templatefile("${path.module}/templates/values-cni.yaml.tpl", {}),
@@ -213,19 +214,21 @@ resource "helm_release" "linkerd_extras" {
     kubernetes_secret.webhook_issuer_tls
   ]
 
-  chart     = "${path.module}/charts/linkerd-extras"
-  name      = "linkerd-extras"
-  namespace = kubernetes_namespace.this.metadata[0].name
+  chart       = "${path.module}/charts/linkerd-extras"
+  name        = "linkerd-extras"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  max_history = 3
 }
 
 resource "helm_release" "linkerd" {
   depends_on = [helm_release.linkerd_extras, helm_release.linkerd_cni]
 
-  repository = "https://helm.linkerd.io/stable"
-  chart      = "linkerd2"
-  name       = "linkerd"
-  namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "2.10.2"
+  repository  = "https://helm.linkerd.io/stable"
+  chart       = "linkerd2"
+  name        = "linkerd"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "2.10.2"
+  max_history = 3
   values = [
     templatefile("${path.module}/templates/values.yaml.tpl", {
       linkerd_trust_anchor_pem = indent(2, tls_self_signed_cert.linkerd_trust_anchor.cert_pem),
@@ -238,11 +241,12 @@ resource "helm_release" "linkerd" {
 resource "helm_release" "linkerd_viz" {
   depends_on = [helm_release.linkerd]
 
-  repository = "https://helm.linkerd.io/stable"
-  chart      = "linkerd-viz"
-  name       = "linkerd-viz"
-  namespace  = kubernetes_namespace.viz.metadata[0].name
-  version    = "2.10.2"
+  repository  = "https://helm.linkerd.io/stable"
+  chart       = "linkerd-viz"
+  name        = "linkerd-viz"
+  namespace   = kubernetes_namespace.viz.metadata[0].name
+  version     = "2.10.2"
+  max_history = 3
   values = [
     templatefile("${path.module}/templates/values-viz.yaml.tpl", {}),
   ]

--- a/modules/kubernetes/loki/main.tf
+++ b/modules/kubernetes/loki/main.tf
@@ -59,11 +59,12 @@ resource "kubernetes_namespace" "this" {
 }
 
 resource "helm_release" "minio" {
-  name       = "loki-minio"
-  repository = "https://helm.min.io/"
-  chart      = "minio"
-  version    = "8.0.10"
-  namespace  = kubernetes_namespace.this.metadata[0].name
+  name        = "loki-minio"
+  repository  = "https://helm.min.io/"
+  chart       = "minio"
+  version     = "8.0.10"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  max_history = 3
 
   values = [
     templatefile("${path.module}/templates/minio-values.yaml.tpl", {}),
@@ -81,11 +82,12 @@ resource "helm_release" "minio" {
 }
 
 resource "helm_release" "loki_stack" {
-  name       = "loki"
-  repository = "https://grafana.github.io/loki/charts"
-  chart      = "loki-stack"
-  version    = "2.1.2"
-  namespace  = kubernetes_namespace.this.metadata[0].name
+  name        = "loki"
+  repository  = "https://grafana.github.io/loki/charts"
+  chart       = "loki-stack"
+  version     = "2.1.2"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  max_history = 3
 
   values = [
     templatefile("${path.module}/templates/loki-stack-values.yaml.tpl", {}),

--- a/modules/kubernetes/opa-gatekeeper/main.tf
+++ b/modules/kubernetes/opa-gatekeeper/main.tf
@@ -119,11 +119,12 @@ resource "kubernetes_namespace" "this" {
 }
 
 resource "helm_release" "gatekeeper" {
-  repository = "https://open-policy-agent.github.io/gatekeeper/charts"
-  chart      = "gatekeeper"
-  name       = "gatekeeper"
-  namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "3.6.0"
+  repository  = "https://open-policy-agent.github.io/gatekeeper/charts"
+  chart       = "gatekeeper"
+  name        = "gatekeeper"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "3.6.0"
+  max_history = 3
   values = [templatefile("${path.module}/templates/gatekeeper-values.yaml.tpl", {
     provider = var.cloud_provider
   })]
@@ -132,21 +133,23 @@ resource "helm_release" "gatekeeper" {
 resource "helm_release" "gatekeeper_templates" {
   depends_on = [helm_release.gatekeeper]
 
-  repository = "https://xenitab.github.io/gatekeeper-library/"
-  chart      = "gatekeeper-library-templates"
-  name       = "gatekeeper-library-templates"
-  namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "v0.7.3"
-  values     = [local.values]
+  repository  = "https://xenitab.github.io/gatekeeper-library/"
+  chart       = "gatekeeper-library-templates"
+  name        = "gatekeeper-library-templates"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "v0.7.3"
+  max_history = 3
+  values      = [local.values]
 }
 
 resource "helm_release" "gatekeeper_constraints" {
   depends_on = [helm_release.gatekeeper, helm_release.gatekeeper_templates]
 
-  repository = "https://xenitab.github.io/gatekeeper-library/"
-  chart      = "gatekeeper-library-constraints"
-  name       = "gatekeeper-library-constraints"
-  namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "v0.7.3"
-  values     = [local.values]
+  repository  = "https://xenitab.github.io/gatekeeper-library/"
+  chart       = "gatekeeper-library-constraints"
+  name        = "gatekeeper-library-constraints"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "v0.7.3"
+  max_history = 3
+  values      = [local.values]
 }

--- a/modules/kubernetes/reloader/main.tf
+++ b/modules/kubernetes/reloader/main.tf
@@ -31,11 +31,12 @@ resource "kubernetes_namespace" "this" {
 }
 
 resource "helm_release" "reloader" {
-  repository = "https://stakater.github.io/stakater-charts"
-  chart      = "reloader"
-  name       = "reloader"
-  namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "v0.0.102"
+  repository  = "https://stakater.github.io/stakater-charts"
+  chart       = "reloader"
+  name        = "reloader"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "v0.0.102"
+  max_history = 3
 
   set {
     name  = "reloader.deployment.priorityClassName"

--- a/modules/kubernetes/starboard/main.tf
+++ b/modules/kubernetes/starboard/main.tf
@@ -45,20 +45,22 @@ resource "kubernetes_namespace" "trivy" {
 }
 
 resource "helm_release" "starboard" {
-  repository = "https://aquasecurity.github.io/helm-charts/"
-  chart      = "starboard-operator"
-  name       = "starboard-operator"
-  namespace  = kubernetes_namespace.starboard.metadata[0].name
-  version    = "0.7.0"
+  repository  = "https://aquasecurity.github.io/helm-charts/"
+  chart       = "starboard-operator"
+  name        = "starboard-operator"
+  namespace   = kubernetes_namespace.starboard.metadata[0].name
+  version     = "0.7.0"
+  max_history = 3
   values = [templatefile("${path.module}/templates/starboard-values.yaml.tpl", {
     provider = var.cloud_provider
   })]
 }
 
 resource "helm_release" "trivy" {
-  repository = "https://aquasecurity.github.io/helm-charts/"
-  chart      = "trivy"
-  name       = "trivy"
-  namespace  = kubernetes_namespace.trivy.metadata[0].name
-  version    = "0.4.4"
+  repository  = "https://aquasecurity.github.io/helm-charts/"
+  chart       = "trivy"
+  name        = "trivy"
+  namespace   = kubernetes_namespace.trivy.metadata[0].name
+  version     = "0.4.4"
+  max_history = 3
 }

--- a/modules/kubernetes/velero/main.tf
+++ b/modules/kubernetes/velero/main.tf
@@ -30,11 +30,12 @@ resource "kubernetes_namespace" "this" {
 }
 
 resource "helm_release" "velero" {
-  repository = "https://vmware-tanzu.github.io/helm-charts"
-  chart      = "velero"
-  name       = "velero"
-  namespace  = kubernetes_namespace.this.metadata[0].name
-  version    = "2.23.6"
+  repository  = "https://vmware-tanzu.github.io/helm-charts"
+  chart       = "velero"
+  name        = "velero"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "2.23.6"
+  max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     cloud_provider = var.cloud_provider,
     azure_config   = var.azure_config,
@@ -45,9 +46,10 @@ resource "helm_release" "velero" {
 resource "helm_release" "velero_extras" {
   depends_on = [helm_release.velero]
 
-  chart     = "${path.module}/charts/velero-extras"
-  name      = "velero-extras"
-  namespace = kubernetes_namespace.this.metadata[0].name
+  chart       = "${path.module}/charts/velero-extras"
+  name        = "velero-extras"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  max_history = 3
 
   set {
     name  = "resourceID"


### PR DESCRIPTION
This change will reduce the amount of secrets created by Helm to store chart history. The default max history is 0 meaning that there is no limit. We dont really use the chart history as we do not rollback on failure. Setting it to 3 is just what I think is a reasonable number.