### PR TITLE
Give users access to read/delete starboard reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+
+- [#504](https://github.com/XenitAB/terraform-modules/pull/504) Give developers access to starboards report.
+
 ## 2021.12.6
 
 ### Changed

--- a/modules/kubernetes/aks-core/README.md
+++ b/modules/kubernetes/aks-core/README.md
@@ -58,6 +58,7 @@ This module is used to create AKS clusters.
 | [kubernetes_cluster_role.custom_resource_edit](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role.helm_release](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role.list_namespaces](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/cluster_role) | resource |
+| [kubernetes_cluster_role.starboard_reports](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role.top](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role_binding.cluster_admin](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/cluster_role_binding) | resource |
 | [kubernetes_cluster_role_binding.cluster_view](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/cluster_role_binding) | resource |
@@ -72,6 +73,7 @@ This module is used to create AKS clusters.
 | [kubernetes_role_binding.helm_release](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.sa_edit](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.sa_helm_release](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/role_binding) | resource |
+| [kubernetes_role_binding.starboard_reports](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.top](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.view](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/role_binding) | resource |
 | [kubernetes_service_account.tenant](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/service_account) | resource |

--- a/modules/kubernetes/aks-core/k8s-cluster-role.tf
+++ b/modules/kubernetes/aks-core/k8s-cluster-role.tf
@@ -60,3 +60,23 @@ resource "kubernetes_cluster_role" "top" {
     verbs      = ["get", "list", "watch"]
   }
 }
+
+resource "kubernetes_cluster_role" "starboard_reports" {
+  for_each = {
+    for s in ["starboard"] :
+    s => s
+    if var.starboard_enabled
+  }
+
+  metadata {
+    name = "starboard-reports"
+    labels = {
+      "xkf.xenit.io/kind" = "platform"
+    }
+  }
+  rule {
+    api_groups = ["aquasecurity.github.io"]
+    resources  = ["vulnerabilityreports", "configauditreports"]
+    verbs      = ["get", "list", "watch", "update", "delete"]
+  }
+}

--- a/modules/kubernetes/aks-core/k8s-role-binding.tf
+++ b/modules/kubernetes/aks-core/k8s-role-binding.tf
@@ -180,7 +180,7 @@ resource "kubernetes_role_binding" "starboard_reports" {
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "ClusterRole"
-    name      = kubernetes_cluster_role.starboard_reports[each.key].metadata[0].name
+    name      = kubernetes_cluster_role.starboard_reports["starboard"].metadata[0].name
   }
   subject {
     api_group = "rbac.authorization.k8s.io"

--- a/modules/kubernetes/aks-core/k8s-role-binding.tf
+++ b/modules/kubernetes/aks-core/k8s-role-binding.tf
@@ -160,3 +160,31 @@ resource "kubernetes_role_binding" "top" {
     name      = var.aad_groups.edit[each.key].id
   }
 }
+
+resource "kubernetes_role_binding" "starboard_reports" {
+  for_each = {
+    for ns in var.namespaces :
+    ns.name => ns
+    if var.starboard_enabled
+  }
+
+  metadata {
+    name      = "${each.value.name}-starboard-reports"
+    namespace = kubernetes_namespace.tenant[each.key].metadata[0].name
+
+    labels = {
+      "aad-group-name"    = var.aad_groups.edit[each.key].name
+      "xkf.xenit.io/kind" = "platform"
+    }
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role.starboard_reports[each.key].metadata[0].name
+  }
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Group"
+    name      = var.aad_groups.edit[each.key].id
+  }
+}

--- a/modules/kubernetes/eks-core/README.md
+++ b/modules/kubernetes/eks-core/README.md
@@ -53,6 +53,7 @@ This module is used to configure EKS clusters.
 | [kubernetes_cluster_role.custom_resource_edit](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role.helm_release](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role.list_namespaces](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/cluster_role) | resource |
+| [kubernetes_cluster_role.starboard_reports](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role.top](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role_binding.cluster_admin](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/cluster_role_binding) | resource |
 | [kubernetes_cluster_role_binding.cluster_view](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/cluster_role_binding) | resource |
@@ -67,6 +68,7 @@ This module is used to configure EKS clusters.
 | [kubernetes_role_binding.helm_release](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.sa_edit](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.sa_helm_release](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/role_binding) | resource |
+| [kubernetes_role_binding.starboard_reports](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.top](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.view](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/role_binding) | resource |
 | [kubernetes_service_account.tenant](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/service_account) | resource |

--- a/modules/kubernetes/eks-core/k8s-cluster-role.tf
+++ b/modules/kubernetes/eks-core/k8s-cluster-role.tf
@@ -60,3 +60,23 @@ resource "kubernetes_cluster_role" "top" {
     verbs      = ["get", "list", "watch"]
   }
 }
+
+resource "kubernetes_cluster_role" "starboard_reports" {
+  for_each = {
+    for s in ["starboard"] :
+    s => s
+    if var.starboard_enabled
+  }
+
+  metadata {
+    name = "starboard-reports"
+    labels = {
+      "xkf.xenit.io/kind" = "platform"
+    }
+  }
+  rule {
+    api_groups = ["aquasecurity.github.io"]
+    resources  = ["vulnerabilityreports", "configauditreports"]
+    verbs      = ["get", "list", "watch", "update", "delete"]
+  }
+}

--- a/modules/kubernetes/eks-core/k8s-role-binding.tf
+++ b/modules/kubernetes/eks-core/k8s-role-binding.tf
@@ -180,7 +180,7 @@ resource "kubernetes_role_binding" "starboard_reports" {
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "ClusterRole"
-    name      = kubernetes_cluster_role.starboard_reports[each.key].metadata[0].name
+    name      = kubernetes_cluster_role.starboard_reports["starboard"].metadata[0].name
   }
   subject {
     api_group = "rbac.authorization.k8s.io"

--- a/modules/kubernetes/eks-core/k8s-role-binding.tf
+++ b/modules/kubernetes/eks-core/k8s-role-binding.tf
@@ -160,3 +160,31 @@ resource "kubernetes_role_binding" "top" {
     name      = var.aad_groups.edit[each.key].id
   }
 }
+
+resource "kubernetes_role_binding" "starboard_reports" {
+  for_each = {
+    for ns in var.namespaces :
+    ns.name => ns
+    if var.starboard_enabled
+  }
+
+  metadata {
+    name      = "${each.value.name}-starboard-reports"
+    namespace = kubernetes_namespace.tenant[each.key].metadata[0].name
+
+    labels = {
+      "aad-group-name"    = var.aad_groups.edit[each.key].name
+      "xkf.xenit.io/kind" = "platform"
+    }
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role.starboard_reports[each.key].metadata[0].name
+  }
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Group"
+    name      = var.aad_groups.edit[each.key].id
+  }
+}


### PR DESCRIPTION
In the future developers should be able to use the reports generated from starboard to gain insights on how there configuration of their deployments is done together with CVE:s.