### PR TITLE
Fix k8s version check and update supported versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - [#636](https://github.com/XenitAB/terraform-modules/pull/636) Make Node Local DNS enabled by default in AWS and Azure.
+- [#688](https://github.com/XenitAB/terraform-modules/pull/688) Fix Kubernetes version check and update supported versions.
 
 ## 2022.05.4
 

--- a/modules/aws/eks/variables.tf
+++ b/modules/aws/eks/variables.tf
@@ -47,11 +47,12 @@ variable "eks_config" {
     condition     = can(regex("^([0-9]\\d*)\\.([0-9]\\d*)$", var.eks_config.version))
     error_message = "Control plane version must only include major and minor version."
   }
+
   validation {
     condition = alltrue([
-      for np in concat(var.eks_config.node_pools, [{ version : var.eks_config.version }]) : can(regex("^1.(20|21|22)", np.version))
+      for np in concat(var.eks_config.node_pools, [{ version : var.eks_config.version }]) : can(regex("^1.(21|22)", np.version))
     ])
-    error_message = "The Kubernetes version has not been validated yet, supported versions are 1.20, 1.21, 1.22."
+    error_message = "The Kubernetes version has not been validated yet, supported versions are 1.21, 1.22."
   }
 
   validation {

--- a/modules/azure/aks/variables.tf
+++ b/modules/azure/aks/variables.tf
@@ -50,14 +50,14 @@ variable "aks_config" {
 
   validation {
     condition = alltrue([
-      for np in concat(var.aks_config.node_pools, [{ version : var.aks_config.version }]) : can(regex("^1.(20|21|22)", np.version))
+      for np in concat(var.aks_config.node_pools, [{ version : var.aks_config.version }]) : can(regex("^1.(21|22)", np.version))
     ])
-    error_message = "The Kubernetes version has not been validated yet, supported versions are 1.20, 1.21, 1.22."
+    error_message = "The Kubernetes version has not been validated yet, supported versions are 1.21, 1.22."
   }
 
   validation {
     condition = alltrue([
-      for np in var.aks_config.node_pools : split(".", np.version)[1] <= split(".", var.aks_config.version)[1] && split(".", np.version)[2] <= split(".", var.aks_config.version)[2]
+      for np in var.aks_config.node_pools : split(".", np.version)[1] <= split(".", var.aks_config.version)[1]
     ])
     error_message = "The node Kubernetes version should not be newer than the cluster version, upgrade the cluster first."
   }


### PR DESCRIPTION
I must have been tired when writing the AKS version check because it obviously does not work. This change accepts defeat and only checks the minor version, just as EKS.