### PR TITLE
Fix tfsec AWS security warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#593](https://github.com/XenitAB/terraform-modules/pull/593) Change Prometheus remote write settings to align with best practices.
 - [#574](https://github.com/XenitAB/terraform-modules/pull/574) [Breaking] Update cert-manager version.
+- [#598](https://github.com/XenitAB/terraform-modules/pull/598) Fix tfsec AWS security warnings.
 
 ### Removed
 

--- a/modules/aws/eks-global/cloud-watch.tf
+++ b/modules/aws/eks-global/cloud-watch.tf
@@ -3,9 +3,15 @@ locals {
   eks_cluster2_name = "${var.environment}-${var.name}2"
 }
 
+resource "aws_kms_key" "eks_cluster_logs" {
+  description             = "EKS Cluster Logs"
+  deletion_window_in_days = 10
+}
+
 resource "aws_cloudwatch_log_group" "eks1" {
   name              = "/aws/eks/${local.eks_cluster1_name}/cluster"
   retention_in_days = var.eks_cloudwatch_retention_period
+  kms_key_id = aws_kms_key.eks_cluster_logs.arn
 
   tags = local.global_tags
 }
@@ -13,6 +19,7 @@ resource "aws_cloudwatch_log_group" "eks1" {
 resource "aws_cloudwatch_log_group" "eks2" {
   name              = "/aws/eks/${local.eks_cluster2_name}/cluster"
   retention_in_days = var.eks_cloudwatch_retention_period
+  kms_key_id = aws_kms_key.eks_cluster_logs.arn
 
   tags = local.global_tags
 }

--- a/modules/aws/eks/eks.tf
+++ b/modules/aws/eks/eks.tf
@@ -140,6 +140,9 @@ resource "aws_launch_template" "eks_node_group" {
       volume_size = 20
     }
   }
+  metadata_options {
+    http_tokens = "required"
+  }  
   user_data = base64encode(templatefile("${path.module}/templates/userdata.sh.tpl", {
     cluster_name   = aws_eks_cluster.this.name,
     b64_cluster_ca = aws_eks_cluster.this.certificate_authority[0].data,


### PR DESCRIPTION
This changes fixes the following TFSec warnings.
https://aquasecurity.github.io/tfsec/v1.8.0/checks/aws/autoscaling/enforce-http-token-imds/
https://aquasecurity.github.io/tfsec/v1.8.0/checks/aws/cloudwatch/log-group-customer-key/

The first one has to be verified that it actually works with IRSA.