### PR TITLE
Adjust prometheus resource requests to fix OOM Kill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#463](https://github.com/XenitAB/terraform-modules/pull/463) Add azure-metrics to monitor azure specific metrics.
 
+### Fixed
+
+- [#474](https://github.com/XenitAB/terraform-modules/pull/474) Adjust prometheus resource requests to fix OOM Kill.
+
 ## 2021.11.7
 
 ### Added

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.28
+version: 0.1.29
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/values.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/values.yaml
@@ -24,10 +24,10 @@ service:
 
 resources:
   requests:
-    memory: "500Mi"
+    memory: "1Gi"
     cpu: "20m"
   limits:
-    memory: "2Gi"
+    memory: "8Gi"
 
 volumeClaim:
   storageClassName: default


### PR DESCRIPTION
Prometheus needs a lot of head room in case of a WAL replay so the limit needs to be high. These settings should be adjusted as we move to agent mode in the next Prometheus release.