### PR TITLE
Bump git-auth-proxy to v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#589](https://github.com/XenitAB/terraform-modules/pull/589) Update git-auth-proxy to 0.6.0 to include case-insensitive path matching.
+
 ### Fixed
 
 - [#587](https://github.com/XenitAB/terraform-modules/pull/587) Fix space error in grafana-agent podLogs

--- a/modules/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/main.tf
@@ -69,7 +69,7 @@ resource "helm_release" "git_auth_proxy" {
   chart       = "git-auth-proxy"
   name        = "git-auth-proxy"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "v0.5.2"
+  version     = "v0.6.0"
   max_history = 3
   values = [templatefile("${path.module}/templates/git-auth-proxy-values.yaml.tpl", {
     azure_devops_pat  = var.azure_devops_pat,

--- a/modules/kubernetes/fluxcd-v2-github/main.tf
+++ b/modules/kubernetes/fluxcd-v2-github/main.tf
@@ -69,7 +69,7 @@ resource "helm_release" "git_auth_proxy" {
   chart       = "git-auth-proxy"
   name        = "git-auth-proxy"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "v0.5.2"
+  version     = "v0.6.0"
   max_history = 3
   values = [templatefile("${path.module}/templates/git-auth-proxy-values.yaml.tpl", {
     github_org      = var.github_org


### PR DESCRIPTION
This bumps git-auth-proxy to include case-insensitive path matching. See https://github.com/XenitAB/git-auth-proxy/releases/tag/v0.6.0 for more info.