### PR TITLE
Change to calculate AKS resource group instead of using a datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#636](https://github.com/XenitAB/terraform-modules/pull/636) Make Node Local DNS enabled by default in AWS and Azure.
 - [#688](https://github.com/XenitAB/terraform-modules/pull/688) Fix Kubernetes version check and update supported versions.
+- [#689](https://github.com/XenitAB/terraform-modules/pull/689) Change to calculate AKS resource group instead of using a datasource.
 
 ## 2022.05.4
 

--- a/modules/azure/aks/README.md
+++ b/modules/azure/aks/README.md
@@ -47,7 +47,6 @@ No modules.
 | [azurerm_role_assignment.view](https://registry.terraform.io/providers/hashicorp/azurerm/3.8.0/docs/resources/role_assignment) | resource |
 | [azurerm_user_assigned_identity.azure_metrics](https://registry.terraform.io/providers/hashicorp/azurerm/3.8.0/docs/resources/user_assigned_identity) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.8.0/docs/data-sources/client_config) | data source |
-| [azurerm_resource_group.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.8.0/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.8.0/docs/data-sources/resource_group) | data source |
 | [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.8.0/docs/data-sources/subnet) | data source |
 

--- a/modules/azure/aks/aad-group.tf
+++ b/modules/azure/aks/aad-group.tf
@@ -1,3 +1,8 @@
+# Calculate the ID because a datasource would force recreation of role assignments.
+locals {
+  aks_resource_group_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${azurerm_kubernetes_cluster.this.node_resource_group}"
+}
+
 resource "azurerm_role_assignment" "view" {
   for_each = { for ns in var.namespaces : ns.name => ns }
 
@@ -34,13 +39,13 @@ resource "azuread_group_member" "aks_managed_identity" {
 }
 
 resource "azurerm_role_assignment" "aks_managed_identity_noderg_managed_identity_operator" {
-  scope                = data.azurerm_resource_group.aks.id
+  scope                = local.aks_resource_group_id
   role_definition_name = "Managed Identity Operator"
   principal_id         = var.aad_groups.aks_managed_identity.id
 }
 
 resource "azurerm_role_assignment" "aks_managed_identity_noderg_virtual_machine_contributor" {
-  scope                = data.azurerm_resource_group.aks.id
+  scope                = local.aks_resource_group_id
   role_definition_name = "Virtual Machine Contributor"
   principal_id         = var.aad_groups.aks_managed_identity.id
 }

--- a/modules/azure/aks/aks.tf
+++ b/modules/azure/aks/aks.tf
@@ -1,3 +1,9 @@
+data "azurerm_subnet" "this" {
+  name                 = "sn-${var.environment}-${var.location_short}-${var.core_name}-${var.name}${var.aks_name_suffix}"
+  virtual_network_name = "vnet-${var.environment}-${var.location_short}-${var.core_name}"
+  resource_group_name  = "rg-${var.environment}-${var.location_short}-${var.core_name}"
+}
+
 # azure-container-use-rbac-permissions is ignored because the rule has not been updated in tfsec
 #tfsec:ignore:azure-container-limit-authorized-ips tfsec:ignore:azure-container-logging tfsec:ignore:azure-container-use-rbac-permissions
 resource "azurerm_kubernetes_cluster" "this" {

--- a/modules/azure/aks/main.tf
+++ b/modules/azure/aks/main.tf
@@ -36,13 +36,3 @@ data "azurerm_client_config" "current" {}
 data "azurerm_resource_group" "this" {
   name = "rg-${var.environment}-${var.location_short}-${var.name}"
 }
-
-data "azurerm_resource_group" "aks" {
-  name = azurerm_kubernetes_cluster.this.node_resource_group
-}
-
-data "azurerm_subnet" "this" {
-  name                 = "sn-${var.environment}-${var.location_short}-${var.core_name}-${var.name}${var.aks_name_suffix}"
-  virtual_network_name = "vnet-${var.environment}-${var.location_short}-${var.core_name}"
-  resource_group_name  = "rg-${var.environment}-${var.location_short}-${var.core_name}"
-}


### PR DESCRIPTION
This fixes an issue where the AKS role assignment is recreated when changes to the AKS cluster is made. Its not an optimal solution but at least it does not force the resources to be recreated.