### PR TITLE
azure/core: Fix bug in route table association

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- [#532](https://github.com/XenitAB/terraform-modules/pull/532) Fix bug in route table association (does **not** affect XKF by default)
+- [#532](https://github.com/XenitAB/terraform-modules/pull/532) [Breaking] Fix bug in route table association (does **not** affect XKF by default)
 
 ## 2022.01.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#531](https://github.com/XenitAB/terraform-modules/pull/531) Make prefix configurable for Azure role definition names
 
+### Fixed
+
+- [#532](https://github.com/XenitAB/terraform-modules/pull/532) Fix bug in route table association (does **not** affect XKF by default)
+
 ## 2022.01.4
 
 ### Changed

--- a/modules/azure/core/routes.tf
+++ b/modules/azure/core/routes.tf
@@ -43,8 +43,8 @@ resource "azurerm_route" "not_virtual_appliance" {
 
 resource "azurerm_subnet_route_table_association" "this" {
   for_each = {
-    for route in local.routes :
-    route.name => route
+    for route in var.route_config :
+    route.subnet_name => route
   }
 
   subnet_id      = azurerm_subnet.this["sn-${var.environment}-${var.location_short}-${var.name}-${each.value.subnet_name}"].id


### PR DESCRIPTION
This is **not** used by XKF by default and does not affect it if routes haven't been configured.

We were looping through var.routes which contains a list of all the
route+subnet combinations, which would work for the first route but not
for the second and third because the subnet already had a route table
associated.

With this fix, we are moving the configuration to use the correct
var.route_config instead which is the same as the route_tabe
configuration.

This shouldn't cause any big issue, but will temporarily remove the
route association from the subnet and then add it again. But after this
fix, we will be able to use multiple routes for a route table - as god
intended it to be. :^)