### PR TITLE
Ingress-nginx enable default certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - [#666](https://github.com/XenitAB/terraform-modules/pull/666) Enable ingress-nginx logs in promtail.
+- [#670](https://github.com/XenitAB/terraform-modules/pull/670) Ingress-nginx default wildcard certificate enabled.
 
 ## 2022.05.1
 

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -206,6 +206,11 @@ module "ingress_nginx" {
   datadog_enabled           = var.datadog_enabled
   public_private_enabled    = var.ingress_config.public_private_enabled
   allow_snippet_annotations = var.ingress_config.allow_snippet_annotations
+
+  default_certificate = {
+    enabled  = true
+    dns_zone = var.cert_manager_config.dns_zone[0]
+  }
 }
 
 # ingress-healthz

--- a/modules/kubernetes/eks-core/modules.tf
+++ b/modules/kubernetes/eks-core/modules.tf
@@ -141,6 +141,11 @@ module "ingress_nginx" {
   datadog_enabled           = var.datadog_enabled
   public_private_enabled    = var.ingress_config.public_private_enabled
   allow_snippet_annotations = var.ingress_config.allow_snippet_annotations
+
+  default_certificate = {
+    enabled  = true
+    dns_zone = var.cert_manager_config.dns_zone[0]
+  }
 }
 
 module "ingress_healthz" {


### PR DESCRIPTION
This to pass PCI scanning without any issues.