### PR TITLE
Set prometheus in agent mode and upgrade kube-prometheus-stack to 30.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- [#510](https://github.com/XenitAB/terraform-modules/pull/510) Run prometheus in agent mode.
+- [#510](https://github.com/XenitAB/terraform-modules/pull/510) [Breaking] Run prometheus in agent mode and update kube-prometheus-stack to v30.0.0.
 
 ## 2022.01.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#510](https://github.com/XenitAB/terraform-modules/pull/510) Run prometheus in agent mode.
+
 ## 2022.01.1
 
 ### Added

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.35
+version: 0.1.36
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.31
+version: 0.1.34
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.31
+version: 0.1.35
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.34
+version: 0.1.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/templates/prometheus.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/templates/prometheus.yaml
@@ -10,6 +10,19 @@ spec:
     labels:
       aadpodidbinding: prometheus
   {{- end }}
+  containers:
+    - name: prometheus
+      args:
+        - --config.file=/etc/prometheus/config_out/prometheus.env.yaml
+        - --storage.agent.path=/prometheus
+        - --enable-feature=agent
+        - --web.enable-lifecycle
+        - --web.console.templates=/etc/prometheus/consoles
+        - --web.console.libraries=/etc/prometheus/console_libraries
+        - --web.route-prefix=/
+        - --web.config.file=/etc/prometheus/web_config/web-config.yaml
+  enableFeatures:
+    - agent
   externalLabels:
     cluster_name: {{ .Values.externalLabels.clusterName }}
     environment: {{ .Values.externalLabels.environment }}

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/templates/prometheus.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/templates/prometheus.yaml
@@ -10,19 +10,6 @@ spec:
     labels:
       aadpodidbinding: prometheus
   {{- end }}
-  containers:
-    - name: prometheus
-      args:
-        - --config.file=/etc/prometheus/config_out/prometheus.env.yaml
-        - --storage.agent.path=/prometheus
-        - --enable-feature=agent
-        - --web.enable-lifecycle
-        - --web.console.templates=/etc/prometheus/consoles
-        - --web.console.libraries=/etc/prometheus/console_libraries
-        - --web.route-prefix=/
-        - --web.config.file=/etc/prometheus/web_config/web-config.yaml
-  enableFeatures:
-    - agent
   externalLabels:
     cluster_name: {{ .Values.externalLabels.clusterName }}
     environment: {{ .Values.externalLabels.environment }}

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/values.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/values.yaml
@@ -27,7 +27,7 @@ resources:
     memory: "1Gi"
     cpu: "20m"
   limits:
-    memory: "8Gi"
+    memory: "3Gi"
 
 volumeClaim:
   storageClassName: default

--- a/modules/kubernetes/prometheus/main.tf
+++ b/modules/kubernetes/prometheus/main.tf
@@ -40,7 +40,7 @@ resource "helm_release" "prometheus" {
   chart       = "kube-prometheus-stack"
   name        = "prometheus"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "17.2.2"
+  version     = "30.0.0"
   max_history = 3
   values      = [templatefile("${path.module}/templates/values.yaml.tpl", {})]
 }

--- a/modules/kubernetes/prometheus/templates/values.yaml.tpl
+++ b/modules/kubernetes/prometheus/templates/values.yaml.tpl
@@ -31,6 +31,12 @@ kube-state-metrics:
     enabled: false
   metricLabelsAllowlist:
     - "namespaces=[xkf.xenit.io/kind]"
+  #selfMonitor:
+  #  enabled: true
+  prometheus:
+    monitor:
+      additionalLabels:
+        xkf.xenit.io/monitoring: platform
 
 commonLabels:
   xkf.xenit.io/monitoring: platform

--- a/modules/kubernetes/prometheus/templates/values.yaml.tpl
+++ b/modules/kubernetes/prometheus/templates/values.yaml.tpl
@@ -31,8 +31,6 @@ kube-state-metrics:
     enabled: false
   metricLabelsAllowlist:
     - "namespaces=[xkf.xenit.io/kind]"
-  #selfMonitor:
-  #  enabled: true
   prometheus:
     monitor:
       additionalLabels:

--- a/modules/kubernetes/prometheus/templates/values.yaml.tpl
+++ b/modules/kubernetes/prometheus/templates/values.yaml.tpl
@@ -54,3 +54,7 @@ prometheusOperator:
 
 prometheus-node-exporter:
   priorityClassName: "platform-high"
+  prometheus:
+    monitor:
+      additionalLabels:
+        xkf.xenit.io/monitoring: platform


### PR DESCRIPTION
Upgrade kube-prometheus-stack to 30.0.0, this to get the latest prometheus-operator version so we can use
prometheus in agent mode.
Also run prometheus in agent mode, this to lower resource usage and a smarter way of handling WAL.