### PR TITLE
Cahnge cert-manager to http01 for acme

### DIFF
--- a/modules/kubernetes/cert-manager/charts/cert-manager-extras/Chart.yaml
+++ b/modules/kubernetes/cert-manager/charts/cert-manager-extras/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: cert-manager-extras
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: 0.1.0

--- a/modules/kubernetes/cert-manager/charts/cert-manager-extras/templates/cluster-issuer.yaml
+++ b/modules/kubernetes/cert-manager/charts/cert-manager-extras/templates/cluster-issuer.yaml
@@ -1,21 +1,3 @@
-{{- if eq .Values.cloudProvider "azure" }}
-apiVersion: aadpodidentity.k8s.io/v1
-kind: AzureIdentity
-metadata:
-  name: cert-manager
-spec:
-  type: 0
-  resourceID: {{ .Values.azureConfig.resourceID }}
-  clientID: {{ .Values.azureConfig.clientID }}
----
-apiVersion: aadpodidentity.k8s.io/v1
-kind: AzureIdentityBinding
-metadata:
-  name: cert-manager
-spec:
-  azureIdentity: cert-manager
-  selector: cert-manager
-{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -29,16 +11,9 @@ spec:
       name: letsencrypt-cluster-issuer-account-key
     solvers:
     - selector: {}
-      dns01:
-        {{- if eq .Values.cloudProvider "azure" }}
-        azureDNS:
-          environment: AzurePublicCloud
-          subscriptionID: {{ .Values.azureConfig.subscriptionID }}
-          resourceGroupName: {{ .Values.azureConfig.resourceGroupName }}
-          hostedZoneName: {{ .Values.azureConfig.hostedZoneName }}
-        {{- end }}
-        {{- if eq .Values.cloudProvider "aws" }}
-        route53:
-          region: {{ .Values.awsConfig.region }}
-          hostedZoneID: {{ .Values.awsConfig.hostedZoneID }}
+      http01:
+        {{- if .Values.ingressPublicPrivateEnabled }}
+        class: nginx-public
+        {{ else }}
+        class: nginx
         {{- end }}

--- a/modules/kubernetes/cert-manager/charts/cert-manager-extras/values.yaml
+++ b/modules/kubernetes/cert-manager/charts/cert-manager-extras/values.yaml
@@ -3,15 +3,4 @@ fullnameOverride: ""
 notificationEmail: ""
 acmeServer: ""
 
-cloudProvider: ""
-
-azureConfig:
-  resourceGroupName: ""
-  clientID: ""
-  subscriptionID: ""
-  hostedZoneName: ""
-  resourceID: ""
-
-awsConfig:
-  region: ""
-  hostedZoneID: ""
+ingressPublicPrivateEnabled: false

--- a/modules/kubernetes/cert-manager/main.tf
+++ b/modules/kubernetes/cert-manager/main.tf
@@ -41,8 +41,7 @@ resource "helm_release" "cert_manager" {
   version     = "v1.7.1"
   max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
-    provider   = var.cloud_provider,
-    aws_config = var.aws_config,
+    provider = var.cloud_provider,
   })]
 }
 
@@ -63,44 +62,8 @@ resource "helm_release" "cert_manager_extras" {
     name  = "acmeServer"
     value = var.acme_server
   }
-
   set {
-    name  = "cloudProvider"
-    value = var.cloud_provider
-  }
-
-  set {
-    name  = "azureConfig.resourceGroupName"
-    value = var.azure_config.resource_group_name
-  }
-
-  set {
-    name  = "azureConfig.clientID"
-    value = var.azure_config.client_id
-  }
-
-  set {
-    name  = "azureConfig.subscriptionID"
-    value = var.azure_config.subscription_id
-  }
-
-  set {
-    name  = "azureConfig.resourceID"
-    value = var.azure_config.resource_id
-  }
-
-  set {
-    name  = "azureConfig.hostedZoneName"
-    value = var.azure_config.hosted_zone_name
-  }
-
-  set {
-    name  = "awsConfig.region"
-    value = var.aws_config.region
-  }
-
-  set {
-    name  = "awsConfig.hostedZoneID"
-    value = var.aws_config.hosted_zone_id
+    name  = "acmeServer"
+    value = var.ingress_public_private_enabled
   }
 }

--- a/modules/kubernetes/cert-manager/templates/values.yaml.tpl
+++ b/modules/kubernetes/cert-manager/templates/values.yaml.tpl
@@ -3,14 +3,7 @@ installCRDs: true
 global:
   priorityClassName: "platform-medium"
 
-%{ if provider == "azure" }
-podLabels:
-  aadpodidbinding: cert-manager
-%{ endif }
 %{ if provider == "aws" }
-serviceAccount:
-  annotations:
-    eks.amazonaws.com/role-arn: "${aws_config.role_arn}"
 securityContext:
   fsGroup: 1001
 # This has to be enabled because when using Calico

--- a/modules/kubernetes/cert-manager/variables.tf
+++ b/modules/kubernetes/cert-manager/variables.tf
@@ -14,34 +14,8 @@ variable "cloud_provider" {
   type        = string
 }
 
-variable "azure_config" {
-  description = "Azure specific configuration"
-  type = object({
-    subscription_id     = string,
-    hosted_zone_name    = string,
-    resource_group_name = string,
-    client_id           = string,
-    resource_id         = string,
-  })
-  default = {
-    subscription_id     = "",
-    hosted_zone_name    = "",
-    resource_group_name = "",
-    client_id           = "",
-    resource_id         = "",
-  }
-}
-
-variable "aws_config" {
-  description = "AWS specific configuration"
-  type = object({
-    region         = string,
-    hosted_zone_id = string,
-    role_arn       = string,
-  })
-  default = {
-    region         = "",
-    hosted_zone_id = "",
-    role_arn       = "",
-  }
+variable "ingress_public_private_enabled" {
+  description = "Which ingressclass should cert-manager use?"
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
This to make cert-manager less complex and let ingress-nginx verify the acme endpoint
instead of using txt DNS solutions.