### PR TITLE
Add labels to gatekeeper namespace

### DIFF
--- a/modules/kubernetes/opa-gatekeeper/main.tf
+++ b/modules/kubernetes/opa-gatekeeper/main.tf
@@ -113,6 +113,8 @@ resource "kubernetes_namespace" "this" {
       name                             = "gatekeeper-system"
       "admission.gatekeeper.sh/ignore" = "no-self-managing"
       "xkf.xenit.io/kind"              = "platform"
+      "control-plane"                  = "controller-manager"
+      "gatekeeper.sh/system"           = "yes"
     }
     name = "gatekeeper-system"
   }


### PR DESCRIPTION
Adding labels to Gatekeeper-system namespace to fix an issue where updating the helm charts didn't work as expected.

Adding label
```terraform
      "control-plane"                  = "controller-manager"
      "gatekeeper.sh/system"           = "yes"
````

Fixes #529