### PR TITLE
set electionID in ingress-nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fix
+
+- [#606](https://github.com/XenitAB/terraform-modules/pull/606) Fix electionID on ingress-nginx when using private and public ingress-nginx.
+
 ## 2022.03.3
 
 ### Changed

--- a/modules/kubernetes/ingress-nginx/main.tf
+++ b/modules/kubernetes/ingress-nginx/main.tf
@@ -47,6 +47,7 @@ resource "helm_release" "ingress_nginx" {
     provider               = var.cloud_provider
     ingress_class          = "nginx"
     internal_load_balancer = false
+    public_private_enabled = var.public_private_enabled
     default_certificate = {
       enabled         = var.default_certificate.enabled
       dns_zone        = var.default_certificate.dns_zone
@@ -79,6 +80,7 @@ resource "helm_release" "ingress_nginx_public" {
     provider               = var.cloud_provider
     ingress_class          = "nginx-public"
     internal_load_balancer = false
+    public_private_enabled = var.public_private_enabled
     default_certificate = {
       enabled         = var.default_certificate.enabled
       dns_zone        = var.default_certificate.dns_zone
@@ -111,6 +113,7 @@ resource "helm_release" "ingress_nginx_private" {
     provider               = var.cloud_provider
     ingress_class          = "nginx-private"
     internal_load_balancer = true
+    public_private_enabled = var.public_private_enabled
     default_certificate = {
       enabled         = var.default_certificate.enabled
       dns_zone        = var.default_certificate.dns_zone

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -7,9 +7,13 @@ controller:
     name: ${ingress_class}
     default: ${default_ingress_class}
     controllerValue: "k8s.io/ingress-${ingress_class}"
-  
+
   # Should eventually be removed as ingress class annotations are deprecated
   ingressClass: ${ingress_class}
+
+  %{~ if public_private_enabled ~}
+  electionID: ingress-controller-leader-${ingress_class}
+  %{~ endif ~}
 
   %{~ if provider == "aws" ~}
   # Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'.


### PR DESCRIPTION
This to be able to support both public and private ingress-nginx.
This was default before but this was changed upstream.

For more information you can read: https://github.com/kubernetes/ingress-nginx/issues/8276 and https://github.com/kubernetes/ingress-nginx/issues/8144