### PR TITLE
Remove secret and configmap data collection form kube state metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#549](https://github.com/XenitAB/terraform-modules/pull/549) Add resource requests & limits for goldilocks.
 - [#548](https://github.com/XenitAB/terraform-modules/pull/548) Enable grafana-agent in Prometheus.
+
+### Changed
+
+- [#553](https://github.com/XenitAB/terraform-modules/pull/553) Remove Secrets and ConfigMaps from collected Kube State Metrics resources.
+
+### Fixed
+
 - [#551](https://github.com/XenitAB/terraform-modules/pull/551) Fix pod label selector for Prometheus monitor.
 
 ## 2022.02.3

--- a/modules/kubernetes/prometheus/templates/values.yaml.tpl
+++ b/modules/kubernetes/prometheus/templates/values.yaml.tpl
@@ -31,11 +31,11 @@ kube-state-metrics:
     enabled: false
   metricLabelsAllowlist:
     - "namespaces=[xkf.xenit.io/kind]"
-  %{ if vpa_enabled }
-  # specificly add verticalpodautoscalers to collectors
   collectors:
+    # Disable collection of configmaps and secrets to reduce amount of metrics
+    #- configmaps
+    #- secrets
     - certificatesigningrequests
-    - configmaps
     - cronjobs
     - daemonsets
     - deployments
@@ -55,12 +55,13 @@ kube-state-metrics:
     - replicasets
     - replicationcontrollers
     - resourcequotas
-    - secrets
     - services
     - statefulsets
     - storageclasses
     - validatingwebhookconfigurations
     - volumeattachments
+  # Specificly add verticalpodautoscalers to collectors
+  %{ if vpa_enabled }
     - verticalpodautoscalers # not a default resource, see also: https://github.com/kubernetes/kube-state-metrics#enabling-verticalpodautoscalers
   %{ endif }
   prometheus:


### PR DESCRIPTION
This change removes the collection of secrets and configmaps from kube state metrics. My reasoning is that we do not use these metrics at all so there is no real point of collecting them. They only create a large amount of data which has to be remotely sent and received.