### PR TITLE
eks-global azad-kube-proxy config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+
+- [#646](https://github.com/XenitAB/terraform-modules/pull/646) Create Azure AD Application for azad-kube-proxy using eks-global
+
 ## 2022.04.2
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- [#646](https://github.com/XenitAB/terraform-modules/pull/646) Create Azure AD Application for azad-kube-proxy using eks-global
+- [#646](https://github.com/XenitAB/terraform-modules/pull/646) [Breaking] Create Azure AD Application for azad-kube-proxy using eks-global
 
 ## 2022.04.2
 

--- a/modules/aws/eks-global/README.md
+++ b/modules/aws/eks-global/README.md
@@ -57,6 +57,7 @@
 |------|-------------|------|---------|:--------:|
 | <a name="input_azad_kube_proxy_config"></a> [azad\_kube\_proxy\_config](#input\_azad\_kube\_proxy\_config) | Azure AD Kubernetes Proxy configuration | <pre>object({<br>    cluster_name_prefix = string<br>    proxy_url_override  = string<br>  })</pre> | <pre>{<br>  "cluster_name_prefix": "eks",<br>  "proxy_url_override": ""<br>}</pre> | no |
 | <a name="input_azure_ad_group_prefix"></a> [azure\_ad\_group\_prefix](#input\_azure\_ad\_group\_prefix) | Prefix for Azure AD Groups | `string` | `"az"` | no |
+| <a name="input_dns_zone"></a> [dns\_zone](#input\_dns\_zone) | List of DNS Zone to create | `list(string)` | n/a | yes |
 | <a name="input_eks_cloudwatch_retention_period"></a> [eks\_cloudwatch\_retention\_period](#input\_eks\_cloudwatch\_retention\_period) | eks cloudwatch retention period | `number` | `30` | no |
 | <a name="input_eks_group_name_prefix"></a> [eks\_group\_name\_prefix](#input\_eks\_group\_name\_prefix) | Prefix for EKS Azure AD groups | `string` | `"eks"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environemnt | `string` | n/a | yes |
@@ -72,6 +73,7 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_aad_groups"></a> [aad\_groups](#output\_aad\_groups) | Azure AD groups |
+| <a name="output_azad_kube_proxy"></a> [azad\_kube\_proxy](#output\_azad\_kube\_proxy) | The Azure AD Application config for azad-kube-proxy |
 | <a name="output_cluster_role_arn"></a> [cluster\_role\_arn](#output\_cluster\_role\_arn) | EKS cluster IAM role |
 | <a name="output_eks_admin_role_arn"></a> [eks\_admin\_role\_arn](#output\_eks\_admin\_role\_arn) | ARN for IAM role that should be used to create an EKS cluster |
 | <a name="output_eks_encryption_key_arn"></a> [eks\_encryption\_key\_arn](#output\_eks\_encryption\_key\_arn) | KMS key to be used for EKS secret encryption |

--- a/modules/aws/eks-global/README.md
+++ b/modules/aws/eks-global/README.md
@@ -15,7 +15,9 @@
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_azad_kube_proxy"></a> [azad\_kube\_proxy](#module\_azad\_kube\_proxy) | ../../azure-ad/azad-kube-proxy | n/a |
 
 ## Resources
 
@@ -53,6 +55,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_azad_kube_proxy_config"></a> [azad\_kube\_proxy\_config](#input\_azad\_kube\_proxy\_config) | Azure AD Kubernetes Proxy configuration | <pre>object({<br>    cluster_name_prefix = string<br>    proxy_url_override  = string<br>  })</pre> | <pre>{<br>  "cluster_name_prefix": "eks",<br>  "proxy_url_override": ""<br>}</pre> | no |
 | <a name="input_azure_ad_group_prefix"></a> [azure\_ad\_group\_prefix](#input\_azure\_ad\_group\_prefix) | Prefix for Azure AD Groups | `string` | `"az"` | no |
 | <a name="input_eks_cloudwatch_retention_period"></a> [eks\_cloudwatch\_retention\_period](#input\_eks\_cloudwatch\_retention\_period) | eks cloudwatch retention period | `number` | `30` | no |
 | <a name="input_eks_group_name_prefix"></a> [eks\_group\_name\_prefix](#input\_eks\_group\_name\_prefix) | Prefix for EKS Azure AD groups | `string` | `"eks"` | no |

--- a/modules/aws/eks-global/azad-kube-proxy.tf
+++ b/modules/aws/eks-global/azad-kube-proxy.tf
@@ -1,0 +1,12 @@
+locals {
+  azad_kube_proxy_url  = var.azad_kube_proxy_config.proxy_url_override == "" ? "https://eks.${var.dns_zone[0]}" : var.azad_kube_proxy_config.proxy_url_override
+  azad_kube_proxy_name = "${var.azad_kube_proxy_config.cluster_name_prefix}-${var.environment}"
+}
+
+module "azad_kube_proxy" {
+  source = "../../azure-ad/azad-kube-proxy"
+
+  proxy_url    = local.azad_kube_proxy_url
+  display_name = local.azad_kube_proxy_name
+  cluster_name = local.azad_kube_proxy_name
+}

--- a/modules/aws/eks-global/outputs.tf
+++ b/modules/aws/eks-global/outputs.tf
@@ -30,3 +30,11 @@ output "aad_groups" {
   description = "Azure AD groups"
   value       = local.aad_groups
 }
+
+output "azad_kube_proxy" {
+  description = "The Azure AD Application config for azad-kube-proxy"
+  value = {
+    azure_ad_app = module.azad_kube_proxy.data
+  }
+  sensitive = true
+}

--- a/modules/aws/eks-global/variables.tf
+++ b/modules/aws/eks-global/variables.tf
@@ -58,6 +58,11 @@ variable "eks_cloudwatch_retention_period" {
   default     = 30
 }
 
+variable "dns_zone" {
+  description = "List of DNS Zone to create"
+  type        = list(string)
+}
+
 variable "azad_kube_proxy_config" {
   description = "Azure AD Kubernetes Proxy configuration"
   type = object({

--- a/modules/aws/eks-global/variables.tf
+++ b/modules/aws/eks-global/variables.tf
@@ -57,3 +57,15 @@ variable "eks_cloudwatch_retention_period" {
   type        = number
   default     = 30
 }
+
+variable "azad_kube_proxy_config" {
+  description = "Azure AD Kubernetes Proxy configuration"
+  type = object({
+    cluster_name_prefix = string
+    proxy_url_override  = string
+  })
+  default = {
+    cluster_name_prefix = "eks"
+    proxy_url_override  = ""
+  }
+}

--- a/validation/aws/eks-global/main.tf
+++ b/validation/aws/eks-global/main.tf
@@ -19,4 +19,6 @@ module "eks-global" {
       name                    = "team1"
     }
   ]
+
+  dns_zone = ["foo", "bar"]
 }


### PR DESCRIPTION
Breaking change, add support to manage azad-kube-proxy through terraform using azure-ad module in eks-global.
This continues the work done in: https://github.com/XenitAB/terraform-modules/pull/639 but for EKS.

In module module "eks_global" you need to add dns_zone

```.hcl
  dns_zone = var.dns_zone
```

In module "eks2_core"
```.hcl
  azad_kube_proxy_enabled = true

  azad_kube_proxy_config = {
    fqdn                  = "eks.${var.main_dns_zone}"
    azure_ad_group_prefix = var.aks_group_name_prefix
    allowed_ips           = var.eks_authorized_ips
    azure_ad_app          = module.eks_global.azad_kube_proxy.azure_ad_app
  }
```

Importing existing azad config.

```
ENV=qa
AZ_APP_ID=$(az ad app list --display-name "eks-${ENV}" --query "[0].appId" -o tsv)
AZ_APP_PERMISSION_ID=$(az ad app show --id ${AZ_APP_ID} --output tsv --query "oauth2Permissions[0].id")
AZ_APP_OBJECT_ID=$(az ad app show --id ${AZ_APP_ID} --output tsv --query objectId)
AZ_SP_OBJECT_ID=$(az ad sp show --id $AZ_APP_ID --output tsv --query objectId)
APP_ROLE_ASSIGNMENT_ID=$(az rest --method GET --uri "https://graph.microsoft.com/v1.0/servicePrincipals/${AZ_SP_OBJECT_ID}/appRoleAssignments" --query "value[0].id" -o tsv)

aws-vault exec xkf-qa -- terraform import -var-file=../global.tfvars -var-file=variables/common.tfvars -var-file=variables/${ENV}.tfvars module.eks_global.module.azad_kube_proxy.azuread_application.this $AZ_APP_OBJECT_ID
aws-vault exec xkf-qa -- terraform import -var-file=../global.tfvars -var-file=variables/common.tfvars -var-file=variables/${ENV}.tfvars module.eks_global.module.azad_kube_proxy.azuread_service_principal.this $AZ_SP_OBJECT_ID
aws-vault exec xkf-qa -- terraform import -var-file=../global.tfvars -var-file=variables/common.tfvars -var-file=variables/${ENV}.tfvars module.eks_global.module.azad_kube_proxy.azuread_application_pre_authorized.azure_cli ${AZ_APP_OBJECT_ID}/preAuthorizedApplication/04b07795-8ddb-461a-bbee-02f9e1bf7b46
aws-vault exec xkf-qa -- terraform import -var-file=../global.tfvars -var-file=variables/common.tfvars -var-file=variables/${ENV}.tfvars module.eks_global.module.azad_kube_proxy.random_uuid.oauth2_permission_scope_user_impersonation $AZ_APP_PERMISSION_ID
aws-vault exec xkf-qa -- terraform import -var-file=../global.tfvars -var-file=variables/common.tfvars -var-file=variables/${ENV}.tfvars module.eks_global.module.azad_kube_proxy.azuread_app_role_assignment.ms_graph_directory_read_all ${AZ_SP_OBJECT_ID}/appRoleAssignment/${APP_ROLE_ASSIGNMENT_ID}
```