### PR TITLE
Fix nginx ingress service monitor selector when running multiple controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#517](https://github.com/XenitAB/terraform-modules/pull/517) Change VPA storage from prometheus to checkpoint.
 
+### Fixed
+
+- [#519](https://github.com/XenitAB/terraform-modules/pull/519) Fix nginx ingress service monitor selector when running multiple controllers.
+
 ## 2022.01.2
 
 ### Added

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -85,6 +85,9 @@ controller:
 
   metrics:
     enabled: true
+    service:
+      labels:
+        function: metrics
   %{~ if provider == "aws" && internal_load_balancer ~}
     port: 10354
 

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.36
+version: 0.1.37
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/templates/monitors.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/templates/monitors.yaml
@@ -71,8 +71,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: controller
-      app.kubernetes.io/instance: ingress-nginx
       app.kubernetes.io/name: ingress-nginx
+      function: metrics
 {{- if .Values.enabledMonitors.aadPodIdentity }}
 ---
 apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
This change fixes the labels and label selector for the metrics services. Issues occur when private/public controllers are enabled, which cause the service monitor label selector to fail. This fix changes the labels so that both metrics services can be selected with the same selector.

Fixes #518 