### PR TITLE
azure: Add prefix to role definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#531](https://github.com/XenitAB/terraform-modules/pull/531) Make prefix configurable for Azure role definition names
+
 ## 2022.01.4
 
 ### Changed
@@ -15,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- [#513](https://github.com/XenitAB/terraform-modules/pull/513) EKS opinionated module ```eks-core``` added.
+- [#513](https://github.com/XenitAB/terraform-modules/pull/513) EKS opinionated module `eks-core` added.
 
 ## 2022.01.3
 

--- a/modules/azure/core/README.md
+++ b/modules/azure/core/README.md
@@ -46,6 +46,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_azure_ad_group_prefix"></a> [azure\_ad\_group\_prefix](#input\_azure\_ad\_group\_prefix) | Prefix for Azure AD Groups | `string` | `"az"` | no |
+| <a name="input_azure_role_definition_prefix"></a> [azure\_role\_definition\_prefix](#input\_azure\_role\_definition\_prefix) | Prefix for Azure Role Definition names | `string` | `"role"` | no |
 | <a name="input_enable_storage_account"></a> [enable\_storage\_account](#input\_enable\_storage\_account) | Should a storage account be created in the core resource group? (used for diagnostics) | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment name to use for the deploy | `string` | n/a | yes |
 | <a name="input_group_name_separator"></a> [group\_name\_separator](#input\_group\_name\_separator) | Separator for group names | `string` | `"-"` | no |

--- a/modules/azure/core/delegate-service-endpoint-join.tf
+++ b/modules/azure/core/delegate-service-endpoint-join.tf
@@ -1,5 +1,5 @@
 resource "azurerm_role_definition" "service_endpoint_join" {
-  name  = "role-${var.environment}-${var.location_short}-${var.name}-serviceEndpointJoin"
+  name  = "${var.azure_role_definition_prefix}-${var.environment}-${var.location_short}-${var.name}-serviceEndpointJoin"
   scope = azurerm_virtual_network.this.id
 
   permissions {

--- a/modules/azure/core/variables.tf
+++ b/modules/azure/core/variables.tf
@@ -71,6 +71,12 @@ variable "azure_ad_group_prefix" {
   default     = "az"
 }
 
+variable "azure_role_definition_prefix" {
+  description = "Prefix for Azure Role Definition names"
+  type        = string
+  default     = "role"
+}
+
 variable "enable_storage_account" {
   description = "Should a storage account be created in the core resource group? (used for diagnostics)"
   type        = bool

--- a/modules/azure/hub/README.md
+++ b/modules/azure/hub/README.md
@@ -48,6 +48,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_azure_ad_group_prefix"></a> [azure\_ad\_group\_prefix](#input\_azure\_ad\_group\_prefix) | Prefix for Azure AD Groups | `string` | `"az"` | no |
+| <a name="input_azure_role_definition_prefix"></a> [azure\_role\_definition\_prefix](#input\_azure\_role\_definition\_prefix) | Prefix for Azure Role Definition names | `string` | `"role"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment (short name) to use for the deploy | `string` | n/a | yes |
 | <a name="input_group_name_separator"></a> [group\_name\_separator](#input\_group\_name\_separator) | Separator for group names | `string` | `"-"` | no |
 | <a name="input_location_short"></a> [location\_short](#input\_location\_short) | The location shortname for the subscription | `string` | n/a | yes |

--- a/modules/azure/hub/main.tf
+++ b/modules/azure/hub/main.tf
@@ -114,7 +114,7 @@ resource "azurerm_virtual_network_peering" "this" {
 }
 
 resource "azurerm_role_definition" "service_endpoint_join" {
-  name  = "role-${var.environment}-${var.location_short}-${var.name}-serviceEndpointJoin"
+  name  = "${var.azure_role_definition_prefix}-${var.environment}-${var.location_short}-${var.name}-serviceEndpointJoin"
   scope = azurerm_virtual_network.this.id
 
   permissions {

--- a/modules/azure/hub/variables.tf
+++ b/modules/azure/hub/variables.tf
@@ -59,3 +59,9 @@ variable "azure_ad_group_prefix" {
   type        = string
   default     = "az"
 }
+
+variable "azure_role_definition_prefix" {
+  description = "Prefix for Azure Role Definition names"
+  type        = string
+  default     = "role"
+}


### PR DESCRIPTION
The azure_role_definition names needs to be unique for each Azure
tenant, which means if two different landing zones are using the same
everything else they will collide causing issues for the second one.

This fix should be backward compatible, only moving 'role' from being ha
hard coded string into a default variable that new landing zones will be
able to change if needed.