### PR TITLE
Change VPA storage from prometheus to checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#517](https://github.com/XenitAB/terraform-modules/pull/517) Change VPA storage from prometheus to checkpoint.
+
 ## 2022.01.2
 
 ### Added

--- a/modules/kubernetes/vpa/templates/vpa-values.yaml.tpl
+++ b/modules/kubernetes/vpa/templates/vpa-values.yaml.tpl
@@ -1,23 +1,9 @@
 priorityClassName: platform-medium
 
 recommender:
-  # recommender.enabled -- If true, the vpa recommender component will be installed.
-  enabled: true
-  # recommender.extraArgs -- A set of key-value flags to be passed to the recommender
   extraArgs:
     pod-recommendation-min-cpu-millicores: 15
     pod-recommendation-min-memory-mb: 24
-    prometheus-address: http://prometheus-operated.prometheus.svc.cluster.local:9090
-    storage: prometheus
-    # How much time back prometheus have to be queried to get historical metrics
-    # history-length: 8
-  image:
-    # recommender.image.repository -- The location of the recommender image
-    repository: k8s.gcr.io/autoscaling/vpa-recommender
-    # recommender.image.pullPolicy -- The pull policy for the recommender image. Recommend not changing this
-    pullPolicy: IfNotPresent
-    # recommender.image.tag -- Overrides the image tag whose default is the chart appVersion
-    tag: ""
   resources:
     limits:
       cpu: 200m
@@ -27,9 +13,7 @@ recommender:
       memory: 250Mi
 
 updater:
-  # updater.enabled -- If true, the updater component will be deployed
   enabled: false
 
 admissionController:
-  # admissionController.enabled -- If true, will install the admission-controller component of vpa
   enabled: false


### PR DESCRIPTION
Enabling agent mode in Prometheus removes the ability to run queries. The current VPA configuration is setup to use cadvisor metrics from Promtheus to calculate its recommendation. This is not possible anymore. The fix right now is to switch to the default checkpoint method which stores metrics in a CRD.

We should in the future have a look at if this is the best solution, or if there is a better one out there.