### PR TITLE
Add network ACLs to eks-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#530](https://github.com/XenitAB/terraform-modules/pull/530) Add networks ACLs to `eks-core` to lock down access to the `private` and `public` subnets.
+
 ## 2022.01.4
 
 ### Changed

--- a/modules/aws/eks-core/README.md
+++ b/modules/aws/eks-core/README.md
@@ -31,6 +31,8 @@ No modules.
 | [aws_iam_role_policy_attachment.permissions](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_internet_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/internet_gateway) | resource |
 | [aws_nat_gateway.public](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/nat_gateway) | resource |
+| [aws_network_acl.private](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/network_acl) | resource |
+| [aws_network_acl.public](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/network_acl) | resource |
 | [aws_route.peering_accepter](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/route) | resource |
 | [aws_route.peering_requester](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/route) | resource |
 | [aws_route.private](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/route) | resource |


### PR DESCRIPTION
The NLBs in front of the K8S cluster are running in the `public` and `private` subnets. In order restrict access to the NLBs, this PR adds Network ACLs to the subnets they are running in. The reason for using Network ACLs is that it is not possible to associate NLBs with security groups.