### PR TITLE
Increase VolumeSize for Prometheus running in agent mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#549](https://github.com/XenitAB/terraform-modules/pull/549) Add resource requests & limits for goldilocks.
 - [#548](https://github.com/XenitAB/terraform-modules/pull/548) Enable grafana-agent in Prometheus.
 - [#551](https://github.com/XenitAB/terraform-modules/pull/551) Fix pod label selector for Prometheus monitor.
+- [#552](https://github.com/XenitAB/terraform-modules/pull/552) Increase VolumeSize for Prometheus running in agent mode.
 
 ## 2022.02.3
 

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.38
+version: 0.1.39
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/values.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/values.yaml
@@ -31,7 +31,7 @@ resources:
 
 volumeClaim:
   storageClassName: default
-  size: 5Gi
+  size: 10Gi
 
 remoteWrite:
   authenticated: true


### PR DESCRIPTION
We need to set prometheus disk to 10Gi to lower the amount of issues we have with a growing WAL in our prometheus instances that is running in agent mode.
