### PR TITLE
Remove 'use-forwarded-headers: "true"' from ingress-nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fix
+
+- [#658](https://github.com/XenitAB/terraform-modules/pull/658) Remove 'use-forwarded-headers: "true"' from ingress-nginx
+
 ## 2022.04.3
 
 ### Changed

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -40,7 +40,6 @@ controller:
     ${key}: "${value}"
     %{~ endfor ~}
     server-tokens: "false"
-    use-forwarded-headers: "true"
     %{~ if datadog_enabled ~}
     datadog-collector-host: "$HOST_IP"
     enable-opentracing: "true"


### PR DESCRIPTION
[use-forwarded-headers](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-forwarded-headers)

If true, NGINX passes the incoming X-Forwarded-* headers to upstreams. Use this option when NGINX is behind another L7 proxy / load balancer that is setting these headers.

If false, NGINX ignores incoming X-Forwarded-* headers, filling them with the request information it sees. Use this option if NGINX is exposed directly to the internet, or it's behind a L3/packet-based load balancer that doesn't alter the source IP in the packets.