### PR TITLE
Fix cluster-role-binding for get-nodes role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fix
 
+- [#661](https://github.com/XenitAB/terraform-modules/pull/661) Fix cluster-role-binding for get-nodes role.
 - [#658](https://github.com/XenitAB/terraform-modules/pull/658) Remove 'use-forwarded-headers: "true"' from ingress-nginx
 
 ## 2022.04.3

--- a/modules/kubernetes/aks-core/README.md
+++ b/modules/kubernetes/aks-core/README.md
@@ -58,7 +58,7 @@ This module is used to create AKS clusters.
 |------|------|
 | [helm_release.aks_core_extras](https://registry.terraform.io/providers/hashicorp/helm/2.4.1/docs/resources/release) | resource |
 | [kubernetes_cluster_role.custom_resource_edit](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role) | resource |
-| [kubernetes_cluster_role.get_node](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role) | resource |
+| [kubernetes_cluster_role.get_nodes](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role.helm_release](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role.list_namespaces](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role.starboard_reports](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role) | resource |
@@ -66,6 +66,7 @@ This module is used to create AKS clusters.
 | [kubernetes_cluster_role_binding.cluster_admin](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role_binding) | resource |
 | [kubernetes_cluster_role_binding.cluster_view](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role_binding) | resource |
 | [kubernetes_cluster_role_binding.edit_list_ns](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role_binding) | resource |
+| [kubernetes_cluster_role_binding.get-nodes](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role_binding) | resource |
 | [kubernetes_cluster_role_binding.view_list_ns](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role_binding) | resource |
 | [kubernetes_limit_range.tenant](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/limit_range) | resource |
 | [kubernetes_namespace.service_accounts](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/namespace) | resource |
@@ -75,7 +76,6 @@ This module is used to create AKS clusters.
 | [kubernetes_network_policy.tenant](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/network_policy) | resource |
 | [kubernetes_role_binding.custom_resource_edit](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.edit](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
-| [kubernetes_role_binding.get_node](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.helm_release](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.sa_edit](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.sa_helm_release](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |

--- a/modules/kubernetes/aks-core/README.md
+++ b/modules/kubernetes/aks-core/README.md
@@ -66,7 +66,7 @@ This module is used to create AKS clusters.
 | [kubernetes_cluster_role_binding.cluster_admin](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role_binding) | resource |
 | [kubernetes_cluster_role_binding.cluster_view](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role_binding) | resource |
 | [kubernetes_cluster_role_binding.edit_list_ns](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role_binding) | resource |
-| [kubernetes_cluster_role_binding.get-nodes](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role_binding) | resource |
+| [kubernetes_cluster_role_binding.get_nodes](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role_binding) | resource |
 | [kubernetes_cluster_role_binding.view_list_ns](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role_binding) | resource |
 | [kubernetes_limit_range.tenant](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/limit_range) | resource |
 | [kubernetes_namespace.service_accounts](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/namespace) | resource |

--- a/modules/kubernetes/aks-core/k8s-cluster-role-binding-get-nodes.tf
+++ b/modules/kubernetes/aks-core/k8s-cluster-role-binding-get-nodes.tf
@@ -1,0 +1,23 @@
+resource "kubernetes_cluster_role_binding" "get-nodes" {
+  depends_on = [kubernetes_namespace.tenant]
+  for_each   = { for ns in var.namespaces : ns.name => ns }
+
+  metadata {
+    name = "${each.value.name}-get-nodes"
+
+    labels = {
+      "aad-group-name"    = var.aad_groups.view[each.key].name
+      "xkf.xenit.io/kind" = "platform"
+    }
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "get-nodes"
+  }
+  subject {
+    kind      = "Group"
+    name      = var.aad_groups.view[each.key].id
+    api_group = "rbac.authorization.k8s.io"
+  }
+}

--- a/modules/kubernetes/aks-core/k8s-cluster-role-binding-get-nodes.tf
+++ b/modules/kubernetes/aks-core/k8s-cluster-role-binding-get-nodes.tf
@@ -1,4 +1,4 @@
-resource "kubernetes_cluster_role_binding" "get-nodes" {
+resource "kubernetes_cluster_role_binding" "get_nodes" {
   depends_on = [kubernetes_namespace.tenant]
   for_each   = { for ns in var.namespaces : ns.name => ns }
 

--- a/modules/kubernetes/aks-core/k8s-cluster-role.tf
+++ b/modules/kubernetes/aks-core/k8s-cluster-role.tf
@@ -82,9 +82,9 @@ resource "kubernetes_cluster_role" "starboard_reports" {
   }
 }
 
-resource "kubernetes_cluster_role" "get_node" {
+resource "kubernetes_cluster_role" "get_nodes" {
   metadata {
-    name = "get-node"
+    name = "get-nodes"
     labels = {
       "xkf.xenit.io/kind" = "platform"
     }

--- a/modules/kubernetes/aks-core/k8s-role-binding.tf
+++ b/modules/kubernetes/aks-core/k8s-role-binding.tf
@@ -188,25 +188,3 @@ resource "kubernetes_role_binding" "starboard_reports" {
     name      = var.aad_groups.edit[each.key].id
   }
 }
-
-resource "kubernetes_role_binding" "get_node" {
-  for_each = { for ns in var.namespaces : ns.name => ns }
-  metadata {
-    name      = "${each.value.name}-get-node"
-    namespace = kubernetes_namespace.tenant[each.key].metadata[0].name
-    labels = {
-      "aad-group-name"    = var.aad_groups.edit[each.key].name
-      "xkf.xenit.io/kind" = "platform"
-    }
-  }
-  role_ref {
-    api_group = "rbac.authorization.k8s.io"
-    kind      = "ClusterRole"
-    name      = kubernetes_cluster_role.get_node.metadata[0].name
-  }
-  subject {
-    api_group = "rbac.authorization.k8s.io"
-    kind      = "Group"
-    name      = var.aad_groups.edit[each.key].id
-  }
-}


### PR DESCRIPTION
Since nodes are cluster-wide and not namespaced resources, we need 'cluster-role-binding' instead of 'role-binding'

Tested and works :)

