### PR TITLE
Deprecate loki and xenit module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#620](https://github.com/XenitAB/terraform-modules/pull/620) Fix broken cluster autoscaler
 - [#623](https://github.com/XenitAB/terraform-modules/pull/623) Falco AWS disable docker
 
+### Deprecated
+
+- [#627](https://github.com/XenitAB/terraform-modules/pull/627) Deprecate loki and xenit modules.
+
 ## 2022.03.5
 
 ### Changed

--- a/modules/kubernetes/README.md
+++ b/modules/kubernetes/README.md
@@ -16,7 +16,6 @@ This directory contains all the Kubernetes Terraform modules.
 - [`fluxcd-v2-azdo`](fluxcd-v2-azdo/README.md)
 - [`fluxcd-v2-github`](fluxcd-v2-github/README.md)
 - [`ingress-nginx`](ingress-nginx/README.md)
-- [`loki`](loki/README.md)
 - [`opa-gatekeeper`](opa-gatekeeper/README.md)
 - [`velero`](velero/README.md)
 - [`datadog`](datadog/README.md)
@@ -25,7 +24,6 @@ This directory contains all the Kubernetes Terraform modules.
 - [`azad-kube-proxy`](azad-kube-proxy/README.md)
 - [`prometheus`](prometheus/README.md)
 - [`ingress-healthz`](ingress-healthz/README.md)
-- [`xenit`](xenit/README.md)
 - [`linkerd`](linkerd/README.md)
 - [`cluster-autoscaler`](cluster-autoscaler/README.md)
 - [`starboard`](starboard/README.md)
@@ -35,6 +33,8 @@ This directory contains all the Kubernetes Terraform modules.
 
 ### Deprecated
 
+- [`loki`](loki/README.md)
+- [`xenit`](xenit/README.md)
 - [`new-relic`](new-relic/README.md)
 
 ## Style Guide


### PR DESCRIPTION
Deprecate the loki and xenit module.

Removing the xenit module as work going forward is not going to use the proxy.

Will remove all deprecated modules in one go in a future PR later.