### PR TITLE
Disable AKS run command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#678](https://github.com/XenitAB/terraform-modules/pull/678) Update OPA to 3.8.1, gatekeeper-library to 0.12.1 and add k8srequireingressclass constraint.
 - [#679](https://github.com/XenitAB/terraform-modules/pull/679) Update AzureRM provider version.
+- [#680](https://github.com/XenitAB/terraform-modules/pull/680) Disable AKS run command.
 
 ## 2022.05.2
 

--- a/modules/azure/aks/aks.tf
+++ b/modules/azure/aks/aks.tf
@@ -8,6 +8,7 @@ resource "azurerm_kubernetes_cluster" "this" {
   kubernetes_version              = var.aks_config.version
   sku_tier                        = var.aks_config.production_grade ? "Paid" : "Free"
   api_server_authorized_ip_ranges = var.aks_authorized_ips
+  run_command_enabled             = false
 
   auto_scaler_profile {
     # Pods should not depend on local storage like EmptyDir or HostPath


### PR DESCRIPTION
This is a security hardening change which disables [invoking commands](https://docs.microsoft.com/en-us/azure/aks/command-invoke) inside the cluster from the Azure API.