### PR TITLE
Use annotation-value-word-blocklist by default in Ingress-nginx

### DIFF
--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -46,7 +46,7 @@ controller:
       ${http_snippet}
     %{~ endif ~}
     allow-snippet-annotations: ${allow_snippet_annotations}
-    %{~ if !allow_snippet_annotations ~}
+    %{~ if allow_snippet_annotations ~}
     annotation-value-word-blocklist: load_module,lua_package,_by_lua,location,root,proxy_pass,serviceaccount,{,},',\
     %{~ endif ~}
 


### PR DESCRIPTION

Fixes #580 