### PR TITLE
grafana-agent: Add externalLabels to logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#502](https://github.com/XenitAB/terraform-modules/pull/502) Add externalLabels to logs for Grafana Agent
+
 ## 2021.12.5
 
 ### Changed

--- a/modules/kubernetes/grafana-agent/charts/grafana-agent-extras/Chart.yaml
+++ b/modules/kubernetes/grafana-agent/charts/grafana-agent-extras/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/grafana-agent/charts/grafana-agent-extras/templates/grafanaagent.yaml
+++ b/modules/kubernetes/grafana-agent/charts/grafana-agent-extras/templates/grafanaagent.yaml
@@ -16,8 +16,8 @@ spec:
         agent: grafana-agent-metrics
     replicas: {{ .Values.replicas }}
     externalLabels:
+      cluster: {{ .Values.clusterName }}
       environment: {{ .Values.environment }}
-      clusterName: {{ .Values.clusterName }}
   logs:
     instanceSelector:
       matchLabels:

--- a/modules/kubernetes/grafana-agent/charts/grafana-agent-extras/templates/loginstance.yaml
+++ b/modules/kubernetes/grafana-agent/charts/grafana-agent-extras/templates/loginstance.yaml
@@ -8,6 +8,9 @@ metadata:
 spec:
   clients:
     - url: {{ .Values.remote.logsUrl }}
+      externalLabels:
+        cluster: {{ .Values.clusterName }}
+        environment: {{ .Values.environment }}
       basicAuth:
         username:
           name: {{ .Values.credentialsSecretName }}


### PR DESCRIPTION
Please note that `externalLabels` are set in two different places for logs and metrics, which is beautifully described in the following comment: https://github.com/grafana/agent/issues/1035#issuecomment-953607160

We are also changing the name from `clusterName` to `cluster` which replaces the "default" cluster label (which was `grafana-agent/grafana-agent`). This may, or may not, cause issues in the future - but I've been promised by @NissesSenap that he'll solve it using jsonnet. ;^)

This will resolve the following issue: https://github.com/XenitAB/terraform-modules/issues/495