### PR TITLE
Create Azure AD Application for azad-kube-proxy using aks-global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+
+- [#639](https://github.com/XenitAB/terraform-modules/pull/639) Create Azure AD Application for azad-kube-proxy using aks-global
+
 ### Changed
 
 - [#635](https://github.com/XenitAB/terraform-modules/pull/635) Upgrade azurerm provider to v3.1.0.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains the Xenit Terraform modules.
 
 - [`aws`](modules/aws/README.md)
 - [`azure`](modules/azure/README.md)
+- [`azure-ad`](modules/azure-ad/README.md)
 - [`kubernetes`](modules/kubernetes/README.md)
 
 ## Contributing
@@ -20,6 +21,7 @@ apply to that provider. Following the standards below however will help you avoi
 
 Every resource name should be lowercase and snakecased. No other format should be used in the resource names. The role assignment for a cluster admin
 is named `cluster_admin` and not `clusterAdmin`.
+
 ```terraform
 resource "azurerm_role_assignment" "cluster_admin" {
   scope = azurerm_kubernetes_cluster.this.id
@@ -31,6 +33,7 @@ resource "azurerm_role_assignment" "cluster_admin" {
 Resources that only have a single instance and no fitting name that distinguishes it should use the name `this`. The reasoning is that it is more DRY
 than reporting the resource type like `aks` which other people may do. However if there is a fitting name please use it. Additionally please do not
 have to resources of the same type where one of them is called `this` and the other has a specific name, instead give both resources a specific name.
+
 ```terraform
 resource "azurerm_kubernetes_cluster" "this" {
   name                            = "aks-${var.environment}-${var.location_short}-${var.name}${var.aks_name_suffix}"

--- a/modules/azure-ad/.tflint.hcl
+++ b/modules/azure-ad/.tflint.hcl
@@ -1,0 +1,57 @@
+config {
+  module = false
+  force = false
+  disabled_by_default = false
+}
+
+rule "terraform_deprecated_interpolation" {
+  enabled = true
+}
+
+rule "terraform_deprecated_index" {
+  enabled = true
+}
+
+rule "terraform_unused_declarations" {
+  enabled = true
+}
+
+rule "terraform_comment_syntax" {
+  enabled = true
+}
+
+rule "terraform_documented_outputs" {
+  enabled = true
+}
+
+rule "terraform_documented_variables" {
+  enabled = true
+}
+
+rule "terraform_typed_variables" {
+  enabled = true
+}
+
+rule "terraform_module_pinned_source" {
+  enabled = true
+}
+
+rule "terraform_naming_convention" {
+  enabled = true
+}
+
+rule "terraform_required_version" {
+  enabled = true
+}
+
+rule "terraform_required_providers" {
+  enabled = true
+}
+
+rule "terraform_standard_module_structure" {
+  enabled = true
+}
+
+rule "terraform_workspace_remote" {
+  enabled = true
+}

--- a/modules/azure-ad/README.md
+++ b/modules/azure-ad/README.md
@@ -1,0 +1,11 @@
+# Azure AD Terraform modules
+
+This directory contains all the Azure AD Terraform modules.
+
+## Modules
+
+- [`azad-kube-proxy`](azad-kube-proxy/README.md)
+
+## Style Guide
+
+TBD

--- a/modules/azure-ad/azad-kube-proxy/README.md
+++ b/modules/azure-ad/azad-kube-proxy/README.md
@@ -1,0 +1,50 @@
+# Azure AD Application configuration for Azure AD Kubernetes API Proxy
+
+This module is used to configure the Azure AD Application used by [`azad-kube-proxy`](https://github.com/XenitAB/azad-kube-proxy).
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.19.1 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.19.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azuread_app_role_assignment.ms_graph_directory_read_all](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/app_role_assignment) | resource |
+| [azuread_application.this](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/application) | resource |
+| [azuread_application_password.this](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/application_password) | resource |
+| [azuread_application_pre_authorized.azure_cli](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/application_pre_authorized) | resource |
+| [azuread_service_principal.ms_graph](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/service_principal) | resource |
+| [azuread_service_principal.this](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/service_principal) | resource |
+| [random_uuid.oauth2_permission_scope_user_impersonation](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/uuid) | resource |
+| [azuread_application_published_app_ids.well_known](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/data-sources/application_published_app_ids) | data source |
+| [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/data-sources/client_config) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name that will show up in the discovery and be used as the context for the kubeconfig. | `string` | n/a | yes |
+| <a name="input_display_name"></a> [display\_name](#input\_display\_name) | The display name for the Azure AD application. | `string` | n/a | yes |
+| <a name="input_proxy_url"></a> [proxy\_url](#input\_proxy\_url) | The URL to the azad-kube-proxy, will be used for identified\_uris and proxy\_url tag. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_data"></a> [data](#output\_data) | The Azure AD Application data for azad-kube-proxy |

--- a/modules/azure-ad/azad-kube-proxy/main.tf
+++ b/modules/azure-ad/azad-kube-proxy/main.tf
@@ -1,0 +1,88 @@
+/**
+  * # Azure AD Application configuration for Azure AD Kubernetes API Proxy
+  *
+  * This module is used to configure the Azure AD Application used by [`azad-kube-proxy`](https://github.com/XenitAB/azad-kube-proxy).
+  */
+
+terraform {
+  required_version = ">= 1.1.7"
+
+  required_providers {
+    azuread = {
+      version = "2.19.1"
+      source  = "hashicorp/azuread"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.1.0"
+    }
+  }
+}
+
+data "azuread_client_config" "current" {}
+
+data "azuread_application_published_app_ids" "well_known" {}
+
+resource "random_uuid" "oauth2_permission_scope_user_impersonation" {}
+
+resource "azuread_service_principal" "ms_graph" {
+  application_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+  use_existing   = true
+}
+
+resource "azuread_application" "this" {
+  display_name = var.display_name
+  identifier_uris = [
+    var.proxy_url
+  ]
+
+  api {
+    requested_access_token_version = 2
+
+    oauth2_permission_scope {
+      admin_consent_description  = "Allow the application to access azad-kube-proxy on behalf of the signed-in user."
+      admin_consent_display_name = "Access azad-kube-proxy"
+      enabled                    = true
+      id                         = random_uuid.oauth2_permission_scope_user_impersonation.result
+      type                       = "User"
+      user_consent_description   = "Allow the application to access azad-kube-proxy on your behalf."
+      user_consent_display_name  = "Access azad-kube-proxy"
+      value                      = "user_impersonation"
+    }
+  }
+
+  required_resource_access {
+    resource_app_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+
+    resource_access {
+      id   = azuread_service_principal.ms_graph.app_role_ids["Directory.Read.All"]
+      type = "Role"
+    }
+  }
+
+  tags = [
+    "azad-kube-proxy",
+    "cluster_name:${var.cluster_name}",
+    "proxy_url:${var.proxy_url}",
+  ]
+}
+
+resource "azuread_application_pre_authorized" "azure_cli" {
+  application_object_id = azuread_application.this.object_id
+  authorized_app_id     = data.azuread_application_published_app_ids.well_known.result.MicrosoftAzureCli
+  permission_ids        = [random_uuid.oauth2_permission_scope_user_impersonation.result]
+}
+
+resource "azuread_application_password" "this" {
+  application_object_id = azuread_application.this.object_id
+}
+
+resource "azuread_service_principal" "this" {
+  application_id = azuread_application.this.application_id
+}
+
+resource "azuread_app_role_assignment" "ms_graph_directory_read_all" {
+  app_role_id         = azuread_service_principal.ms_graph.app_role_ids["Directory.Read.All"]
+  principal_object_id = azuread_service_principal.this.object_id
+  resource_object_id  = azuread_service_principal.ms_graph.object_id
+}

--- a/modules/azure-ad/azad-kube-proxy/outputs.tf
+++ b/modules/azure-ad/azad-kube-proxy/outputs.tf
@@ -1,0 +1,9 @@
+output "data" {
+  description = "The Azure AD Application data for azad-kube-proxy"
+  value = {
+    client_id     = azuread_application.this.application_id
+    client_secret = azuread_application_password.this.value
+    tenant_id     = data.azuread_client_config.current.tenant_id
+  }
+  sensitive = true
+}

--- a/modules/azure-ad/azad-kube-proxy/variables.tf
+++ b/modules/azure-ad/azad-kube-proxy/variables.tf
@@ -1,0 +1,14 @@
+variable "proxy_url" {
+  description = "The URL to the azad-kube-proxy, will be used for identified_uris and proxy_url tag."
+  type        = string
+}
+
+variable "display_name" {
+  description = "The display name for the Azure AD application."
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "The name that will show up in the discovery and be used as the context for the kubeconfig."
+  type        = string
+}

--- a/modules/azure/aks-global/README.md
+++ b/modules/azure/aks-global/README.md
@@ -18,6 +18,7 @@ This module is used to create resources that are used by AKS clusters.
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.19.1 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.1.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 3.1.0 |
 
 ## Modules
@@ -28,8 +29,12 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [azuread_app_role_assignment.azad_kube_proxy_msgraph_directory_read_all](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/app_role_assignment) | resource |
+| [azuread_application.azad_kube_proxy](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/application) | resource |
 | [azuread_application.helm_operator](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/application) | resource |
+| [azuread_application_password.azad_kube_proxy](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/application_password) | resource |
 | [azuread_application_password.helm_operator](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/application_password) | resource |
+| [azuread_application_pre_authorized.azad_kube_proxy_azure_cli](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/application_pre_authorized) | resource |
 | [azuread_group.aks_managed_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/group) | resource |
 | [azuread_group.cluster_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/group) | resource |
 | [azuread_group.cluster_view](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/group) | resource |
@@ -40,7 +45,9 @@ No modules.
 | [azuread_group_member.resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/group_member) | resource |
 | [azuread_group_member.resource_group_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/group_member) | resource |
 | [azuread_group_member.resource_group_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/group_member) | resource |
+| [azuread_service_principal.azad_kube_proxy](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/service_principal) | resource |
 | [azuread_service_principal.helm_operator](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/service_principal) | resource |
+| [azuread_service_principal.msgraph](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/service_principal) | resource |
 | [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/3.1.0/docs/resources/container_registry) | resource |
 | [azurerm_dns_zone.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.1.0/docs/resources/dns_zone) | resource |
 | [azurerm_key_vault_access_policy.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/3.1.0/docs/resources/key_vault_access_policy) | resource |
@@ -67,7 +74,9 @@ No modules.
 | [azurerm_user_assigned_identity.trivy](https://registry.terraform.io/providers/hashicorp/azurerm/3.1.0/docs/resources/user_assigned_identity) | resource |
 | [azurerm_user_assigned_identity.velero](https://registry.terraform.io/providers/hashicorp/azurerm/3.1.0/docs/resources/user_assigned_identity) | resource |
 | [azurerm_user_assigned_identity.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/3.1.0/docs/resources/user_assigned_identity) | resource |
+| [random_uuid.azad_kube_proxy_oauth2_permission_scope_user_impersonation](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/uuid) | resource |
 | [tls_private_key.ssh_key](https://registry.terraform.io/providers/hashicorp/tls/3.1.0/docs/resources/private_key) | resource |
+| [azuread_application_published_app_ids.well_known](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/data-sources/application_published_app_ids) | data source |
 | [azuread_group.acr_pull](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/data-sources/group) | data source |
 | [azuread_group.acr_push](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/data-sources/group) | data source |
 | [azuread_group.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/data-sources/group) | data source |
@@ -84,6 +93,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_aks_authorized_ips"></a> [aks\_authorized\_ips](#input\_aks\_authorized\_ips) | Authorized IPs to access AKS API | `list(string)` | n/a | yes |
 | <a name="input_aks_group_name_prefix"></a> [aks\_group\_name\_prefix](#input\_aks\_group\_name\_prefix) | Prefix for AKS Azure AD groups | `string` | `"aks"` | no |
+| <a name="input_azad_kube_proxy_config"></a> [azad\_kube\_proxy\_config](#input\_azad\_kube\_proxy\_config) | Azure AD Kubernetes Proxy configuration | <pre>object({<br>    cluster_name_prefix = string<br>    proxy_url_override  = string<br>  })</pre> | <pre>{<br>  "cluster_name_prefix": "aks",<br>  "proxy_url_override": ""<br>}</pre> | no |
 | <a name="input_azure_ad_group_prefix"></a> [azure\_ad\_group\_prefix](#input\_azure\_ad\_group\_prefix) | Prefix for Azure AD Groups | `string` | `"az"` | no |
 | <a name="input_core_name"></a> [core\_name](#input\_core\_name) | The name for the core infrastructure | `string` | n/a | yes |
 | <a name="input_dns_zone"></a> [dns\_zone](#input\_dns\_zone) | List of DNS Zone to create | `list(string)` | n/a | yes |
@@ -107,6 +117,7 @@ No modules.
 | <a name="output_aks_authorized_ips"></a> [aks\_authorized\_ips](#output\_aks\_authorized\_ips) | IP addresses authorized for API communication to Azure Kubernetes Service |
 | <a name="output_aks_managed_identity_group_id"></a> [aks\_managed\_identity\_group\_id](#output\_aks\_managed\_identity\_group\_id) | The group id of aks managed identity |
 | <a name="output_aks_public_ip_prefix_ids"></a> [aks\_public\_ip\_prefix\_ids](#output\_aks\_public\_ip\_prefix\_ids) | Azure Kubernetes Service IP Prefixes |
+| <a name="output_azad_kube_proxy"></a> [azad\_kube\_proxy](#output\_azad\_kube\_proxy) | The Azure AD Application config for azad-kube-proxy |
 | <a name="output_dns_zone"></a> [dns\_zone](#output\_dns\_zone) | DNS Zone to be used with external-dns |
 | <a name="output_external_dns_identity"></a> [external\_dns\_identity](#output\_external\_dns\_identity) | MSI authentication identity for External DNS |
 | <a name="output_helm_operator_credentials"></a> [helm\_operator\_credentials](#output\_helm\_operator\_credentials) | Credentials meant to be used by Helm Operator |

--- a/modules/azure/aks-global/README.md
+++ b/modules/azure/aks-global/README.md
@@ -18,23 +18,20 @@ This module is used to create resources that are used by AKS clusters.
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.19.1 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.1.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 3.1.0 |
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_azad_kube_proxy"></a> [azad\_kube\_proxy](#module\_azad\_kube\_proxy) | ../../azure-ad/azad-kube-proxy | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [azuread_app_role_assignment.azad_kube_proxy_msgraph_directory_read_all](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/app_role_assignment) | resource |
-| [azuread_application.azad_kube_proxy](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/application) | resource |
 | [azuread_application.helm_operator](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/application) | resource |
-| [azuread_application_password.azad_kube_proxy](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/application_password) | resource |
 | [azuread_application_password.helm_operator](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/application_password) | resource |
-| [azuread_application_pre_authorized.azad_kube_proxy_azure_cli](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/application_pre_authorized) | resource |
 | [azuread_group.aks_managed_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/group) | resource |
 | [azuread_group.cluster_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/group) | resource |
 | [azuread_group.cluster_view](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/group) | resource |
@@ -45,9 +42,7 @@ No modules.
 | [azuread_group_member.resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/group_member) | resource |
 | [azuread_group_member.resource_group_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/group_member) | resource |
 | [azuread_group_member.resource_group_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/group_member) | resource |
-| [azuread_service_principal.azad_kube_proxy](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/service_principal) | resource |
 | [azuread_service_principal.helm_operator](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/service_principal) | resource |
-| [azuread_service_principal.msgraph](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/resources/service_principal) | resource |
 | [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/3.1.0/docs/resources/container_registry) | resource |
 | [azurerm_dns_zone.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.1.0/docs/resources/dns_zone) | resource |
 | [azurerm_key_vault_access_policy.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/3.1.0/docs/resources/key_vault_access_policy) | resource |
@@ -74,9 +69,7 @@ No modules.
 | [azurerm_user_assigned_identity.trivy](https://registry.terraform.io/providers/hashicorp/azurerm/3.1.0/docs/resources/user_assigned_identity) | resource |
 | [azurerm_user_assigned_identity.velero](https://registry.terraform.io/providers/hashicorp/azurerm/3.1.0/docs/resources/user_assigned_identity) | resource |
 | [azurerm_user_assigned_identity.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/3.1.0/docs/resources/user_assigned_identity) | resource |
-| [random_uuid.azad_kube_proxy_oauth2_permission_scope_user_impersonation](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/uuid) | resource |
 | [tls_private_key.ssh_key](https://registry.terraform.io/providers/hashicorp/tls/3.1.0/docs/resources/private_key) | resource |
-| [azuread_application_published_app_ids.well_known](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/data-sources/application_published_app_ids) | data source |
 | [azuread_group.acr_pull](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/data-sources/group) | data source |
 | [azuread_group.acr_push](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/data-sources/group) | data source |
 | [azuread_group.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.19.1/docs/data-sources/group) | data source |

--- a/modules/azure/aks-global/azad-kube-proxy.tf
+++ b/modules/azure/aks-global/azad-kube-proxy.tf
@@ -1,0 +1,57 @@
+locals {
+  azad_kube_proxy_url = var.azad_kube_proxy_config.proxy_url_override == "" ? "https://aks.${var.dns_zone[0]}" : var.azad_kube_proxy_config.proxy_url_override
+}
+
+resource "azuread_application" "azad_kube_proxy" {
+  for_each = {
+    for s in ["azad-kube-proxy"] :
+    s => s
+    if var.azad_kube_proxy_config.enabled
+  }
+
+  display_name = "${var.azad_kube_proxy_config.cluster_name_prefix}-${var.environment}"
+  identifier_uris = [
+    local.azad_kube_proxy_url
+  ]
+
+  api {
+    requested_access_token_version = 2
+  }
+
+  required_resource_access {
+    resource_app_id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph
+
+    resource_access {
+      id   = "7ab1d382-f21e-4acd-a863-ba3e13f7da61" # Directory.Read.All
+      type = "Role"
+    }
+  }
+
+  tags = [
+    "azad-kube-proxy",
+    "cluster_name:${var.azad_kube_proxy_config.cluster_name_prefix}-${var.environment}",
+    "proxy_url:${local.azad_kube_proxy_url}",
+  ]
+}
+
+resource "azuread_application_password" "azad_kube_proxy" {
+  for_each = {
+    for s in ["azad-kube-proxy"] :
+    s => s
+    if var.azad_kube_proxy_config.enabled
+  }
+
+  application_object_id = azuread_application.azad_kube_proxy.object_id
+}
+
+resource "azuread_application_pre_authorized" "azad_kube_proxy_azure_cli" {
+  for_each = {
+    for s in ["azad-kube-proxy"] :
+    s => s
+    if var.azad_kube_proxy_config.enabled
+  }
+
+  application_object_id = azuread_application.azad_kube_proxy.object_id
+  authorized_app_id     = "04b07795-8ddb-461a-bbee-02f9e1bf7b46" # Azure CLI
+  permission_ids        = azuread_application.azad_kube_proxy.oauth2_permission_scope_ids
+}

--- a/modules/azure/aks-global/azad-kube-proxy.tf
+++ b/modules/azure/aks-global/azad-kube-proxy.tf
@@ -35,13 +35,9 @@ resource "azuread_application" "azad_kube_proxy" {
   required_resource_access {
     resource_app_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
 
-    # resource_access {
-    #   id   = azuread_service_principal.msgraph.app_role_ids["Directory.Read.All"]
-    #   type = "Role"
-    # }
     resource_access {
-      id   = azuread_service_principal.msgraph.oauth2_permission_scope_ids["Directory.Read.All"]
-      type = "Scope"
+      id   = azuread_service_principal.msgraph.app_role_ids["Directory.Read.All"]
+      type = "Role"
     }
   }
 

--- a/modules/azure/aks-global/azad-kube-proxy.tf
+++ b/modules/azure/aks-global/azad-kube-proxy.tf
@@ -65,5 +65,5 @@ resource "azuread_service_principal" "azad_kube_proxy" {
 resource "azuread_service_principal_delegated_permission_grant" "azad_kube_proxy" {
   service_principal_object_id          = azuread_service_principal.azad_kube_proxy.object_id
   resource_service_principal_object_id = azuread_service_principal.msgraph.object_id
-  claim_values                         = ["Directory.Read.All"]
+  claim_values                         = ["openid", "Directory.Read.All"]
 }

--- a/modules/azure/aks-global/azad-kube-proxy.tf
+++ b/modules/azure/aks-global/azad-kube-proxy.tf
@@ -1,69 +1,12 @@
-data "azuread_application_published_app_ids" "well_known" {}
-resource "random_uuid" "azad_kube_proxy_oauth2_permission_scope_user_impersonation" {
-
-}
-resource "azuread_service_principal" "msgraph" {
-  application_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
-  use_existing   = true
-}
-
 locals {
-  azad_kube_proxy_url = var.azad_kube_proxy_config.proxy_url_override == "" ? "https://aks.${var.dns_zone[0]}" : var.azad_kube_proxy_config.proxy_url_override
+  azad_kube_proxy_url  = var.azad_kube_proxy_config.proxy_url_override == "" ? "https://aks.${var.dns_zone[0]}" : var.azad_kube_proxy_config.proxy_url_override
+  azad_kube_proxy_name = "${var.azad_kube_proxy_config.cluster_name_prefix}-${var.environment}"
 }
 
-resource "azuread_application" "azad_kube_proxy" {
-  display_name = "${var.azad_kube_proxy_config.cluster_name_prefix}-${var.environment}"
-  identifier_uris = [
-    local.azad_kube_proxy_url
-  ]
+module "azad_kube_proxy" {
+  source = "../../azure-ad/azad-kube-proxy"
 
-  api {
-    requested_access_token_version = 2
-
-    oauth2_permission_scope {
-      admin_consent_description  = "Allow the application to access azad-kube-proxy on behalf of the signed-in user."
-      admin_consent_display_name = "Access azad-kube-proxy"
-      enabled                    = true
-      id                         = random_uuid.azad_kube_proxy_oauth2_permission_scope_user_impersonation.result
-      type                       = "User"
-      user_consent_description   = "Allow the application to access azad-kube-proxy on your behalf."
-      user_consent_display_name  = "Access azad-kube-proxy"
-      value                      = "user_impersonation"
-    }
-  }
-
-  required_resource_access {
-    resource_app_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
-
-    resource_access {
-      id   = azuread_service_principal.msgraph.app_role_ids["Directory.Read.All"]
-      type = "Role"
-    }
-  }
-
-  tags = [
-    "azad-kube-proxy",
-    "cluster_name:${var.azad_kube_proxy_config.cluster_name_prefix}-${var.environment}",
-    "proxy_url:${local.azad_kube_proxy_url}",
-  ]
-}
-
-resource "azuread_application_password" "azad_kube_proxy" {
-  application_object_id = azuread_application.azad_kube_proxy.object_id
-}
-
-resource "azuread_application_pre_authorized" "azad_kube_proxy_azure_cli" {
-  application_object_id = azuread_application.azad_kube_proxy.object_id
-  authorized_app_id     = data.azuread_application_published_app_ids.well_known.result.MicrosoftAzureCli
-  permission_ids        = [random_uuid.azad_kube_proxy_oauth2_permission_scope_user_impersonation.result]
-}
-
-resource "azuread_service_principal" "azad_kube_proxy" {
-  application_id = azuread_application.azad_kube_proxy.application_id
-}
-
-resource "azuread_app_role_assignment" "azad_kube_proxy_msgraph_directory_read_all" {
-  app_role_id         = azuread_service_principal.msgraph.app_role_ids["Directory.Read.All"]
-  principal_object_id = azuread_service_principal.azad_kube_proxy.object_id
-  resource_object_id  = azuread_service_principal.msgraph.object_id
+  proxy_url    = local.azad_kube_proxy_url
+  display_name = local.azad_kube_proxy_name
+  cluster_name = local.azad_kube_proxy_name
 }

--- a/modules/azure/aks-global/azad-kube-proxy.tf
+++ b/modules/azure/aks-global/azad-kube-proxy.tf
@@ -20,10 +20,6 @@ resource "azuread_application" "azad_kube_proxy" {
   api {
     requested_access_token_version = 2
 
-    known_client_applications = [
-      data.azuread_application_published_app_ids.well_known.result.MicrosoftAzureCli
-    ]
-
     oauth2_permission_scope {
       admin_consent_description  = "Allow the application to access azad-kube-proxy on behalf of the signed-in user."
       admin_consent_display_name = "Access azad-kube-proxy"
@@ -56,8 +52,8 @@ resource "azuread_application_password" "azad_kube_proxy" {
   application_object_id = azuread_application.azad_kube_proxy.object_id
 }
 
-# resource "azuread_application_pre_authorized" "azad_kube_proxy_azure_cli" {
-#   application_object_id = azuread_application.azad_kube_proxy.object_id
-#   authorized_app_id     = "04b07795-8ddb-461a-bbee-02f9e1bf7b46" # Azure CLI
-#   permission_ids        = [random_uuid.azad_kube_proxy_oauth2_permission_scope_user_impersonation.result]
-# }
+resource "azuread_application_pre_authorized" "azad_kube_proxy_azure_cli" {
+  application_object_id = azuread_application.azad_kube_proxy.object_id
+  authorized_app_id     = data.azuread_application_published_app_ids.well_known.result.MicrosoftAzureCli
+  permission_ids        = [random_uuid.azad_kube_proxy_oauth2_permission_scope_user_impersonation.result]
+}

--- a/modules/azure/aks-global/azad-kube-proxy.tf
+++ b/modules/azure/aks-global/azad-kube-proxy.tf
@@ -53,5 +53,5 @@ resource "azuread_application_pre_authorized" "azad_kube_proxy_azure_cli" {
 
   application_object_id = azuread_application.azad_kube_proxy["azad-kube-proxy"].object_id
   authorized_app_id     = "04b07795-8ddb-461a-bbee-02f9e1bf7b46" # Azure CLI
-  permission_ids        = azuread_application.azad_kube_proxy["azad-kube-proxy"].oauth2_permission_scope_ids
+  permission_ids        = azuread_application.azad_kube_proxy["azad-kube-proxy"].oauth2_permission_scope_ids[0]
 }

--- a/modules/azure/aks-global/azad-kube-proxy.tf
+++ b/modules/azure/aks-global/azad-kube-proxy.tf
@@ -41,7 +41,7 @@ resource "azuread_application_password" "azad_kube_proxy" {
     if var.azad_kube_proxy_config.enabled
   }
 
-  application_object_id = azuread_application.azad_kube_proxy.object_id
+  application_object_id = azuread_application.azad_kube_proxy["azad-kube-proxy"].object_id
 }
 
 resource "azuread_application_pre_authorized" "azad_kube_proxy_azure_cli" {
@@ -51,7 +51,7 @@ resource "azuread_application_pre_authorized" "azad_kube_proxy_azure_cli" {
     if var.azad_kube_proxy_config.enabled
   }
 
-  application_object_id = azuread_application.azad_kube_proxy.object_id
+  application_object_id = azuread_application.azad_kube_proxy["azad-kube-proxy"].object_id
   authorized_app_id     = "04b07795-8ddb-461a-bbee-02f9e1bf7b46" # Azure CLI
-  permission_ids        = azuread_application.azad_kube_proxy.oauth2_permission_scope_ids
+  permission_ids        = azuread_application.azad_kube_proxy["azad-kube-proxy"].oauth2_permission_scope_ids
 }

--- a/modules/azure/aks-global/azad-kube-proxy.tf
+++ b/modules/azure/aks-global/azad-kube-proxy.tf
@@ -62,12 +62,12 @@ resource "azuread_application_pre_authorized" "azad_kube_proxy_azure_cli" {
   permission_ids        = [random_uuid.azad_kube_proxy_oauth2_permission_scope_user_impersonation.result]
 }
 
-# resource "azuread_service_principal" "azad_kube_proxy" {
-#   application_id = azuread_application.azad_kube_proxy.application_id
-# }
+resource "azuread_service_principal" "azad_kube_proxy" {
+  application_id = azuread_application.azad_kube_proxy.application_id
+}
 
-# resource "azuread_service_principal_delegated_permission_grant" "azad_kube_proxy" {
-#   service_principal_object_id          = azuread_service_principal.azad_kube_proxy.object_id
-#   resource_service_principal_object_id = azuread_service_principal.msgraph.object_id
-#   claim_values                         = ["openid", "Directory.Read.All"]
-# }
+resource "azuread_service_principal_delegated_permission_grant" "azad_kube_proxy" {
+  service_principal_object_id          = azuread_service_principal.azad_kube_proxy.object_id
+  resource_service_principal_object_id = azuread_service_principal.msgraph.object_id
+  claim_values                         = ["Directory.Read.All"]
+}

--- a/modules/azure/aks-global/azad-kube-proxy.tf
+++ b/modules/azure/aks-global/azad-kube-proxy.tf
@@ -35,9 +35,13 @@ resource "azuread_application" "azad_kube_proxy" {
   required_resource_access {
     resource_app_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
 
+    # resource_access {
+    #   id   = azuread_service_principal.msgraph.app_role_ids["Directory.Read.All"]
+    #   type = "Role"
+    # }
     resource_access {
-      id   = azuread_service_principal.msgraph.app_role_ids["Directory.Read.All"]
-      type = "Role"
+      id   = azuread_service_principal.msgraph.oauth2_permission_scope_ids["Directory.Read.All"]
+      type = "Scope"
     }
   }
 
@@ -58,12 +62,12 @@ resource "azuread_application_pre_authorized" "azad_kube_proxy_azure_cli" {
   permission_ids        = [random_uuid.azad_kube_proxy_oauth2_permission_scope_user_impersonation.result]
 }
 
-resource "azuread_service_principal" "azad_kube_proxy" {
-  application_id = azuread_application.azad_kube_proxy.application_id
-}
+# resource "azuread_service_principal" "azad_kube_proxy" {
+#   application_id = azuread_application.azad_kube_proxy.application_id
+# }
 
-resource "azuread_service_principal_delegated_permission_grant" "azad_kube_proxy" {
-  service_principal_object_id          = azuread_service_principal.azad_kube_proxy.object_id
-  resource_service_principal_object_id = azuread_service_principal.msgraph.object_id
-  claim_values                         = ["openid", "Directory.Read.All"]
-}
+# resource "azuread_service_principal_delegated_permission_grant" "azad_kube_proxy" {
+#   service_principal_object_id          = azuread_service_principal.azad_kube_proxy.object_id
+#   resource_service_principal_object_id = azuread_service_principal.msgraph.object_id
+#   claim_values                         = ["openid", "Directory.Read.All"]
+# }

--- a/modules/azure/aks-global/azad-kube-proxy.tf
+++ b/modules/azure/aks-global/azad-kube-proxy.tf
@@ -62,8 +62,8 @@ resource "azuread_service_principal" "azad_kube_proxy" {
   application_id = azuread_application.azad_kube_proxy.application_id
 }
 
-resource "azuread_service_principal_delegated_permission_grant" "azad_kube_proxy" {
-  service_principal_object_id          = azuread_service_principal.azad_kube_proxy.object_id
-  resource_service_principal_object_id = azuread_service_principal.msgraph.object_id
-  claim_values                         = ["Directory.Read.All"]
+resource "azuread_app_role_assignment" "azad_kube_proxy_msgraph_directory_read_all" {
+  app_role_id         = azuread_service_principal.msgraph.app_role_ids["Directory.Read.All"]
+  principal_object_id = azuread_service_principal.azad_kube_proxy.object_id
+  resource_object_id  = azuread_service_principal.msgraph.object_id
 }

--- a/modules/azure/aks-global/azad-kube-proxy.tf
+++ b/modules/azure/aks-global/azad-kube-proxy.tf
@@ -3,12 +3,6 @@ locals {
 }
 
 resource "azuread_application" "azad_kube_proxy" {
-  for_each = {
-    for s in ["azad-kube-proxy"] :
-    s => s
-    if var.azad_kube_proxy_config.enabled
-  }
-
   display_name = "${var.azad_kube_proxy_config.cluster_name_prefix}-${var.environment}"
   identifier_uris = [
     local.azad_kube_proxy_url
@@ -35,23 +29,11 @@ resource "azuread_application" "azad_kube_proxy" {
 }
 
 resource "azuread_application_password" "azad_kube_proxy" {
-  for_each = {
-    for s in ["azad-kube-proxy"] :
-    s => s
-    if var.azad_kube_proxy_config.enabled
-  }
-
-  application_object_id = azuread_application.azad_kube_proxy["azad-kube-proxy"].object_id
+  application_object_id = azuread_application.azad_kube_proxy.object_id
 }
 
 resource "azuread_application_pre_authorized" "azad_kube_proxy_azure_cli" {
-  for_each = {
-    for s in ["azad-kube-proxy"] :
-    s => s
-    if var.azad_kube_proxy_config.enabled
-  }
-
-  application_object_id = azuread_application.azad_kube_proxy["azad-kube-proxy"].object_id
+  application_object_id = azuread_application.azad_kube_proxy.object_id
   authorized_app_id     = "04b07795-8ddb-461a-bbee-02f9e1bf7b46" # Azure CLI
-  permission_ids        = [for id in azuread_application.azad_kube_proxy["azad-kube-proxy"].oauth2_permission_scope_ids : id]
+  permission_ids        = [for id in azuread_application.azad_kube_proxy.oauth2_permission_scope_ids : id]
 }

--- a/modules/azure/aks-global/azad-kube-proxy.tf
+++ b/modules/azure/aks-global/azad-kube-proxy.tf
@@ -57,3 +57,13 @@ resource "azuread_application_pre_authorized" "azad_kube_proxy_azure_cli" {
   authorized_app_id     = data.azuread_application_published_app_ids.well_known.result.MicrosoftAzureCli
   permission_ids        = [random_uuid.azad_kube_proxy_oauth2_permission_scope_user_impersonation.result]
 }
+
+resource "azuread_service_principal" "azad_kube_proxy" {
+  application_id = azuread_application.azad_kube_proxy.application_id
+}
+
+resource "azuread_service_principal_delegated_permission_grant" "azad_kube_proxy" {
+  service_principal_object_id          = azuread_service_principal.azad_kube_proxy.object_id
+  resource_service_principal_object_id = azuread_service_principal.msgraph.object_id
+  claim_values                         = ["Directory.Read.All"]
+}

--- a/modules/azure/aks-global/azad-kube-proxy.tf
+++ b/modules/azure/aks-global/azad-kube-proxy.tf
@@ -53,5 +53,5 @@ resource "azuread_application_pre_authorized" "azad_kube_proxy_azure_cli" {
 
   application_object_id = azuread_application.azad_kube_proxy["azad-kube-proxy"].object_id
   authorized_app_id     = "04b07795-8ddb-461a-bbee-02f9e1bf7b46" # Azure CLI
-  permission_ids        = azuread_application.azad_kube_proxy["azad-kube-proxy"].oauth2_permission_scope_ids[0]
+  permission_ids        = [for id in azuread_application.azad_kube_proxy["azad-kube-proxy"].oauth2_permission_scope_ids : id]
 }

--- a/modules/azure/aks-global/outputs.tf
+++ b/modules/azure/aks-global/outputs.tf
@@ -94,3 +94,15 @@ output "aks_managed_identity_group_id" {
   description = "The group id of aks managed identity"
   value       = azuread_group.aks_managed_identity.id
 }
+
+output "azad_kube_proxy" {
+  description = "The Azure AD Application config for azad-kube-proxy"
+  value = {
+    azure_ad_app = {
+      client_id     = azuread_application.azad_kube_proxy["azad-kube-proxy"].application_id
+      client_secret = azuread_application_password.azad_kube_proxy["azad-kube-proxy"].value
+      tenant_id     = data.azurerm_client_config.current.tenant_id
+    }
+  }
+  sensitive = true
+}

--- a/modules/azure/aks-global/outputs.tf
+++ b/modules/azure/aks-global/outputs.tf
@@ -98,11 +98,7 @@ output "aks_managed_identity_group_id" {
 output "azad_kube_proxy" {
   description = "The Azure AD Application config for azad-kube-proxy"
   value = {
-    azure_ad_app = {
-      client_id     = azuread_application.azad_kube_proxy.application_id
-      client_secret = azuread_application_password.azad_kube_proxy.value
-      tenant_id     = data.azurerm_client_config.current.tenant_id
-    }
+    azure_ad_app = module.azad_kube_proxy.data
   }
   sensitive = true
 }

--- a/modules/azure/aks-global/outputs.tf
+++ b/modules/azure/aks-global/outputs.tf
@@ -99,8 +99,8 @@ output "azad_kube_proxy" {
   description = "The Azure AD Application config for azad-kube-proxy"
   value = {
     azure_ad_app = {
-      client_id     = azuread_application.azad_kube_proxy["azad-kube-proxy"].application_id
-      client_secret = azuread_application_password.azad_kube_proxy["azad-kube-proxy"].value
+      client_id     = azuread_application.azad_kube_proxy.application_id
+      client_secret = azuread_application_password.azad_kube_proxy.value
       tenant_id     = data.azurerm_client_config.current.tenant_id
     }
   }

--- a/modules/azure/aks-global/variables.tf
+++ b/modules/azure/aks-global/variables.tf
@@ -90,7 +90,7 @@ variable "azad_kube_proxy_config" {
   type = object({
     enabled             = bool
     cluster_name_prefix = string
-    proxy_url_override  = ""
+    proxy_url_override  = string
   })
   default = {
     enabled             = false

--- a/modules/azure/aks-global/variables.tf
+++ b/modules/azure/aks-global/variables.tf
@@ -88,12 +88,10 @@ variable "aks_group_name_prefix" {
 variable "azad_kube_proxy_config" {
   description = "Azure AD Kubernetes Proxy configuration"
   type = object({
-    enabled             = bool
     cluster_name_prefix = string
     proxy_url_override  = string
   })
   default = {
-    enabled             = false
     cluster_name_prefix = "aks"
     proxy_url_override  = ""
   }

--- a/modules/azure/aks-global/variables.tf
+++ b/modules/azure/aks-global/variables.tf
@@ -84,3 +84,17 @@ variable "aks_group_name_prefix" {
   type        = string
   default     = "aks"
 }
+
+variable "azad_kube_proxy_config" {
+  description = "Azure AD Kubernetes Proxy configuration"
+  type = object({
+    enabled             = bool
+    cluster_name_prefix = string
+    proxy_url_override  = ""
+  })
+  default = {
+    enabled             = false
+    cluster_name_prefix = "aks"
+    proxy_url_override  = ""
+  }
+}

--- a/modules/kubernetes/azad-kube-proxy/main.tf
+++ b/modules/kubernetes/azad-kube-proxy/main.tf
@@ -2,43 +2,7 @@
  * # Azure AD Kubernetes API Proxy
  * Adds [`azad-kube-proxy`](https://github.com/XenitAB/azad-kube-proxy) to a Kubernetes clusters.
  *
- * ## Configuring Azure AD Applications
- *
- * ### Azure AD App: azad-kube-proxy
- *
- * ```shell
- * ENVIRONMENT="dev"
- * TENANT_ID=$(az account show --output tsv --query tenantId)
- * AZ_APP_NAME="aks-${ENVIRONMENT}"
- * AZ_APP_URI="https://aks.${ENVIRONMENT}.example.com"
- * AZ_APP_ID=$(az ad app create --display-name ${AZ_APP_NAME} --identifier-uris ${AZ_APP_URI} --query appId -o tsv)
- * AZ_APP_OBJECT_ID=$(az ad app show --id ${AZ_APP_ID} --output tsv --query objectId)
- * AZ_APP_PERMISSION_ID=$(az ad app show --id ${AZ_APP_ID} --output tsv --query "oauth2Permissions[0].id")
- * az rest --method PATCH --uri "https://graph.microsoft.com/beta/applications/${AZ_APP_OBJECT_ID}" --body '{"api":{"requestedAccessTokenVersion": 2}}'
- * # Add Azure CLI as allowed client
- * az rest --method PATCH --uri "https://graph.microsoft.com/beta/applications/${AZ_APP_OBJECT_ID}" --body "{\"api\":{\"preAuthorizedApplications\":[{\"appId\":\"04b07795-8ddb-461a-bbee-02f9e1bf7b46\",\"permissionIds\":[\"${AZ_APP_PERMISSION_ID}\"]}]}}"
- * # This tag will enable discovery using kubectl azad-proxy discover
- * az rest --method PATCH --uri "https://graph.microsoft.com/beta/applications/${AZ_APP_OBJECT_ID}" --body '{"tags":["azad-kube-proxy"]}'
- * AZ_APP_SECRET=$(az ad sp credential reset --name ${AZ_APP_ID} --credential-description "azad-kube-proxy" --output tsv --query password)
- * az ad app permission add --id ${AZ_APP_ID} --api 00000003-0000-0000-c000-000000000000 --api-permissions 7ab1d382-f21e-4acd-a863-ba3e13f7da61=Role
- * az ad app permission admin-consent --id ${AZ_APP_ID}
- * ```
- *
- * ### Azure KeyVault
- *
- * ```shell
- * JSON_FMT='{"client_id":"%s","client_secret":"%s","tenant_id":"%s"}'
- * KV_SECRET=$(printf "${JSON_FMT}" "${AZ_APP_ID}" "${AZ_APP_SECRET}" "${TENANT_ID}")
- * az keyvault secret set --vault-name <keyvault name> --name azad-kube-proxy --value "${KV_SECRET}"
- * ```
- *
- * ## Terraform example (aks-core)
- *
- * ```terraform
- * data "azurerm_key_vault_secret" "azad_kube_proxy" {
- *   key_vault_id = data.azurerm_key_vault.core.id
- *   name         = "azad-kube-proxy"
- * }
+ * # Terraform example (aks-core)
  *
  * module "aks_core" {
  *   source = "github.com/xenitab/terraform-modules//modules/kubernetes/aks-core?ref=[ref]"
@@ -50,11 +14,7 @@
  *     fqdn                  = "aks.${var.dns_zone}"
  *     azure_ad_group_prefix = var.aks_group_name_prefix
  *     allowed_ips           = var.aks_authorized_ips
- *     azure_ad_app = {
- *       client_id     = jsondecode(data.azurerm_key_vault_secret.azad_kube_proxy.value).client_id
- *       client_secret = jsondecode(data.azurerm_key_vault_secret.azad_kube_proxy.value).client_secret
- *       tenant_id     = jsondecode(data.azurerm_key_vault_secret.azad_kube_proxy.value).tenant_id
- *     }
+ *     azure_ad_app          = module.aks_global.azad_kube_proxy.azure_ad_app
  *   }
  * }
  * ```
@@ -115,7 +75,7 @@ resource "helm_release" "azad_kube_proxy" {
   chart       = "azad-kube-proxy"
   name        = "azad-kube-proxy"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "v0.0.30"
+  version     = "v0.0.33"
   max_history = 3
   values      = [local.values]
 }

--- a/validation/azure-ad/azad-kube-proxy/main.tf
+++ b/validation/azure-ad/azad-kube-proxy/main.tf
@@ -1,0 +1,9 @@
+terraform {}
+
+module "azad_kube_proxy" {
+  source = "../../../modules/azure-ad/azad-kube-proxy"
+
+  proxy_url    = "https://aks.dev.example.com"
+  display_name = "example-aks-dev"
+  cluster_name = "example-aks-dev"
+}


### PR DESCRIPTION
This PR introduces a long awaited feature now enabled with using the latests terraform Azure AD provider (and with that, Microsoft Graph) where we are creating the Azure AD application used by azad-kube-proxy with terraform instead of manually.

You will now configure `aks-global` like this:
```terraform
module "aks_global" {
  source = "github.com/xenitab/terraform-modules//modules/azure/aks-global?ref=[ref]"

  [...]

  azad_kube_proxy_config = {
    cluster_name_prefix = "aks"
    proxy_url_override  = ""
  }
}
```

And then `aks-core` like this:
```terraform
module "aks1_core" {
  source = "github.com/xenitab/terraform-modules//modules/kubernetes/aks-core?ref=[ref]"

  [...]

  azad_kube_proxy_enabled = true
  azad_kube_proxy_config = {
    fqdn                  = "aks.${var.dns_zone}"
    azure_ad_group_prefix = var.aks_group_name_prefix
    allowed_ips           = var.aks_authorized_ips
    azure_ad_app          = module.aks_global.azad_kube_proxy.azure_ad_app
  }
}
```

This will also make it easy to change the name that shows up in the kubectl context, from `aks-[env]` to something like `customer-aks-[env]` if we want to by changing the `cluster_name_prefix` from `aks` to `customer-aks`. This may be a breaking change and should be tested carefully before doing.

Importing current Azure AD Application:
```shell
ENV=dev
AZ_APP_ID=$(az ad app list --display-name "aks-${ENV}" --query "[0].appId" -o tsv)
AZ_APP_PERMISSION_ID=$(az ad app show --id ${AZ_APP_ID} --output tsv --query "oauth2Permissions[0].id")
AZ_APP_OBJECT_ID=$(az ad app show --id ${AZ_APP_ID} --output tsv --query objectId)
AZ_SP_OBJECT_ID=$(az ad sp show --id $AZ_APP_ID --output tsv --query objectId)
APP_ROLE_ASSIGNMENT_ID=$(az rest --method GET --uri "https://graph.microsoft.com/v1.0/servicePrincipals/${AZ_SP_OBJECT_ID}/appRoleAssignments" --query "value[0].id" -o tsv)

terraform import -var-file=../global.tfvars -var-file=variables/common.tfvars -var-file=variables/${ENV}.tfvars module.aks_global.module.azad_kube_proxy.azuread_application.this $AZ_APP_OBJECT_ID
terraform import -var-file=../global.tfvars -var-file=variables/common.tfvars -var-file=variables/${ENV}.tfvars module.aks_global.module.azad_kube_proxy.azuread_service_principal.this $AZ_SP_OBJECT_ID
terraform import -var-file=../global.tfvars -var-file=variables/common.tfvars -var-file=variables/${ENV}.tfvars module.aks_global.module.azad_kube_proxy.azuread_application_pre_authorized.azure_cli ${AZ_APP_OBJECT_ID}/preAuthorizedApplication/04b07795-8ddb-461a-bbee-02f9e1bf7b46
terraform import -var-file=../global.tfvars -var-file=variables/common.tfvars -var-file=variables/${ENV}.tfvars module.aks_global.module.azad_kube_proxy.random_uuid.oauth2_permission_scope_user_impersonation $AZ_APP_PERMISSION_ID
terraform import -var-file=../global.tfvars -var-file=variables/common.tfvars -var-file=variables/${ENV}.tfvars module.aks_global.module.azad_kube_proxy.azuread_app_role_assignment.ms_graph_directory_read_all ${AZ_SP_OBJECT_ID}/appRoleAssignment/${APP_ROLE_ASSIGNMENT_ID}
```