### PR TITLE
Set AKS cluster autoscaler expander strategy to least waste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - [#497](https://github.com/XenitAB/terraform-modules/pull/497) Remove namespaces config option for kube-state-metrics.
+- [#498](https://github.com/XenitAB/terraform-modules/pull/498) Set AKS cluster autoscaler expander strategy to least waste.
 
 ## 2021.12.4
 

--- a/modules/azure/aks/aks.tf
+++ b/modules/azure/aks/aks.tf
@@ -17,6 +17,9 @@ resource "azurerm_kubernetes_cluster" "this" {
   auto_scaler_profile {
     # Pods should not depend on local storage like EmptyDir or HostPath
     skip_nodes_with_local_storage = false
+    # Selects the node pool which would result in the least amount of waste.
+    # TODO: When supported we should make use of multiple expanders #499
+    expander = "least-waste"
   }
 
   network_profile {


### PR DESCRIPTION
This changes the expander strategy from the default random to least waste. Hopefully this will result in the cluster autoscaler selecting the right type of instance class when scaling up. It is possible to select multiple expanders but that is not currently supported by AKS. There is an issue in the provider which tracks this hashicorp/terraform-provider-azurerm/issues/13900.

Refer to the cluster autoscaler documentation for detailed information.
https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders