### PR TITLE
metrics-server take extraArgs as a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fix
+
+- [#690](https://github.com/XenitAB/terraform-modules/pull/690) Helm metrics-server extraArgs as list.
+
 ### Changed
 
 - [#636](https://github.com/XenitAB/terraform-modules/pull/636) Make Node Local DNS enabled by default in AWS and Azure.
 - [#688](https://github.com/XenitAB/terraform-modules/pull/688) Fix Kubernetes version check and update supported versions.
 - [#654](https://github.com/XenitAB/terraform-modules/pull/654) AWS specify last addon version in EKS.
-
 
 ## 2022.05.4
 

--- a/modules/kubernetes/prometheus/templates/values-metrics-server.yaml.tpl
+++ b/modules/kubernetes/prometheus/templates/values-metrics-server.yaml.tpl
@@ -1,10 +1,10 @@
 # For more values: https://github.com/bitnami/charts/blob/master/bitnami/metrics-server/values.yaml
 
 extraArgs:
-  cert-dir: /tmp
-  kubelet-preferred-address-types: "InternalIP,ExternalIP,Hostname"
-  metric-resolution: 15s
-  kubelet-use-node-status-port:
+  - --cert-dir=/tmp
+  - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+  - --kubelet-use-node-status-port
+  - --metric-resolution=15s
 
 rbac:
   create: true


### PR DESCRIPTION
There was a breaking change in 6.0 in the helm chart.

This solves the following error on AWS:

```shell
│ Error: YAML parse error on metrics-server/templates/deployment.yaml: error converting YAML to JSON: yaml: line 58: did not find expected '-' indicator
│
│   with module.eks2_core.module.prometheus["prometheus"].helm_release.metrics_server["metrics-server"],
│   on .terraform/modules/eks2_core/modules/kubernetes/prometheus/main.tf line 48, in resource "helm_release" "metrics_server":
│   48: resource "helm_release" "metrics_server" {
```
