### PR TITLE
Node local dns tenant network networkpolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#570](https://github.com/XenitAB/terraform-modules/pull/570) Only add network policy for Datadog / Grafana-Agent if default deny is true
 - [#582](https://github.com/XenitAB/terraform-modules/pull/582) Add the coreDNS ip to tenant networkpolicy CIDR block to work with node-local-dns.
+  Use variable for node-local-dns.
 
 ## 2022.02.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - [#570](https://github.com/XenitAB/terraform-modules/pull/570) Only add network policy for Datadog / Grafana-Agent if default deny is true
+- [#582](https://github.com/XenitAB/terraform-modules/pull/582) Add the coreDNS ip to tenant networkpolicy CIDR block to work with node-local-dns.
 
 ## 2022.02.4
 

--- a/modules/kubernetes/aks-core/README.md
+++ b/modules/kubernetes/aks-core/README.md
@@ -86,8 +86,6 @@ This module is used to create AKS clusters.
 | [kubernetes_storage_class.zrs_standard](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/storage_class) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/data-sources/resource_group) | data source |
-| [kubernetes_namespace.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/data-sources/namespace) | data source |
-| [kubernetes_service.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/data-sources/service) | data source |
 
 ## Inputs
 

--- a/modules/kubernetes/aks-core/README.md
+++ b/modules/kubernetes/aks-core/README.md
@@ -86,6 +86,8 @@ This module is used to create AKS clusters.
 | [kubernetes_storage_class.zrs_standard](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/resources/storage_class) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/data-sources/resource_group) | data source |
+| [kubernetes_namespace.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/data-sources/namespace) | data source |
+| [kubernetes_service.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/data-sources/service) | data source |
 
 ## Inputs
 

--- a/modules/kubernetes/aks-core/namespace.tf
+++ b/modules/kubernetes/aks-core/namespace.tf
@@ -7,19 +7,6 @@ resource "kubernetes_namespace" "service_accounts" {
   }
 }
 
-data "kubernetes_namespace" "this" {
-  metadata {
-    name = "kube-system"
-  }
-}
-
-data "kubernetes_service" "this" {
-  metadata {
-    name      = "kube-dns"
-    namespace = data.kubernetes_namespace.this.metadata[0].name
-  }
-}
-
 resource "kubernetes_service_account" "tenant" {
   for_each = { for ns in var.namespaces : ns.name => ns }
 
@@ -105,7 +92,7 @@ resource "kubernetes_network_policy" "tenant" {
           }
         }
         ip_block {
-          cidr = "${data.kubernetes_service.this.spec[0].cluster_ip}/32"
+          cidr = "10.0.0.10/32"
         }
       }
 

--- a/modules/kubernetes/aks-core/namespace.tf
+++ b/modules/kubernetes/aks-core/namespace.tf
@@ -91,6 +91,8 @@ resource "kubernetes_network_policy" "tenant" {
             k8s-app = "kube-dns"
           }
         }
+      }
+      to {
         ip_block {
           cidr = "10.0.0.10/32"
         }

--- a/modules/kubernetes/aks-core/namespace.tf
+++ b/modules/kubernetes/aks-core/namespace.tf
@@ -7,6 +7,19 @@ resource "kubernetes_namespace" "service_accounts" {
   }
 }
 
+data "kubernetes_namespace" "this" {
+  metadata {
+    name = "kube-system"
+  }
+}
+
+data "kubernetes_service" "this" {
+  metadata {
+    name      = "kube-dns"
+    namespace = data.kubernetes_namespace.this.metadata[0].name
+  }
+}
+
 resource "kubernetes_service_account" "tenant" {
   for_each = { for ns in var.namespaces : ns.name => ns }
 
@@ -92,7 +105,7 @@ resource "kubernetes_network_policy" "tenant" {
           }
         }
         ip_block {
-          cidr = "10.0.0.10/32"
+          cidr = "${data.kubernetes_service.this.spec[0].cluster_ip}/32"
         }
       }
 

--- a/modules/kubernetes/aks-core/namespace.tf
+++ b/modules/kubernetes/aks-core/namespace.tf
@@ -91,11 +91,18 @@ resource "kubernetes_network_policy" "tenant" {
             k8s-app = "kube-dns"
           }
         }
+        ip_block {
+          cidr = "10.0.0.10/32"
+        }
       }
 
       ports {
         port     = 53
         protocol = "UDP"
+      }
+      ports {
+        port     = 53
+        protocol = "TCP"
       }
     }
 

--- a/modules/kubernetes/node-local-dns/README.md
+++ b/modules/kubernetes/node-local-dns/README.md
@@ -15,7 +15,6 @@ This module is used to add [`node-local-dns`](https://kubernetes.io/docs/tasks/a
 | Name | Version |
 |------|---------|
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.3.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.6.1 |
 
 ## Modules
 
@@ -26,12 +25,12 @@ No modules.
 | Name | Type |
 |------|------|
 | [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/2.3.0/docs/resources/release) | resource |
-| [kubernetes_namespace.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/data-sources/namespace) | data source |
-| [kubernetes_service.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.6.1/docs/data-sources/service) | data source |
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_dns_ip"></a> [dns\_ip](#input\_dns\_ip) | Central DNS IP | `string` | `"10.0.0.10"` | no |
 
 ## Outputs
 

--- a/modules/kubernetes/node-local-dns/main.tf
+++ b/modules/kubernetes/node-local-dns/main.tf
@@ -19,27 +19,14 @@ terraform {
   }
 }
 
-data "kubernetes_namespace" "this" {
-  metadata {
-    name = "kube-system"
-  }
-}
-
-data "kubernetes_service" "this" {
-  metadata {
-    name      = "kube-dns"
-    namespace = data.kubernetes_namespace.this.metadata[0].name
-  }
-}
-
 resource "helm_release" "this" {
   chart       = "${path.module}/charts/node-local-dns"
   name        = "node-local-dns"
-  namespace   = data.kubernetes_namespace.this.metadata[0].name
+  namespace   = "kube-system"
   max_history = 3
 
   set {
     name  = "dnsServer"
-    value = data.kubernetes_service.this.spec[0].cluster_ip
+    value = var.dns_ip
   }
 }

--- a/modules/kubernetes/node-local-dns/variables.tf
+++ b/modules/kubernetes/node-local-dns/variables.tf
@@ -1,1 +1,5 @@
-
+variable "dns_ip" {
+    description = "Central DNS IP"
+    type = string
+    default = "10.0.0.10"
+}

--- a/modules/kubernetes/node-local-dns/variables.tf
+++ b/modules/kubernetes/node-local-dns/variables.tf
@@ -1,5 +1,5 @@
 variable "dns_ip" {
-    description = "Central DNS IP"
-    type = string
-    default = "10.0.0.10"
+  description = "Central DNS IP"
+  type        = string
+  default     = "10.0.0.10"
 }


### PR DESCRIPTION
After a few weeks of usage of node-local-dns we started to see issues with talking to the dns.
I don't know why this happens but after reading up on node-local-dns I understand why we need this rule.

This IP is very specific and I don't add any logic around it since it's the real IP of coreDNS service.
