### PR TITLE
Update cert-manager version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - [#593](https://github.com/XenitAB/terraform-modules/pull/593) Change Prometheus remote write settings to align with best practices.
+- [#574](https://github.com/XenitAB/terraform-modules/pull/574) [Breaking] Update cert-manager version.
 
 ## 2022.03.2
 

--- a/modules/kubernetes/cert-manager/main.tf
+++ b/modules/kubernetes/cert-manager/main.tf
@@ -38,7 +38,7 @@ resource "helm_release" "cert_manager" {
   chart       = "cert-manager"
   name        = "cert-manager"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "v1.6.1"
+  version     = "v1.7.1"
   max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     provider   = var.cloud_provider,


### PR DESCRIPTION
The major change here is that all CRD versions other than v1 are removed. We need to do a quick inventory och clusters to determine that old versions are not being used. Probably not the case as v1 has been present for a while but we still need to make sure.