### PR TITLE
Add variable for excluding promtail namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - [#624](https://github.com/XenitAB/terraform-modules/pull/624) Add Promtail for platform logs in Azure.
+- [#630](https://github.com/XenitAB/terraform-modules/pull/630) Add variable for exluding Promtail namespaces
 
 ### Changed
 

--- a/modules/kubernetes/aks-core/README.md
+++ b/modules/kubernetes/aks-core/README.md
@@ -130,6 +130,7 @@ This module is used to create AKS clusters.
 | <a name="input_prometheus_enabled"></a> [prometheus\_enabled](#input\_prometheus\_enabled) | Should prometheus be enabled | `bool` | `true` | no |
 | <a name="input_promtail_config"></a> [promtail\_config](#input\_promtail\_config) | Configuration for promtail | <pre>object({<br>    azure_key_vault_name = string<br>    identity = object({<br>      client_id   = string<br>      resource_id = string<br>      tenant_id   = string<br>    })<br>    loki_address = string<br>  })</pre> | n/a | yes |
 | <a name="input_promtail_enabled"></a> [promtail\_enabled](#input\_promtail\_enabled) | Should promtail be enabled | `bool` | `false` | no |
+| <a name="input_promtail_exclude_namespaces"></a> [promtail\_exclude\_namespaces](#input\_promtail\_exclude\_namespaces) | Promtail will ship logs for all namespaces except for the ones in this variable. | `list(string)` | n/a | yes |
 | <a name="input_reloader_enabled"></a> [reloader\_enabled](#input\_reloader\_enabled) | Should Reloader be enabled | `bool` | `true` | no |
 | <a name="input_starboard_config"></a> [starboard\_config](#input\_starboard\_config) | Configuration for starboard | <pre>object({<br>    client_id   = string<br>    resource_id = string<br>  })</pre> | n/a | yes |
 | <a name="input_starboard_enabled"></a> [starboard\_enabled](#input\_starboard\_enabled) | Should Starboard be enabled | `bool` | `true` | no |

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -475,7 +475,7 @@ module "promtail" {
   cluster_name        = "${var.name}${var.aks_name_suffix}"
   environment         = var.environment
   tenant_id           = var.prometheus_config.tenant_id
-  excluded_namespaces = var.namespaces[*].name
+  excluded_namespaces = var.promtail_exclude_namespaces
 
   loki_address = var.promtail_config.loki_address
   azure_config = {

--- a/modules/kubernetes/aks-core/variables.tf
+++ b/modules/kubernetes/aks-core/variables.tf
@@ -60,6 +60,11 @@ variable "namespaces" {
   )
 }
 
+variable "promtail_exclude_namespaces" {
+  description = "Promtail will ship logs for all namespaces except for the ones in this variable."
+  type        = list(string)
+}
+
 variable "kubernetes_network_policy_default_deny" {
   description = "If network policies should by default deny cross namespace traffic"
   type        = bool

--- a/modules/kubernetes/eks-core/README.md
+++ b/modules/kubernetes/eks-core/README.md
@@ -117,6 +117,7 @@ This module is used to configure EKS clusters.
 | <a name="input_prometheus_enabled"></a> [prometheus\_enabled](#input\_prometheus\_enabled) | Should prometheus be enabled | `bool` | `true` | no |
 | <a name="input_promtail_config"></a> [promtail\_config](#input\_promtail\_config) | Configuration for promtail | <pre>object({<br>    role_arn     = string<br>    loki_address = string<br>  })</pre> | n/a | yes |
 | <a name="input_promtail_enabled"></a> [promtail\_enabled](#input\_promtail\_enabled) | Should promtail be enabled | `bool` | `false` | no |
+| <a name="input_promtail_exclude_namespaces"></a> [promtail\_exclude\_namespaces](#input\_promtail\_exclude\_namespaces) | Promtail will ship logs for all namespaces except for the ones in this variable. | `list(string)` | n/a | yes |
 | <a name="input_reloader_enabled"></a> [reloader\_enabled](#input\_reloader\_enabled) | Should Reloader be enabled | `bool` | `true` | no |
 | <a name="input_starboard_config"></a> [starboard\_config](#input\_starboard\_config) | Configuration for starboard & trivy | <pre>object({<br>    starboard_role_arn = string<br>    trivy_role_arn     = string<br>  })</pre> | n/a | yes |
 | <a name="input_starboard_enabled"></a> [starboard\_enabled](#input\_starboard\_enabled) | Should Starboard be enabled | `bool` | `false` | no |

--- a/modules/kubernetes/eks-core/modules.tf
+++ b/modules/kubernetes/eks-core/modules.tf
@@ -280,7 +280,7 @@ module "promtail" {
   cluster_name        = "${var.name}${var.eks_name_suffix}"
   environment         = var.environment
   tenant_id           = var.prometheus_config.tenant_id
-  excluded_namespaces = var.namespaces[*].name
+  excluded_namespaces = var.promtail_exclude_namespaces
 
   aws_config = {
     role_arn = var.promtail_config.role_arn

--- a/modules/kubernetes/eks-core/variables.tf
+++ b/modules/kubernetes/eks-core/variables.tf
@@ -35,6 +35,11 @@ variable "namespaces" {
   )
 }
 
+variable "promtail_exclude_namespaces" {
+  description = "Promtail will ship logs for all namespaces except for the ones in this variable."
+  type        = list(string)
+}
+
 variable "aad_groups" {
   description = "Configuration for aad groups"
   type = object({

--- a/validation/kubernetes/aks-core/main.tf
+++ b/validation/kubernetes/aks-core/main.tf
@@ -7,11 +7,12 @@ provider "azurerm" {
 module "aks_core" {
   source = "../../../modules/kubernetes/aks-core"
 
-  name            = "baz"
-  aks_name_suffix = 1
-  location_short  = "foo"
-  environment     = "bar"
-  namespaces      = []
+  name                        = "baz"
+  aks_name_suffix             = 1
+  location_short              = "foo"
+  environment                 = "bar"
+  namespaces                  = []
+  promtail_exclude_namespaces = []
   external_dns_config = {
     client_id   = "foo"
     resource_id = "bar"

--- a/validation/kubernetes/eks-core/main.tf
+++ b/validation/kubernetes/eks-core/main.tf
@@ -7,7 +7,8 @@ provider "aws" {
 module "eks_core" {
   source = "../../../modules/kubernetes/eks-core"
 
-  namespaces = []
+  namespaces                  = []
+  promtail_exclude_namespaces = []
 
   environment     = "dev"
   name            = "foo"


### PR DESCRIPTION
By default, Promtail in XKF in the aks-core and eks-core modules is set up to ships logs from all platform namespaces (i.e. the tenant namespaces are ignored). This PR makes it possible, on the aks-core and eks-core module level, to configure the namespaces that Promtail shall ignore to allow for a more flexible setup.