### PR TITLE
Hardcode image version for starboard job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#574](https://github.com/XenitAB/terraform-modules/pull/574) [Breaking] Update cert-manager version.
 - [#595](https://github.com/XenitAB/terraform-modules/pull/595) Update Terraform provider versions.
 
+### Fix
+
+- [#600](https://github.com/XenitAB/terraform-modules/pull/600) Hardcode trivy starboard image to 0.24.3
+
 ### Removed
 
 - [#594](https://github.com/XenitAB/terraform-modules/pull/594) Remove deprecated goldpinger module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fix
 
-- [#600](https://github.com/XenitAB/terraform-modules/pull/600) Hardcode trivy starboard image to 0.24.3
+- [#600](https://github.com/XenitAB/terraform-modules/pull/600) Hardcode trivy starboard image to 0.24.3 and update trivy helm chart.
 
 ### Removed
 

--- a/modules/kubernetes/starboard/main.tf
+++ b/modules/kubernetes/starboard/main.tf
@@ -66,7 +66,7 @@ resource "helm_release" "trivy" {
   chart       = "trivy"
   name        = "trivy"
   namespace   = kubernetes_namespace.starboard.metadata[0].name
-  version     = "0.4.11"
+  version     = "0.4.12"
   max_history = 3
   values = [templatefile("${path.module}/templates/trivy-values.yaml.tpl", {
     provider       = var.cloud_provider

--- a/modules/kubernetes/starboard/templates/starboard-values.yaml.tpl
+++ b/modules/kubernetes/starboard/templates/starboard-values.yaml.tpl
@@ -11,6 +11,7 @@ trivy:
   severity: MEDIUM,HIGH,CRITICAL
   ignoreUnfixed: true
   serverURL: "http://trivy.starboard-operator.svc.cluster.local:4954"
+  imageRef: docker.io/aquasec/trivy:0.24.3
 
 operator:
   # configAuditScannerEnabled the flag to enable configuration audit scanner


### PR DESCRIPTION
The current default value is trivy 0.22.0 and the version we need
for aadpodidentity is 0.23.0.