### PR TITLE
aks/eks core: fix network policy bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+
+- [#570](https://github.com/XenitAB/terraform-modules/pull/570) Only add network policy for Datadog / Grafana-Agent if default deny is true
+
 ## 2022.02.4
 
 ### Added
@@ -49,7 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- [#522](https://github.com/XenitAB/terraform-modules/pull/522) Add  networkpolicy for datadog and grafana-agent to tenant namespace.
+- [#522](https://github.com/XenitAB/terraform-modules/pull/522) Add networkpolicy for datadog and grafana-agent to tenant namespace.
 
 ### Changed
 

--- a/modules/kubernetes/aks-core/networkpolicy.tf
+++ b/modules/kubernetes/aks-core/networkpolicy.tf
@@ -2,7 +2,7 @@ resource "kubernetes_network_policy" "allow_egress_datadog" {
   for_each = {
     for ns in var.namespaces :
     ns.name => ns
-    if var.datadog_enabled
+    if var.datadog_enabled && var.kubernetes_network_policy_default_deny
   }
 
   metadata {
@@ -45,7 +45,7 @@ resource "kubernetes_network_policy" "allow_egress_ingress_grafana_agent" {
   for_each = {
     for ns in var.namespaces :
     ns.name => ns
-    if var.grafana_agent_enabled
+    if var.grafana_agent_enabled && var.kubernetes_network_policy_default_deny
   }
 
   metadata {

--- a/modules/kubernetes/eks-core/networkpolicy.tf
+++ b/modules/kubernetes/eks-core/networkpolicy.tf
@@ -2,7 +2,7 @@ resource "kubernetes_network_policy" "allow_egress_datadog" {
   for_each = {
     for ns in var.namespaces :
     ns.name => ns
-    if var.datadog_enabled
+    if var.datadog_enabled && var.kubernetes_network_policy_default_deny
   }
 
   metadata {
@@ -45,7 +45,7 @@ resource "kubernetes_network_policy" "allow_egress_ingress_grafana_agent" {
   for_each = {
     for ns in var.namespaces :
     ns.name => ns
-    if var.grafana_agent_enabled
+    if var.grafana_agent_enabled && var.kubernetes_network_policy_default_deny
   }
 
   metadata {


### PR DESCRIPTION
For cluster using var.kubernetes_network_policy_default_deny = false,
these new network policies are causing issues (all traffic is blocked).

Fixes #569