### PR TITLE
Fix CRD server side apply conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#678](https://github.com/XenitAB/terraform-modules/pull/678) Update OPA to 3.8.1, gatekeeper-library to 0.12.1 and add k8srequireingressclass constraint.
 - [#679](https://github.com/XenitAB/terraform-modules/pull/679) Update AzureRM provider version.
 - [#680](https://github.com/XenitAB/terraform-modules/pull/680) Disable AKS run command.
+- [#682](https://github.com/XenitAB/terraform-modules/pull/680) Fix CRD server side apply conflicts.
 
 ## 2022.05.2
 

--- a/modules/kubernetes/helm-crd/main.tf
+++ b/modules/kubernetes/helm-crd/main.tf
@@ -42,6 +42,8 @@ resource "kubectl_manifest" "this" {
     if can(regex("^/apis/apiextensions.k8s.io/v1/customresourcedefinitions/", k))
   }
   server_side_apply = true
-  apply_only        = true
-  yaml_body         = each.value
+  # Required while migrating to kubectl managed CRDs
+  force_conflicts = true
+  apply_only      = true
+  yaml_body       = each.value
 }


### PR DESCRIPTION
Issues are caused when switching methods to apply CRDs. This forces the changes to managed fields. Should be removed eventually.