### PR TITLE
Update external dns version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - [#565](https://github.com/XenitAB/terraform-modules/pull/565) [Breaking] Update Ingress Nginx major version.
+- [#573](https://github.com/XenitAB/terraform-modules/pull/573) Update External DNS version.
 
 ### Fixed
 

--- a/modules/kubernetes/external-dns/main.tf
+++ b/modules/kubernetes/external-dns/main.tf
@@ -19,9 +19,6 @@ terraform {
   }
 }
 
-locals {
-}
-
 resource "kubernetes_namespace" "this" {
   metadata {
     labels = {
@@ -37,7 +34,7 @@ resource "helm_release" "external_dns" {
   chart       = "external-dns"
   name        = "external-dns"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "6.0.2"
+  version     = "6.1.6"
   max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     provider     = var.dns_provider,


### PR DESCRIPTION
This change updates external-dns. A major difference is that it now requires Kubernetes 1.19 or higher.