### PR TITLE
azure/core: add support for non VirtualAppliance routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#482](https://github.com/XenitAB/terraform-modules/pull/482) azure/core: add support for non VirtualAppliance routes
+
 ## 2021.12.2
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- [#482](https://github.com/XenitAB/terraform-modules/pull/482) azure/core: add support for non VirtualAppliance routes
+- [#482](https://github.com/XenitAB/terraform-modules/pull/482) add support for non VirtualAppliance routes
 
 ## 2021.12.2
 

--- a/modules/azure/core/README.md
+++ b/modules/azure/core/README.md
@@ -28,6 +28,7 @@ No modules.
 | [azurerm_network_security_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/network_security_group) | resource |
 | [azurerm_role_assignment.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_definition.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/role_definition) | resource |
+| [azurerm_route.not_virtual_appliance](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/route) | resource |
 | [azurerm_route.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/route) | resource |
 | [azurerm_route_table.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/route_table) | resource |
 | [azurerm_storage_account.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/storage_account) | resource |

--- a/modules/azure/core/routes.tf
+++ b/modules/azure/core/routes.tf
@@ -13,6 +13,7 @@ resource "azurerm_route" "this" {
   for_each = {
     for route in local.routes :
     route.name => route
+    if route.next_hop_type == "VirtualAppliance"
   }
 
   name                   = each.value.route.name
@@ -21,6 +22,20 @@ resource "azurerm_route" "this" {
   address_prefix         = each.value.route.address_prefix
   next_hop_type          = each.value.route.next_hop_type
   next_hop_in_ip_address = each.value.route.next_hop_in_ip_address
+}
+
+resource "azurerm_route" "not_virtual_appliance" {
+  for_each = {
+    for route in local.routes :
+    route.name => route
+    if route.next_hop_type != "VirtualAppliance"
+  }
+
+  name                = each.value.route.name
+  resource_group_name = data.azurerm_resource_group.this.name
+  route_table_name    = azurerm_route_table.this[each.value.subnet_name].name
+  address_prefix      = each.value.route.address_prefix
+  next_hop_type       = each.value.route.next_hop_type
 }
 
 resource "azurerm_subnet_route_table_association" "this" {

--- a/modules/azure/core/routes.tf
+++ b/modules/azure/core/routes.tf
@@ -13,7 +13,7 @@ resource "azurerm_route" "this" {
   for_each = {
     for route in local.routes :
     route.name => route
-    if route.next_hop_type == "VirtualAppliance"
+    if route.route.next_hop_type == "VirtualAppliance"
   }
 
   name                   = each.value.route.name
@@ -31,7 +31,7 @@ resource "azurerm_route" "not_virtual_appliance" {
   for_each = {
     for route in local.routes :
     route.name => route
-    if route.next_hop_type != "VirtualAppliance"
+    if route.route.next_hop_type != "VirtualAppliance"
   }
 
   name                = each.value.route.name

--- a/modules/azure/core/routes.tf
+++ b/modules/azure/core/routes.tf
@@ -24,6 +24,9 @@ resource "azurerm_route" "this" {
   next_hop_in_ip_address = each.value.route.next_hop_in_ip_address
 }
 
+# Note: In the future, we shouldn't use negated names but we have to do this
+#       for now until `move` is supported (when we've updated to 1.1.0 or later):
+#       https://github.com/hashicorp/terraform/releases/tag/v1.1.0
 resource "azurerm_route" "not_virtual_appliance" {
   for_each = {
     for route in local.routes :

--- a/validation/azure/core/main.tf
+++ b/validation/azure/core/main.tf
@@ -56,6 +56,12 @@ module "core" {
           next_hop_type          = "Internet"
           next_hop_in_ip_address = ""
         },
+        {
+          name                   = "local_test"
+          address_prefix         = "0.0.0.0/0"
+          next_hop_type          = "VirtualAppliance"
+          next_hop_in_ip_address = "192.168.0.1"
+        },
       ]
     },
   ]


### PR DESCRIPTION
This fixes the issue described in the following issue:
https://github.com/XenitAB/terraform-modules/issues/303

Now we're forking on the next_hop_type and remove the
next_hop_in_ip_address if it's not a VirtualAppliance route.

Let's hope it solves the problem. :^)