### PR TITLE
Ingress if snippet-annotations remove blocklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+
+- [#478](https://github.com/XenitAB/terraform-modules/pull/478) Ingress if allow-snippet-annotations == true there is no annotation-value-word-blocklist defined.
+
 ## 2021.12.1
 
 ### Changed

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -45,7 +45,9 @@ controller:
       ${http_snippet}
     %{~ endif ~}
     allow-snippet-annotations: ${allow_snippet_annotations}
+    %{~ if !allow_snippet_annotations ~}
     annotation-value-word-blocklist: load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},',\
+    %{~ endif ~}
 
   addHeaders:
     %{~ for key, value in extra_headers ~}


### PR DESCRIPTION
This is the best we can do but if you decide to allow-snippet-annotations
the developers will have to make sure that they don't write any dangerous lua.