### PR TITLE
Fix multi doc separator in prometheus monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - [#474](https://github.com/XenitAB/terraform-modules/pull/474) Adjust prometheus resource requests to fix OOM Kill.
+- [#475](https://github.com/XenitAB/terraform-modules/pull/475) Fix multi doc separator in prometheus monitors.
 
 ## 2021.11.7
 

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.29
+version: 0.1.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/templates/monitors.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/templates/monitors.yaml
@@ -12,7 +12,69 @@ spec:
     matchLabels:
       app: prometheus
 ---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    xkf.xenit.io/monitoring: platform
+  name: cert-manager
+  namespace: cert-manager
+spec:
+  endpoints:
+  - interval: 60s
+    path: /metrics
+    scrapeTimeout: 30s
+    targetPort: 9402
+  jobLabel: cert-manager
+  namespaceSelector:
+    matchNames:
+    - cert-manager
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/name: cert-manager
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    xkf.xenit.io/monitoring: platform
+  name: external-dns
+  namespace: external-dns
+spec:
+  endpoints:
+  - path: /metrics
+    port: http
+  namespaceSelector:
+    matchNames:
+    - external-dns
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: external-dns
+      app.kubernetes.io/name: external-dns
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    xkf.xenit.io/monitoring: platform
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+  namespaceSelector:
+    matchNames:
+    - ingress-nginx
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: ingress-nginx
+      app.kubernetes.io/name: ingress-nginx
 {{- if .Values.enabledMonitors.aadPodIdentity }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -47,31 +109,8 @@ spec:
     - path: /metrics
       port: metrics
 {{- end }}
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  labels:
-    xkf.xenit.io/monitoring: platform
-  name: cert-manager
-  namespace: cert-manager
-spec:
-  endpoints:
-  - interval: 60s
-    path: /metrics
-    scrapeTimeout: 30s
-    targetPort: 9402
-  jobLabel: cert-manager
-  namespaceSelector:
-    matchNames:
-    - cert-manager
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: controller
-      app.kubernetes.io/instance: cert-manager
-      app.kubernetes.io/name: cert-manager
----
 {{- if .Values.enabledMonitors.csiSecretsStorProviderAzure }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -88,8 +127,8 @@ spec:
     - path: /metrics
       port: "8081"
 {{- end }}
----
 {{- if .Values.enabledMonitors.csiSecretsStorProviderAws }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -106,27 +145,8 @@ spec:
     - path: /metrics
       port: "8081"
 {{- end }}
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  labels:
-    xkf.xenit.io/monitoring: platform
-  name: external-dns
-  namespace: external-dns
-spec:
-  endpoints:
-  - path: /metrics
-    port: http
-  namespaceSelector:
-    matchNames:
-    - external-dns
-  selector:
-    matchLabels:
-      app.kubernetes.io/instance: external-dns
-      app.kubernetes.io/name: external-dns
----
 {{- if .Values.enabledMonitors.flux }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -202,26 +222,6 @@ spec:
       app.kubernetes.io/instance: git-auth-proxy
       app.kubernetes.io/name: git-auth-proxy
 {{- end }}
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  labels:
-    xkf.xenit.io/monitoring: platform
-  name: ingress-nginx-controller
-  namespace: ingress-nginx
-spec:
-  endpoints:
-  - interval: 30s
-    port: metrics
-  namespaceSelector:
-    matchNames:
-    - ingress-nginx
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: controller
-      app.kubernetes.io/instance: ingress-nginx
-      app.kubernetes.io/name: ingress-nginx
 {{- if .Values.enabledMonitors.falco }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -327,6 +327,7 @@ spec:
       port: metrics
 {{- end }}
 {{- if .Values.enabledMonitors.csiSecretsStorProviderAzure }}
+----
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -344,6 +345,7 @@ spec:
       port: metrics
 {{- end }}
 {{- if .Values.enabledMonitors.csiSecretsStorProviderAws }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:


### PR DESCRIPTION
This change fixes a multidoc file separator in the prometheus extras Helm chart. Currently some monitors are not created because of this.