### PR TITLE
Update Ingress Nginx version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#565](https://github.com/XenitAB/terraform-modules/pull/565) [Breaking] Update Ingress Nginx major version.
+
 ### Fixed
 
 - [#570](https://github.com/XenitAB/terraform-modules/pull/570) Only add network policy for Datadog / Grafana-Agent if default deny is true

--- a/modules/kubernetes/ingress-nginx/main.tf
+++ b/modules/kubernetes/ingress-nginx/main.tf
@@ -40,7 +40,7 @@ resource "helm_release" "ingress_nginx" {
   chart       = "ingress-nginx"
   name        = "ingress-nginx"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "3.40.0"
+  version     = "4.0.17"
   max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     http_snippet           = var.http_snippet
@@ -57,7 +57,7 @@ resource "helm_release" "ingress_nginx" {
     linkerd_enabled           = var.linkerd_enabled
     datadog_enabled           = var.datadog_enabled
     allow_snippet_annotations = var.allow_snippet_annotations
-    default_ingress_class     = false
+    default_ingress_class     = true
   })]
 }
 
@@ -72,7 +72,7 @@ resource "helm_release" "ingress_nginx_public" {
   chart       = "ingress-nginx"
   name        = "ingress-nginx-public"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "3.40.0"
+  version     = "4.0.17"
   max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     http_snippet           = var.http_snippet
@@ -104,7 +104,7 @@ resource "helm_release" "ingress_nginx_private" {
   chart       = "ingress-nginx"
   name        = "ingress-nginx-private"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "3.40.0"
+  version     = "4.0.17"
   max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     http_snippet           = var.http_snippet

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -3,12 +3,13 @@ controller:
 
   priorityClassName: platform-medium
 
-  ingressClass: ${ingress_class}
-
-  # https://github.com/kubernetes/ingress-nginx/issues/5593#issuecomment-647538272
   ingressClassResource:
-    enabled: true
+    name: ${ingress_class}
     default: ${default_ingress_class}
+    controllerValue: "k8s.io/ingress-${ingress_class}"
+  
+  # Should eventually be removed as ingress class annotations are deprecated
+  ingressClass: ${ingress_class}
 
   %{~ if provider == "aws" ~}
   # Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.


### PR DESCRIPTION
This looks like a major change from the outside but hopefully is not one. The main difference is dropping support for `networking.k8s.io/v1beta` and switching to `networking.k8s.io/v1`. The consequence of this is dropping support for clusters older than 1.19, which we are not running anyway.

We are going to have to test the upgrade before merging this just to be sure. I have also done some reading in the Helm chart and project changelogs to see if there are any obvious issues.
https://github.com/kubernetes/ingress-nginx/blob/main/Changelog.md
https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/CHANGELOG.md

One issue is the change from ingress class annotations to the IngressClass resource. We are already create an IngressClass resource but do not enforce the use of a specific default class. This has to be verified that the controller still works without an ingress class. Additionally it seems like the permissions changed to be cluster wide which has caused issues for some people.
https://github.com/kubernetes/ingress-nginx/pull/7578

There seems to be a change in the Helm chart which adds an option for internal/external load balancers. I do not know how that will affect our current method of configuring this.
https://github.com/kubernetes/ingress-nginx/pull/7806

The default annotation word block list has been changed to an empty string. Not really sure what the current value is in our version but this has to be verified to work in the places we use lua. We should probably just follow the documentation recommendations.
https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#annotation-value-word-blocklist