### PR TITLE
Change remote write settings to align with best practices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#593](https://github.com/XenitAB/terraform-modules/pull/593) Change Prometheus remote write settings to align with best practices.
+
 ## 2022.03.2
 
 ### Changed

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.38
+version: 0.1.39
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/templates/prometheus.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/templates/prometheus.yaml
@@ -68,10 +68,10 @@ spec:
       # Check docs for more information about settings
       # https://prometheus.io/docs/practices/remote_write/
       queueConfig:
-        capacity: 3000
+        capacity: 2500
         maxBackoff: 5s
-        maxSamplesPerSend: 1000
-        maxShards: 100
+        maxSamplesPerSend: 500
+        maxShards: 50
       {{- if .Values.remoteWrite.authenticated }}
       tlsConfig:
         certFile: /mnt/tls/tls.crt


### PR DESCRIPTION
This change aligns some settings with the current remote write defaults and decreases the max shards to reduce the amount of parallel requests. 