### PR TITLE
Falco aws disable docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fix
 
 - [#620](https://github.com/XenitAB/terraform-modules/pull/620) Fix broken cluster autoscaler
+- [#623](https://github.com/XenitAB/terraform-modules/pull/623) Falco AWS disable docker
 
 ## 2022.03.5
 

--- a/modules/kubernetes/falco/templates/falco-values.yaml.tpl
+++ b/modules/kubernetes/falco/templates/falco-values.yaml.tpl
@@ -1,11 +1,8 @@
 auditLog:
   enabled: false
 
-%{~ if provider == "azure" ~}
-# AKS does not use docker anymore
 docker:
   enabled: false
-%{~ endif ~}
 
 # Use EBPF instead of kernel module
 ebpf:


### PR DESCRIPTION
Seems like AWS have removed there extra docker runtime that was available on older nodes.
After disabling docker I can now see data in AWS again.