### PR TITLE
Add podAntiAffinity to Ingress-nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-- [#540](https://github.com/XenitAB/terraform-modules/pull/540) Add podAntiAffinity to spread pods on nodes based on avalibility zones.
+### Fixed
+
+- [#540](https://github.com/XenitAB/terraform-modules/pull/540) Add podAntiAffinity to Ingress-nginx.
 
 ## 2022.02.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+- [#540](https://github.com/XenitAB/terraform-modules/pull/540) Add podAntiAffinity to spread pods on nodes based on avalibility zones.
+
 ## 2022.02.1
 
 ### Added

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -118,8 +118,9 @@ controller:
   readinessProbe:
     httpGet:
       port: 10354
+  %{~ endif ~}
 
-  affinity:
+affinity:
     podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 100
@@ -138,4 +139,3 @@ controller:
               values:
               - controller
           topologyKey: "topology.kubernetes.io/zone"
-  %{~ endif ~}

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -120,7 +120,7 @@ controller:
       port: 10354
   %{~ endif ~}
 
-affinity:
+  affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - podAffinityTerm:

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -118,4 +118,24 @@ controller:
   readinessProbe:
     httpGet:
       port: 10354
+
+  affinity:
+    podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+        - labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - ingress-nginx
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+              - ingress-nginx
+            - key: app.kubernetes.io/component
+              operator: In
+              values:
+              - controller
+          topologyKey: "topology.kubernetes.io/zone"
   %{~ endif ~}

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -122,20 +122,13 @@ controller:
 
 affinity:
     podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-        - labelSelector:
-            matchExpressions:
-            - key: app.kubernetes.io/name
-              operator: In
-              values:
-              - ingress-nginx
-            - key: app.kubernetes.io/instance
-              operator: In
-              values:
-              - ingress-nginx
-            - key: app.kubernetes.io/component
-              operator: In
-              values:
-              - controller
-          topologyKey: "topology.kubernetes.io/zone"
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                    - ingress-nginx
+            topologyKey: topology.kubernetes.io/zone
+          weight: 100


### PR DESCRIPTION
Edvin saw an issue with the pods being assigned to nodes in the same availability zones, this would result in if a zone goes down, so will our pods. So I add podAntiAffinity to spread pods on nodes based on availability  zones.

First time configuring this, please consider anything.

Fixes #538 <!-- This will close the issue automatically when you merge -->
