### PR TITLE
Create opinionated EKS Core module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#523](https://github.com/XenitAB/terraform-modules/pull/523) Update starboard to 0.14.0, only scan the latest deployments
   and set a TTL on the vulnerability reports to be recreated after 25 hours.
 
+### Added
+
+- [#513](https://github.com/XenitAB/terraform-modules/pull/513) EKS opinionated module ```eks-core``` added.
 ## 2022.01.3
 
 ### Changed

--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -5,6 +5,7 @@ This directory contains all the AWS Terraform modules.
 ## Modules
 
 - [`core`](core/README.md)
+- [`eks-core`](eks-core/README.md)
 - [`eks-global`](eks-global/README.md)
 - [`eks`](eks/README.md)
 - [`irsa`](irsa/README.md)

--- a/modules/aws/eks-core/README.md
+++ b/modules/aws/eks-core/README.md
@@ -1,0 +1,70 @@
+# Core
+
+This module is used to configure an opinionated VPC for XKS.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 0.15.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.63.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.63.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/cloudwatch_log_group) | resource |
+| [aws_eip.public](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/eip) | resource |
+| [aws_flow_log.this](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/flow_log) | resource |
+| [aws_iam_policy.flow_log](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/iam_policy) | resource |
+| [aws_iam_role.flow_log](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.permissions](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_internet_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/internet_gateway) | resource |
+| [aws_nat_gateway.public](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/nat_gateway) | resource |
+| [aws_route.peering_accepter](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/route) | resource |
+| [aws_route.peering_requester](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/route) | resource |
+| [aws_route.private](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/route) | resource |
+| [aws_route.public](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/route) | resource |
+| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/route53_zone) | resource |
+| [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/route_table) | resource |
+| [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/route_table) | resource |
+| [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/route_table_association) | resource |
+| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/subnet) | resource |
+| [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/subnet) | resource |
+| [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/vpc) | resource |
+| [aws_vpc_peering_connection.this](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/vpc_peering_connection) | resource |
+| [aws_vpc_peering_connection_accepter.peer](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/vpc_peering_connection_accepter) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/data-sources/availability_zones) | data source |
+| [aws_iam_policy_document.flow_log](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/data-sources/region) | data source |
+| [aws_vpc_peering_connection.this](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/data-sources/vpc_peering_connection) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | CIDR block of the VPC. The prefix length of the CIDR block must be 18 or less | `string` | n/a | yes |
+| <a name="input_dns_zone"></a> [dns\_zone](#input\_dns\_zone) | The DNS Zone host name | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | The environment name to use for the deployment | `string` | n/a | yes |
+| <a name="input_flow_log_enabled"></a> [flow\_log\_enabled](#input\_flow\_log\_enabled) | Should flow logs be enabled | `bool` | `false` | no |
+| <a name="input_name"></a> [name](#input\_name) | Deployment name | `string` | n/a | yes |
+| <a name="input_vpc_peering_config_accepter"></a> [vpc\_peering\_config\_accepter](#input\_vpc\_peering\_config\_accepter) | VPC Peering configuration accepter | <pre>list(object({<br>    name                   = string<br>    peer_owner_id          = string<br>    destination_cidr_block = string<br>  }))</pre> | `[]` | no |
+| <a name="input_vpc_peering_config_requester"></a> [vpc\_peering\_config\_requester](#input\_vpc\_peering\_config\_requester) | VPC Peering configuration requester | <pre>list(object({<br>    name                   = string<br>    peer_owner_id          = string<br>    peer_vpc_id            = string<br>    destination_cidr_block = string<br>  }))</pre> | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_private_subnets_ids"></a> [private\_subnets\_ids](#output\_private\_subnets\_ids) | The ids of the of private subnets created by this module |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The id of the VPC created by this module |

--- a/modules/aws/eks-core/flow-log.tf
+++ b/modules/aws/eks-core/flow-log.tf
@@ -1,0 +1,86 @@
+data "aws_region" "current" {}
+
+resource "aws_flow_log" "this" {
+  for_each = {
+    for s in ["flowlog"] :
+    s => s
+    if var.flow_log_enabled
+  }
+
+  iam_role_arn    = aws_iam_role.flow_log[each.key].arn
+  log_destination = aws_cloudwatch_log_group.this[each.key].arn
+  traffic_type    = "ALL"
+  vpc_id          = aws_vpc.this.id
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  for_each = {
+    for s in ["flowlog"] :
+    s => s
+    if var.flow_log_enabled
+  }
+  name = "${data.aws_region.current.name}-${var.environment}-${var.name}-flowlogs"
+}
+
+resource "aws_iam_role" "flow_log" {
+  for_each = {
+    for s in ["flowlog"] :
+    s => s
+    if var.flow_log_enabled
+  }
+  name = "${data.aws_region.current.name}-${var.environment}-${var.name}-cloudwatch"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "vpc-flow-logs.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+data "aws_iam_policy_document" "flow_log" {
+  for_each = {
+    for s in ["flowlog"] :
+    s => s
+    if var.flow_log_enabled
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams"
+    ]
+    resources = ["${aws_cloudwatch_log_group.this[each.key].arn}:log-stream:*"]
+  }
+}
+
+resource "aws_iam_policy" "flow_log" {
+  for_each = {
+    for s in ["flowlog"] :
+    s => s
+    if var.flow_log_enabled
+  }
+  name   = "${data.aws_region.current.name}-${var.environment}-${var.name}-cloudwatch"
+  policy = data.aws_iam_policy_document.flow_log[each.key].json
+}
+
+resource "aws_iam_role_policy_attachment" "permissions" {
+  for_each = {
+    for s in ["flowlog"] :
+    s => s
+    if var.flow_log_enabled
+  }
+  policy_arn = aws_iam_policy.flow_log[each.key].arn
+  role       = aws_iam_role.flow_log[each.key].name
+}

--- a/modules/aws/eks-core/main.tf
+++ b/modules/aws/eks-core/main.tf
@@ -1,0 +1,29 @@
+/**
+  * # Core
+  *
+  * This module is used to configure an opinionated VPC for XKS.
+  *
+  */
+
+terraform {
+  required_version = "0.15.3"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.63.0"
+    }
+  }
+}
+
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  global_tags = {
+    Name        = var.name
+    Environment = var.environment
+    Module      = "core"
+  }
+}

--- a/modules/aws/eks-core/outputs.tf
+++ b/modules/aws/eks-core/outputs.tf
@@ -1,0 +1,14 @@
+output "vpc_id" {
+  description = "The id of the VPC created by this module"
+  value       = aws_vpc.this.id
+}
+
+output "private_subnets_ids" {
+  description = "The ids of the of private subnets created by this module"
+  value = [
+    for subnet in aws_subnet.private :
+    subnet.id
+    if contains(local.private_subnets.*.cidr_block, subnet.cidr_block)
+  ]
+}
+

--- a/modules/aws/eks-core/route53.tf
+++ b/modules/aws/eks-core/route53.tf
@@ -1,0 +1,15 @@
+resource "aws_route53_zone" "this" {
+  name = var.dns_zone
+
+  for_each = {
+    for s in ["zone"] :
+    s => s
+  }
+
+  tags = merge(
+    local.global_tags,
+    {
+      Name = var.dns_zone
+    },
+  )
+}

--- a/modules/aws/eks-core/variables.tf
+++ b/modules/aws/eks-core/variables.tf
@@ -1,0 +1,46 @@
+variable "environment" {
+  description = "The environment name to use for the deployment"
+  type        = string
+}
+
+variable "name" {
+  description = "Deployment name"
+  type        = string
+}
+
+variable "dns_zone" {
+  description = "The DNS Zone host name"
+  type        = string
+}
+
+variable "cidr_block" {
+  description = "CIDR block of the VPC. The prefix length of the CIDR block must be 18 or less"
+  type        = string
+}
+
+variable "flow_log_enabled" {
+  description = "Should flow logs be enabled"
+  type        = bool
+  default     = false
+}
+
+variable "vpc_peering_config_requester" {
+  description = "VPC Peering configuration requester"
+  type = list(object({
+    name                   = string
+    peer_owner_id          = string
+    peer_vpc_id            = string
+    destination_cidr_block = string
+  }))
+  default = []
+}
+
+variable "vpc_peering_config_accepter" {
+  description = "VPC Peering configuration accepter"
+  type = list(object({
+    name                   = string
+    peer_owner_id          = string
+    destination_cidr_block = string
+  }))
+  default = []
+}

--- a/validation/aws/eks-core/main.tf
+++ b/validation/aws/eks-core/main.tf
@@ -1,0 +1,14 @@
+terraform {}
+
+provider "aws" {
+  region = "eu-west-1"
+}
+
+module "core" {
+  source = "../../../modules/aws/eks-core"
+
+  environment = "dev"
+  name        = "eks-core"
+  cidr_block  = "10.0.0.0/18"
+  dns_zone    = "foobar.com"
+}


### PR DESCRIPTION
In order to be able to add network ACLs to the core setup of EKS, an EKS opinionated core module was created and the previous "generic" core module was renamed to "generic-core". Names can of course be discussed here. The new EKS opinionated core module contains copied code from "generic-core" . It would however be possible to refer to the "generic-core" module from this module but the reason for not doing that is that we allow the different code bases to diverge if needed. Could of course also be discussed.