### PR TITLE
Upgrade Azure AD provider to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - [#587](https://github.com/XenitAB/terraform-modules/pull/587) Fix space error in grafana-agent podLogs
+- [#585](https://github.com/XenitAB/terraform-modules/pull/585) [Breaking] Upgrade Azure AD provider to v2
 
 ## 2022.03.1
 

--- a/modules/aws/eks-global/README.md
+++ b/modules/aws/eks-global/README.md
@@ -4,14 +4,14 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 0.15.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.63.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 1.6.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.18.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 3.63.0 |
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 1.6.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.18.0 |
 
 ## Modules
 
@@ -31,20 +31,20 @@ No modules.
 | [aws_kms_key.velero](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/kms_key) | resource |
 | [aws_s3_bucket.velero](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_public_access_block.velero](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/resources/s3_bucket_public_access_block) | resource |
-| [azuread_group.cluster_admin](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [azuread_group.cluster_view](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [azuread_group.edit](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [azuread_group.view](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [azuread_group_member.resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
-| [azuread_group_member.resource_group_owner](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
-| [azuread_group_member.resource_group_reader](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
+| [azuread_group.cluster_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group) | resource |
+| [azuread_group.cluster_view](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group) | resource |
+| [azuread_group.edit](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group) | resource |
+| [azuread_group.view](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group) | resource |
+| [azuread_group_member.resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
+| [azuread_group_member.resource_group_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
+| [azuread_group_member.resource_group_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.eks_admin_assume](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.eks_admin_permission](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.63.0/docs/data-sources/region) | data source |
-| [azuread_group.resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/data-sources/group) | data source |
-| [azuread_group.resource_group_owner](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/data-sources/group) | data source |
-| [azuread_group.resource_group_reader](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/data-sources/group) | data source |
+| [azuread_group.resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/group) | data source |
+| [azuread_group.resource_group_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/group) | data source |
+| [azuread_group.resource_group_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/group) | data source |
 
 ## Inputs
 

--- a/modules/aws/eks-global/aad-group.tf
+++ b/modules/aws/eks-global/aad-group.tf
@@ -1,9 +1,9 @@
 locals {
   aad_groups = {
-    view          = { for k, v in azuread_group.view : k => { id = v.id, name = v.name } }
-    edit          = { for k, v in azuread_group.edit : k => { id = v.id, name = v.name } }
-    cluster_admin = { id = azuread_group.cluster_admin.id, name = azuread_group.cluster_admin.name }
-    cluster_view  = { id = azuread_group.cluster_view.id, name = azuread_group.cluster_view.name }
+    view          = { for k, v in azuread_group.view : k => { id = v.id, name = v.display_name } }
+    edit          = { for k, v in azuread_group.edit : k => { id = v.id, name = v.display_name } }
+    cluster_admin = { id = azuread_group.cluster_admin.id, name = azuread_group.cluster_admin.display_name }
+    cluster_view  = { id = azuread_group.cluster_view.id, name = azuread_group.cluster_view.display_name }
   }
 }
 

--- a/modules/aws/eks-global/aad-group.tf
+++ b/modules/aws/eks-global/aad-group.tf
@@ -12,6 +12,7 @@ resource "azuread_group" "view" {
   display_name = "${var.eks_group_name_prefix}${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}${each.value.name}${var.group_name_separator}view"
   #description             = "Members of this group will have view access to the ${each.value.name} namespace."
   prevent_duplicate_names = true
+  security_enabled        = true
 }
 
 resource "azuread_group" "edit" {
@@ -19,16 +20,19 @@ resource "azuread_group" "edit" {
   display_name = "${var.eks_group_name_prefix}${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}${each.value.name}${var.group_name_separator}edit"
   #description             = "Members of this group will have edit access to the ${each.value.name} namespace."
   prevent_duplicate_names = true
+  security_enabled        = true
 }
 
 resource "azuread_group" "cluster_admin" {
   display_name = "${var.eks_group_name_prefix}${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}clusteradmin"
   #description             = "Members of this group will have cluster admin access to the cluster."
   prevent_duplicate_names = true
+  security_enabled        = true
 }
 
 resource "azuread_group" "cluster_view" {
   display_name = "${var.eks_group_name_prefix}${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}clusterview"
   #description             = "Members of this group will have cluster viewer access to the cluster."
   prevent_duplicate_names = true
+  security_enabled        = true
 }

--- a/modules/aws/eks-global/main.tf
+++ b/modules/aws/eks-global/main.tf
@@ -6,7 +6,7 @@ terraform {
       version = "3.63.0"
     }
     azuread = {
-      version = "1.6.0"
+      version = "2.18.0"
       source  = "hashicorp/azuread"
     }
   }

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -33,31 +33,24 @@ Create and delegate access to the `owner` service principal:
 - Grant service principal the following permissions:
   - API Permissions: (Application)
     - `Group.ReadWrite.All` (`Microsoft Graph`)
-    - `Application.ReadWrite.All` (`Azure Active Directory Graph` - it's under the `Supported legacy APIs` section - see the note below)
+    - `Application.ReadWrite.All` (`Microsoft Graph`)
   - API Permissions: `Grant admin consent for <Tenant>`
   - Subscription permissions on all the subscriptions: `Owner`
   - The service principal also needs to be member of the `User administrator` role
+	
+### Migrating to Azure AD v2 provider
 
-Note regarding Azure Active Directory Graph: The AAD Graph has been deprecated and it's not possible to add it using the UI anymore. It will be completely decomissioned soon, but if you need it please add the following to your Azure AD App manifest:
+If you are using the Azure AD v1 provider and start using the v2 provider, please follow the below steps:
+	
+  - Add API permission `Application.ReadWrite.All` (`Microsoft Graph`) to the service principal(s)
+	- Remove the following from the state: module.governance_global.data.azuread_application.owner_spn (related [issue](https://github.com/hashicorp/terraform-provider-azuread/issues/541))
+		```shell
+	  make state-remove ENV=dev DIR=governance
+	  confirm: governance/dev
+	  regexp: data.azuread_application
+	  ```
+  - Run plan / apply, validate that only `random_password` resources are removed
+  - Remove service principal(s) from the `User administrator` role
+  - Remove the `Application.ReadWrite.All` (`Azure Active Directory Graph`) permission and admin consent from the service principal(s)	
+  - Remove the `Directory.ReadWrite.All` (`Azure Active Directory Graph`) permission and admin consent from the service principal(s) if it exists	
 
-```json
-{
-  "...",
-	"requiredResourceAccess": [
-		{
-			"resourceAppId": "00000002-0000-0000-c000-000000000000",
-			"resourceAccess": [
-				{
-					"id": "1cda74f2-2616-4834-b122-5cb1b07f8a59",
-					"type": "Role"
-				},
-				{
-					"id": "78c8a3c8-a07e-4b9e-af1b-b5ccab50a175",
-					"type": "Role"
-				}
-			]
-		}
-	],
-  "..."
-}
-```

--- a/modules/azure/aks-global/README.md
+++ b/modules/azure/aks-global/README.md
@@ -7,7 +7,7 @@ This module is used to create resources that are used by AKS clusters.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 0.15.3 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 1.6.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.18.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 2.97.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | 3.1.0 |
@@ -16,9 +16,8 @@ This module is used to create resources that are used by AKS clusters.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 1.6.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.18.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 2.97.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 3.1.0 |
 
 ## Modules
@@ -29,19 +28,19 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azuread_application.helm_operator](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/application) | resource |
-| [azuread_application_password.helm_operator](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/application_password) | resource |
-| [azuread_group.aks_managed_identity](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [azuread_group.cluster_admin](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [azuread_group.cluster_view](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [azuread_group.edit](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [azuread_group.view](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [azuread_group_member.aad_pod_identity](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
-| [azuread_group_member.helm_operator](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
-| [azuread_group_member.resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
-| [azuread_group_member.resource_group_owner](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
-| [azuread_group_member.resource_group_reader](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
-| [azuread_service_principal.helm_operator](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/service_principal) | resource |
+| [azuread_application.helm_operator](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/application) | resource |
+| [azuread_application_password.helm_operator](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/application_password) | resource |
+| [azuread_group.aks_managed_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group) | resource |
+| [azuread_group.cluster_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group) | resource |
+| [azuread_group.cluster_view](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group) | resource |
+| [azuread_group.edit](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group) | resource |
+| [azuread_group.view](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group) | resource |
+| [azuread_group_member.aad_pod_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
+| [azuread_group_member.helm_operator](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
+| [azuread_group_member.resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
+| [azuread_group_member.resource_group_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
+| [azuread_group_member.resource_group_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
+| [azuread_service_principal.helm_operator](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal) | resource |
 | [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/container_registry) | resource |
 | [azurerm_dns_zone.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/dns_zone) | resource |
 | [azurerm_key_vault_access_policy.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/key_vault_access_policy) | resource |
@@ -68,14 +67,13 @@ No modules.
 | [azurerm_user_assigned_identity.trivy](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/user_assigned_identity) | resource |
 | [azurerm_user_assigned_identity.velero](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/user_assigned_identity) | resource |
 | [azurerm_user_assigned_identity.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/user_assigned_identity) | resource |
-| [random_password.helm_operator](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/password) | resource |
 | [tls_private_key.ssh_key](https://registry.terraform.io/providers/hashicorp/tls/3.1.0/docs/resources/private_key) | resource |
-| [azuread_group.acr_pull](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/data-sources/group) | data source |
-| [azuread_group.acr_push](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/data-sources/group) | data source |
-| [azuread_group.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/data-sources/group) | data source |
-| [azuread_group.resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/data-sources/group) | data source |
-| [azuread_group.resource_group_owner](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/data-sources/group) | data source |
-| [azuread_group.resource_group_reader](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/data-sources/group) | data source |
+| [azuread_group.acr_pull](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/group) | data source |
+| [azuread_group.acr_push](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/group) | data source |
+| [azuread_group.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/group) | data source |
+| [azuread_group.resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/group) | data source |
+| [azuread_group.resource_group_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/group) | data source |
+| [azuread_group.resource_group_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/group) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/data-sources/client_config) | data source |
 | [azurerm_key_vault.core](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/data-sources/key_vault) | data source |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/data-sources/resource_group) | data source |

--- a/modules/azure/aks-global/aad-group.tf
+++ b/modules/azure/aks-global/aad-group.tf
@@ -3,6 +3,7 @@ resource "azuread_group" "view" {
   display_name = "${var.aks_group_name_prefix}${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}${each.value.name}${var.group_name_separator}view"
   #description             = "Members of this group will have view access to the ${each.value.name} namespace."
   prevent_duplicate_names = true
+  security_enabled        = true
 }
 
 resource "azuread_group" "edit" {
@@ -10,22 +11,26 @@ resource "azuread_group" "edit" {
   display_name = "${var.aks_group_name_prefix}${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}${each.value.name}${var.group_name_separator}edit"
   #description             = "Members of this group will have edit access to the ${each.value.name} namespace."
   prevent_duplicate_names = true
+  security_enabled        = true
 }
 
 resource "azuread_group" "cluster_admin" {
   display_name = "${var.aks_group_name_prefix}${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}clusteradmin"
   #description             = "Members of this group will have cluster admin access to the cluster."
   prevent_duplicate_names = true
+  security_enabled        = true
 }
 
 resource "azuread_group" "cluster_view" {
   display_name = "${var.aks_group_name_prefix}${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}clusterview"
   #description             = "Members of this group will have cluster viewer access to the cluster."
   prevent_duplicate_names = true
+  security_enabled        = true
 }
 
 resource "azuread_group" "aks_managed_identity" {
   display_name = "${var.aks_group_name_prefix}${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}aksmsi"
   #description             = "The AKS cluster Managed Identity (MSI) will be members of this group to get access to different resources."
   prevent_duplicate_names = true
+  security_enabled        = true
 }

--- a/modules/azure/aks-global/helm-operator.tf
+++ b/modules/azure/aks-global/helm-operator.tf
@@ -6,19 +6,8 @@ resource "azuread_service_principal" "helm_operator" {
   application_id = azuread_application.helm_operator.application_id
 }
 
-resource "random_password" "helm_operator" {
-  length           = 48
-  special          = true
-  override_special = "!-_="
-
-  keepers = {
-    service_principal = azuread_service_principal.helm_operator.id
-  }
-}
-
 resource "azuread_application_password" "helm_operator" {
   application_object_id = azuread_application.helm_operator.id
-  value                 = random_password.helm_operator.result
   end_date              = timeadd(timestamp(), "87600h") # 10 years
 
   lifecycle {

--- a/modules/azure/aks-global/locals.tf
+++ b/modules/azure/aks-global/locals.tf
@@ -6,11 +6,11 @@ locals {
     k => { id = v.id, client_id = v.client_id }
   }
   aad_groups = {
-    view                 = { for k, v in azuread_group.view : k => { id = v.id, name = v.name } }
-    edit                 = { for k, v in azuread_group.edit : k => { id = v.id, name = v.name } }
-    cluster_admin        = { id = azuread_group.cluster_admin.id, name = azuread_group.cluster_admin.name }
-    cluster_view         = { id = azuread_group.cluster_view.id, name = azuread_group.cluster_view.name }
-    aks_managed_identity = { id = azuread_group.aks_managed_identity.id, name = azuread_group.aks_managed_identity.name }
+    view                 = { for k, v in azuread_group.view : k => { id = v.id, name = v.display_name } }
+    edit                 = { for k, v in azuread_group.edit : k => { id = v.id, name = v.display_name } }
+    cluster_admin        = { id = azuread_group.cluster_admin.id, name = azuread_group.cluster_admin.display_name }
+    cluster_view         = { id = azuread_group.cluster_view.id, name = azuread_group.cluster_view.display_name }
+    aks_managed_identity = { id = azuread_group.aks_managed_identity.id, name = azuread_group.aks_managed_identity.display_name }
   }
 
   key_vault_default_permissions = {

--- a/modules/azure/aks-global/main.tf
+++ b/modules/azure/aks-global/main.tf
@@ -13,7 +13,7 @@ terraform {
       source  = "hashicorp/azurerm"
     }
     azuread = {
-      version = "1.6.0"
+      version = "2.18.0"
       source  = "hashicorp/azuread"
     }
     random = {

--- a/modules/azure/aks-global/outputs.tf
+++ b/modules/azure/aks-global/outputs.tf
@@ -46,7 +46,7 @@ output "helm_operator_credentials" {
   sensitive   = true
   value = {
     client_id = azuread_service_principal.helm_operator.application_id
-    secret    = random_password.helm_operator.result
+    secret    = azuread_application_password.helm_operator.value
   }
 }
 

--- a/modules/azure/aks/README.md
+++ b/modules/azure/aks/README.md
@@ -14,7 +14,7 @@ https://pumpingco.de/blog/modify-aks-default-node-pool-in-terraform-without-rede
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 0.15.3 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 1.6.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.18.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 2.97.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |
 
@@ -22,7 +22,7 @@ https://pumpingco.de/blog/modify-aks-default-node-pool-in-terraform-without-rede
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 1.6.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.18.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 2.97.0 |
 
 ## Modules
@@ -33,7 +33,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azuread_group_member.aks_managed_identity](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
+| [azuread_group_member.aks_managed_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
 | [azurerm_kubernetes_cluster.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/kubernetes_cluster) | resource |
 | [azurerm_kubernetes_cluster_node_pool.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/kubernetes_cluster_node_pool) | resource |
 | [azurerm_role_assignment.aks_managed_identity_noderg_managed_identity_operator](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/role_assignment) | resource |

--- a/modules/azure/aks/main.tf
+++ b/modules/azure/aks/main.tf
@@ -21,7 +21,7 @@ terraform {
       source  = "hashicorp/azurerm"
     }
     azuread = {
-      version = "1.6.0"
+      version = "2.18.0"
       source  = "hashicorp/azuread"
     }
     random = {

--- a/modules/azure/core/README.md
+++ b/modules/azure/core/README.md
@@ -7,14 +7,14 @@ This module is used to create core resources like virtual network for the subscr
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 0.15.3 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 1.6.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.18.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 2.82.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 1.6.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.18.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 2.82.0 |
 
 ## Modules
@@ -38,7 +38,7 @@ No modules.
 | [azurerm_subnet_route_table_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/subnet_route_table_association) | resource |
 | [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/virtual_network) | resource |
 | [azurerm_virtual_network_peering.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/virtual_network_peering) | resource |
-| [azuread_group.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/data-sources/group) | data source |
+| [azuread_group.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/group) | data source |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/data-sources/resource_group) | data source |
 
 ## Inputs

--- a/modules/azure/core/main.tf
+++ b/modules/azure/core/main.tf
@@ -13,7 +13,7 @@ terraform {
       source  = "hashicorp/azurerm"
     }
     azuread = {
-      version = "1.6.0"
+      version = "2.18.0"
       source  = "hashicorp/azuread"
     }
   }

--- a/modules/azure/governance-global/README.md
+++ b/modules/azure/governance-global/README.md
@@ -7,7 +7,7 @@ This module is used for governance on a global level and not using any specific 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 0.15.3 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 1.6.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.18.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 2.82.0 |
 | <a name="requirement_pal"></a> [pal](#requirement\_pal) | 0.2.4 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |
@@ -16,10 +16,9 @@ This module is used for governance on a global level and not using any specific 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 1.6.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.18.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 2.82.0 |
 | <a name="provider_pal"></a> [pal](#provider\_pal) | 0.2.4 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 
 ## Modules
 
@@ -29,44 +28,43 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azuread_application.aad_app](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/application) | resource |
-| [azuread_application.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/application) | resource |
-| [azuread_application.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/application) | resource |
-| [azuread_application_password.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/application_password) | resource |
-| [azuread_group.acr_pull](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [azuread_group.acr_push](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [azuread_group.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [azuread_group.rg_contributor](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [azuread_group.rg_owner](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [azuread_group.rg_reader](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [azuread_group.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [azuread_group.sub_contributor](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [azuread_group.sub_owner](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [azuread_group.sub_reader](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group) | resource |
-| [azuread_group_member.acr_contributor](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
-| [azuread_group_member.acr_owner](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
-| [azuread_group_member.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
-| [azuread_group_member.acr_reader_rg_contributor](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
-| [azuread_group_member.acr_reader_rg_owner](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
-| [azuread_group_member.acr_reader_rg_reader](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
-| [azuread_group_member.acr_spn](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
-| [azuread_group_member.sub_all_contributor](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
-| [azuread_group_member.sub_all_owner](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
-| [azuread_group_member.sub_all_reader](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
-| [azuread_service_principal.aad_sp](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/service_principal) | resource |
-| [azuread_service_principal.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/service_principal) | resource |
-| [azuread_service_principal.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/service_principal) | resource |
+| [azuread_application.aad_app](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/application) | resource |
+| [azuread_application.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/application) | resource |
+| [azuread_application.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/application) | resource |
+| [azuread_application_password.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/application_password) | resource |
+| [azuread_group.acr_pull](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group) | resource |
+| [azuread_group.acr_push](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group) | resource |
+| [azuread_group.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group) | resource |
+| [azuread_group.rg_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group) | resource |
+| [azuread_group.rg_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group) | resource |
+| [azuread_group.rg_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group) | resource |
+| [azuread_group.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group) | resource |
+| [azuread_group.sub_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group) | resource |
+| [azuread_group.sub_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group) | resource |
+| [azuread_group.sub_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group) | resource |
+| [azuread_group_member.acr_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
+| [azuread_group_member.acr_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
+| [azuread_group_member.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
+| [azuread_group_member.acr_reader_rg_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
+| [azuread_group_member.acr_reader_rg_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
+| [azuread_group_member.acr_reader_rg_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
+| [azuread_group_member.acr_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
+| [azuread_group_member.sub_all_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
+| [azuread_group_member.sub_all_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
+| [azuread_group_member.sub_all_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
+| [azuread_service_principal.aad_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal) | resource |
+| [azuread_service_principal.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal) | resource |
+| [azuread_service_principal.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal) | resource |
 | [azurerm_role_assignment.sub_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.sub_owner](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.sub_reader](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/role_assignment) | resource |
 | [pal_management_partner.owner_spn](https://registry.terraform.io/providers/xenitab/pal/0.2.4/docs/resources/management_partner) | resource |
-| [random_password.owner_spn](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/password) | resource |
-| [azuread_application.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/data-sources/application) | data source |
-| [azuread_group.all_contributor](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/data-sources/group) | data source |
-| [azuread_group.all_owner](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/data-sources/group) | data source |
-| [azuread_group.all_reader](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/data-sources/group) | data source |
-| [azuread_service_principal.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/data-sources/service_principal) | data source |
+| [azuread_application.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/application) | data source |
+| [azuread_group.all_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/group) | data source |
+| [azuread_group.all_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/group) | data source |
+| [azuread_group.all_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/group) | data source |
+| [azuread_service_principal.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/service_principal) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/data-sources/subscription) | data source |
 
 ## Inputs

--- a/modules/azure/governance-global/aad-group-rg.tf
+++ b/modules/azure/governance-global/aad-group-rg.tf
@@ -7,6 +7,7 @@ resource "azuread_group" "rg_owner" {
 
   display_name            = "${var.azure_ad_group_prefix}${var.group_name_separator}rg${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}${each.value.common_name}${var.group_name_separator}owner"
   prevent_duplicate_names = true
+  security_enabled        = true
 }
 
 # AAD Group for Resource Group Contributors
@@ -18,6 +19,7 @@ resource "azuread_group" "rg_contributor" {
 
   display_name            = "${var.azure_ad_group_prefix}${var.group_name_separator}rg${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}${each.value.common_name}${var.group_name_separator}contributor"
   prevent_duplicate_names = true
+  security_enabled        = true
 }
 
 
@@ -30,4 +32,5 @@ resource "azuread_group" "rg_reader" {
 
   display_name            = "${var.azure_ad_group_prefix}${var.group_name_separator}rg${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}${each.value.common_name}${var.group_name_separator}reader"
   prevent_duplicate_names = true
+  security_enabled        = true
 }

--- a/modules/azure/governance-global/aad-group-sub.tf
+++ b/modules/azure/governance-global/aad-group-sub.tf
@@ -2,6 +2,7 @@
 resource "azuread_group" "sub_owner" {
   display_name            = "${var.azure_ad_group_prefix}${var.group_name_separator}sub${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}owner"
   prevent_duplicate_names = true
+  security_enabled = true
 }
 
 resource "azurerm_role_assignment" "sub_owner" {
@@ -14,6 +15,7 @@ resource "azurerm_role_assignment" "sub_owner" {
 resource "azuread_group" "sub_contributor" {
   display_name            = "${var.azure_ad_group_prefix}${var.group_name_separator}sub${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}contributor"
   prevent_duplicate_names = true
+  security_enabled = true
 }
 
 resource "azurerm_role_assignment" "sub_contributor" {
@@ -26,6 +28,7 @@ resource "azurerm_role_assignment" "sub_contributor" {
 resource "azuread_group" "sub_reader" {
   display_name            = "${var.azure_ad_group_prefix}${var.group_name_separator}sub${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}reader"
   prevent_duplicate_names = true
+  security_enabled = true
 }
 
 resource "azurerm_role_assignment" "sub_reader" {

--- a/modules/azure/governance-global/aad-group-sub.tf
+++ b/modules/azure/governance-global/aad-group-sub.tf
@@ -2,7 +2,7 @@
 resource "azuread_group" "sub_owner" {
   display_name            = "${var.azure_ad_group_prefix}${var.group_name_separator}sub${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}owner"
   prevent_duplicate_names = true
-  security_enabled = true
+  security_enabled        = true
 }
 
 resource "azurerm_role_assignment" "sub_owner" {
@@ -15,7 +15,7 @@ resource "azurerm_role_assignment" "sub_owner" {
 resource "azuread_group" "sub_contributor" {
   display_name            = "${var.azure_ad_group_prefix}${var.group_name_separator}sub${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}contributor"
   prevent_duplicate_names = true
-  security_enabled = true
+  security_enabled        = true
 }
 
 resource "azurerm_role_assignment" "sub_contributor" {
@@ -28,7 +28,7 @@ resource "azurerm_role_assignment" "sub_contributor" {
 resource "azuread_group" "sub_reader" {
   display_name            = "${var.azure_ad_group_prefix}${var.group_name_separator}sub${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}reader"
   prevent_duplicate_names = true
-  security_enabled = true
+  security_enabled        = true
 }
 
 resource "azurerm_role_assignment" "sub_reader" {

--- a/modules/azure/governance-global/delegate-acr.tf
+++ b/modules/azure/governance-global/delegate-acr.tf
@@ -10,6 +10,7 @@ resource "azuread_group" "acr_push" {
 
   display_name            = "${var.aks_group_name_prefix}${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}acrpush"
   prevent_duplicate_names = true
+  security_enabled        = true
 }
 
 # ACR Pull Azure AD group will grant pull permissions to the Container Registry
@@ -22,6 +23,7 @@ resource "azuread_group" "acr_pull" {
 
   display_name            = "${var.aks_group_name_prefix}${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}acrpull"
   prevent_duplicate_names = true
+  security_enabled        = true
 }
 
 # ACR Reader Azure AD group will grant ARM (to view Container Registry in Azure Portal) and pull permissions to the Container Registry
@@ -34,6 +36,7 @@ resource "azuread_group" "acr_reader" {
 
   display_name            = "${var.aks_group_name_prefix}${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}acrreader"
   prevent_duplicate_names = true
+  security_enabled        = true
 }
 
 # Grant ACR Push permissions to the resource group service principal

--- a/modules/azure/governance-global/delegate-se.tf
+++ b/modules/azure/governance-global/delegate-se.tf
@@ -1,4 +1,5 @@
 resource "azuread_group" "service_endpoint_join" {
   display_name            = "${var.azure_ad_group_prefix}${var.group_name_separator}sub${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}serviceEndpointJoin"
   prevent_duplicate_names = true
+  security_enabled        = true
 }

--- a/modules/azure/governance-global/main.tf
+++ b/modules/azure/governance-global/main.tf
@@ -13,7 +13,7 @@ terraform {
       source  = "hashicorp/azurerm"
     }
     azuread = {
-      version = "1.6.0"
+      version = "2.18.0"
       source  = "hashicorp/azuread"
     }
     random = {

--- a/modules/azure/governance-regional/README.md
+++ b/modules/azure/governance-regional/README.md
@@ -7,7 +7,7 @@ This module is used for governance on a regional level and not using any specifi
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 0.15.3 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 1.6.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.18.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 2.82.0 |
 | <a name="requirement_pal"></a> [pal](#requirement\_pal) | 0.2.4 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |
@@ -16,10 +16,9 @@ This module is used for governance on a regional level and not using any specifi
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 1.6.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.18.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 2.82.0 |
 | <a name="provider_pal"></a> [pal](#provider\_pal) | 0.2.4 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 
 ## Modules
 
@@ -29,12 +28,12 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azuread_application_password.aad_sp](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/application_password) | resource |
-| [azuread_application_password.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/application_password) | resource |
-| [azuread_application_password.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/application_password) | resource |
-| [azuread_group_member.service_endpoint_join_contributor](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
-| [azuread_group_member.service_endpoint_join_owner](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
-| [azuread_group_member.service_endpoint_join_spn](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/resources/group_member) | resource |
+| [azuread_application_password.aad_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/application_password) | resource |
+| [azuread_application_password.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/application_password) | resource |
+| [azuread_application_password.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/application_password) | resource |
+| [azuread_group_member.service_endpoint_join_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
+| [azuread_group_member.service_endpoint_join_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
+| [azuread_group_member.service_endpoint_join_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/group_member) | resource |
 | [azurerm_key_vault.delegate_kv](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/key_vault) | resource |
 | [azurerm_key_vault_access_policy.ap_kvreader_sp](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.ap_owner_spn](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/key_vault_access_policy) | resource |
@@ -52,10 +51,7 @@ No modules.
 | [azurerm_role_assignment.rg_owner](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.rg_reader](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/role_assignment) | resource |
 | [pal_management_partner.aad_sp](https://registry.terraform.io/providers/xenitab/pal/0.2.4/docs/resources/management_partner) | resource |
-| [random_password.aad_sp](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/password) | resource |
-| [random_password.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/password) | resource |
-| [random_password.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/password) | resource |
-| [azuread_service_principal.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/data-sources/service_principal) | data source |
+| [azuread_service_principal.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/service_principal) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/data-sources/client_config) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/data-sources/subscription) | data source |
 

--- a/modules/azure/governance-regional/delegate-kv-sp.tf
+++ b/modules/azure/governance-regional/delegate-kv-sp.tf
@@ -1,19 +1,3 @@
-resource "random_password" "delegate_kv_aad" {
-  for_each = {
-    for rg in var.resource_group_configs :
-    rg.common_name => rg
-    if rg.delegate_key_vault == true
-  }
-
-  length           = 48
-  special          = true
-  override_special = "!-_="
-
-  keepers = {
-    service_principal = var.azuread_apps.delegate_kv[each.key].service_principal_object_id
-  }
-}
-
 resource "azuread_application_password" "delegate_kv_aad" {
   for_each = {
     for rg in var.resource_group_configs :
@@ -22,7 +6,6 @@ resource "azuread_application_password" "delegate_kv_aad" {
   }
 
   application_object_id = var.azuread_apps.delegate_kv[each.key].application_object_id
-  value                 = random_password.delegate_kv_aad[each.key].result
   end_date              = timeadd(timestamp(), "87600h") # 10 years
 
   lifecycle {
@@ -45,7 +28,7 @@ resource "azurerm_key_vault_secret" "delegate_kv_aad" {
     tenantId       = data.azurerm_subscription.current.tenant_id
     subscriptionId = data.azurerm_subscription.current.subscription_id
     clientId       = var.azuread_apps.delegate_kv[each.key].application_id
-    clientSecret   = random_password.delegate_kv_aad[each.value.common_name].result
+    clientSecret   = azuread_application_password.delegate_kv_aad[each.value.common_name].value
     keyVaultName   = azurerm_key_vault.delegate_kv[each.key].name
   })
   key_vault_id = azurerm_key_vault.delegate_kv[each.key].id

--- a/modules/azure/governance-regional/main.tf
+++ b/modules/azure/governance-regional/main.tf
@@ -13,7 +13,7 @@ terraform {
       source  = "hashicorp/azurerm"
     }
     azuread = {
-      version = "1.6.0"
+      version = "2.18.0"
       source  = "hashicorp/azuread"
     }
     random = {

--- a/modules/azure/governance-regional/sp-sub-reader.tf
+++ b/modules/azure/governance-regional/sp-sub-reader.tf
@@ -1,16 +1,5 @@
-resource "random_password" "sub_reader_sp" {
-  length           = 48
-  special          = true
-  override_special = "!-_="
-
-  keepers = {
-    service_principal = var.azuread_apps.sub_reader.service_principal_object_id
-  }
-}
-
 resource "azuread_application_password" "sub_reader_sp" {
   application_object_id = var.azuread_apps.sub_reader.application_object_id
-  value                 = random_password.sub_reader_sp.result
   end_date              = timeadd(timestamp(), "87600h") # 10 years
 
   lifecycle {
@@ -27,7 +16,7 @@ resource "azurerm_key_vault_secret" "sub_reader_sp" {
     tenantId       = data.azurerm_subscription.current.tenant_id
     subscriptionId = data.azurerm_subscription.current.subscription_id
     clientId       = var.azuread_apps.sub_reader.application_id
-    clientSecret   = random_password.sub_reader_sp.result
+    clientSecret   = azuread_application_password.sub_reader_sp.value
   })
   key_vault_id = azurerm_key_vault.delegate_kv[var.core_name].id
   content_type = "application/json"

--- a/modules/azure/hub/README.md
+++ b/modules/azure/hub/README.md
@@ -11,14 +11,14 @@ Use together with the `core` module to create a peered network where SPOF (singl
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 0.15.3 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 1.6.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.18.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 2.82.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 1.6.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.18.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 2.82.0 |
 
 ## Modules
@@ -40,7 +40,7 @@ No modules.
 | [azurerm_subnet_network_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/subnet_network_security_group_association) | resource |
 | [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/virtual_network) | resource |
 | [azurerm_virtual_network_peering.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/resources/virtual_network_peering) | resource |
-| [azuread_group.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/data-sources/group) | data source |
+| [azuread_group.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/group) | data source |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/2.82.0/docs/data-sources/resource_group) | data source |
 
 ## Inputs

--- a/modules/azure/hub/main.tf
+++ b/modules/azure/hub/main.tf
@@ -17,7 +17,7 @@ terraform {
       source  = "hashicorp/azurerm"
     }
     azuread = {
-      version = "1.6.0"
+      version = "2.18.0"
       source  = "hashicorp/azuread"
     }
   }

--- a/modules/kubernetes/aks-core/README.md
+++ b/modules/kubernetes/aks-core/README.md
@@ -7,7 +7,7 @@ This module is used to create AKS clusters.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 0.15.3 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 1.6.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.18.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 2.97.0 |
 | <a name="requirement_flux"></a> [flux](#requirement\_flux) | 0.5.1 |
 | <a name="requirement_github"></a> [github](#requirement\_github) | 4.17.0 |

--- a/modules/kubernetes/aks-core/main.tf
+++ b/modules/kubernetes/aks-core/main.tf
@@ -13,7 +13,7 @@ terraform {
       source  = "hashicorp/azurerm"
     }
     azuread = {
-      version = "1.6.0"
+      version = "2.18.0"
       source  = "hashicorp/azuread"
     }
     random = {


### PR DESCRIPTION
This PR upgrades the Azure AD provider to v2 (1.6.0 -> 2.18.0) and fixes the different deprecations and changes related to it.

See [`AzureAD v2.0 and Microsoft Graph`](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/guides/microsoft-graph) for more details on the upgrade. The big difference is that we are moving away from the deprecated Azure AD Graph to the Microsoft Graph. This change requires us to update the service principals used in regards to their permissions:

>  - Add API permission `Application.ReadWrite.All` (`Microsoft Graph`) to the service principal(s)
>  - Remove the following from the state: module.governance_global.data.azuread_application.owner_spn (related [issue](https://github.com/hashicorp/terraform-provider-azuread/issues/541))
>	  ```shell
>	  make state-remove ENV=dev DIR=governance
>	  confirm: governance/dev
>	  regexp: data.azuread_application
>	  ```
>  - Run plan / apply, validate that only `random_password` resources are removed
>  - Remove service principal(s) from the `User administrator` role
>  - Remove the `Application.ReadWrite.All` (`Azure Active Directory Graph`) permission and admin consent from the service principal(s)	
>  - Remove the `Directory.ReadWrite.All` (`Azure Active Directory Graph`) permission and admin consent from the service principal(s) if it exists

Please note that the above is for `governance` and the same issue that required `state-remove` may occur with other modules using the data source `azuread_application`. The following error will be thrown if it's required:

> Error: .group_membership_claims: missing expected [

The other changes that have been made are:

- Stopped generating `random_password` for a couple of resources since the provider handles it for `azuread_application_password`
- Removed `value` from `azuread_application_password` since the provider handles it (and migrates it)
- Update resources using `random_password` that was used for `azuread_application_password` and instead use the `value` attribute from the `azuread_application_password`
- The `name` attribute has been changed for all resources and where used it has been replaced with `display_name`
- Set `security_enabled = true` on `azuread_group` resources

Fixes #507