### PR TITLE
Create new EKS and AKS node pools before deleting existing node pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#618](https://github.com/XenitAB/terraform-modules/pull/618) Create new EKS and AKS node pools before deleting existing node pools.
+
 ## 2022.03.4
 
 ### Fix

--- a/modules/aws/eks/eks.tf
+++ b/modules/aws/eks/eks.tf
@@ -180,7 +180,8 @@ resource "aws_eks_node_group" "this" {
   tags = local.global_tags
 
   lifecycle {
-    ignore_changes = [scaling_config[0].desired_size]
+    create_before_destroy = true
+    ignore_changes        = [scaling_config[0].desired_size]
   }
 
   timeouts {

--- a/modules/azure/aks/aks.tf
+++ b/modules/azure/aks/aks.tf
@@ -73,6 +73,7 @@ resource "azurerm_kubernetes_cluster" "this" {
 
 resource "azurerm_kubernetes_cluster_node_pool" "this" {
   lifecycle {
+    create_before_destroy = true
     ignore_changes = [
       node_count
     ]


### PR DESCRIPTION
This change will hopefully protect against situations where there are two node pools and someone attempts to replace the node pool in one shot. Normally Terraform will first delete the existing node pool which will start the eviction process before creating the new node pool. This is normally not an issue but not idea either. This change will make sure that there are nodes for pods to be evicted to before draining the old nodes.