### PR TITLE
Enable ingress-nginx logs in promtail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#666](https://github.com/XenitAB/terraform-modules/pull/666) Enable ingress-nginx logs in promtail.
+
 ## 2022.05.1
 
 ### Changed

--- a/modules/kubernetes/promtail/templates/values.yaml.tpl
+++ b/modules/kubernetes/promtail/templates/values.yaml.tpl
@@ -12,12 +12,13 @@ config:
           tenant_id: "${tenant_id}"
           environment: "${environment}"
           cluster: "${cluster_name}"
+      - match:
+          # Drop 2xx and 3xx from the Nginx access log
+          selector: '{namespace="ingress-nginx"} |~ "^([\w\.]+) - ([^ ]*) \[(.*)\] "([^ ]*) ([^ ]*) ([^ ]*)" ([2-3][0-9][0-9]) .*"'
+          action: drop
+          drop_counter_reason: nginx_ok
 
-    extraRelabelConfigs:
-      - action: drop
-        regex: ingress-nginx
-        source_labels:
-          - __meta_kubernetes_namespace
+   extraRelabelConfigs:
       %{~ for namespace in excluded_namespaces ~}
       - action: drop
         regex: ${namespace}

--- a/modules/kubernetes/promtail/templates/values.yaml.tpl
+++ b/modules/kubernetes/promtail/templates/values.yaml.tpl
@@ -13,11 +13,11 @@ config:
           environment: "${environment}"
           cluster: "${cluster_name}"
       - match:
-          selector: '{namespace="ingress-nginx"} |~ "^([\w\.]+) - ([^ ]*) \[(.*)\] "([^ ]*) ([^ ]*) ([^ ]*)" ([2-3][0-9][0-9]) .*"'
+          selector: '{namespace="ingress-nginx"} |~ `^([\w\.]+) - ([^ ]*) \[(.*)\] \"([^ ]*) ([^ ]*) ([^ ]*)" ([2-3][0-9][0-9]) .*`'
           action: drop
           drop_counter_reason: nginx_ok
 
-   extraRelabelConfigs:
+    extraRelabelConfigs:
       %{~ for namespace in excluded_namespaces ~}
       - action: drop
         regex: ${namespace}

--- a/modules/kubernetes/promtail/templates/values.yaml.tpl
+++ b/modules/kubernetes/promtail/templates/values.yaml.tpl
@@ -13,7 +13,6 @@ config:
           environment: "${environment}"
           cluster: "${cluster_name}"
       - match:
-          # Drop 2xx and 3xx from the Nginx access log
           selector: '{namespace="ingress-nginx"} |~ "^([\w\.]+) - ([^ ]*) \[(.*)\] "([^ ]*) ([^ ]*) ([^ ]*)" ([2-3][0-9][0-9]) .*"'
           action: drop
           drop_counter_reason: nginx_ok

--- a/modules/kubernetes/promtail/templates/values.yaml.tpl
+++ b/modules/kubernetes/promtail/templates/values.yaml.tpl
@@ -12,9 +12,18 @@ config:
           tenant_id: "${tenant_id}"
           environment: "${environment}"
           cluster: "${cluster_name}"
+      
+      # Drop 2xx and 3xx from ingress-nginx since it it generates a lot of log messages. Example:
+      # xxx.xxx.xxx.xxx - - [04/May/2022:13:12:50 +0000] "POST /api/v1/receive HTTP/2.0" 200 0 "-" "Prometheus/2.35.0" 
+      # 35234 0.004 [monitor-router-receiver-remote-write] [] 10.244.34.149:19291 0 0.004 200 0156a072a34b23dc09bcfcfe87991c7b
       - match:
-          selector: '{namespace="ingress-nginx"} |~ `^([\w\.]+) - ([^ ]*) \[(.*)\] \"([^ ]*) ([^ ]*) ([^ ]*)" ([2-3][0-9][0-9]) .*`'
-          action: drop
+          selector: '{namespace="ingress-nginx"}'
+          stages:
+          - regex:
+              expression: '^(?P<_>[\w\.]+) - (?P<_>[^ ]*) \[(?P<_>.*)\] "(?P<_>[^ ]*) (?P<_>[^ ]*) (?P<_>[^ ]*)" (?P<nginx_status>[\d]+).*'
+      - drop:
+          source: nginx_status
+          expression: "[2-3][0-9][0-9]"
           drop_counter_reason: nginx_ok
 
     extraRelabelConfigs:


### PR DESCRIPTION
Before this change, all logs from the ingress-nginx namespace were
dropped due to the massive amount of logs. This change will enable
ingress-nginx logging but drop the 2xx and 3xx entries from the
access log.