### PR TITLE
Update external-dns Helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- [#487](https://github.com/XenitAB/terraform-modules/pull/487) Update external-dns Helm chart.
 - [#492](https://github.com/XenitAB/terraform-modules/pull/492) Increase scrape interval starboard-exporter metric.
 
 ## 2021.12.6

--- a/modules/kubernetes/external-dns/main.tf
+++ b/modules/kubernetes/external-dns/main.tf
@@ -37,7 +37,7 @@ resource "helm_release" "external_dns" {
   chart       = "external-dns"
   name        = "external-dns"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "5.4.8"
+  version     = "6.0.2"
   max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     provider     = var.dns_provider,


### PR DESCRIPTION
This change updates the external-dns Helm chart as the Azure MSI issues were fixed in the 10.2 release.