### PR TITLE
Add datadog nginx-ingress-controller logs config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#690](https://github.com/XenitAB/terraform-modules/pull/690) Helm metrics-server extraArgs as list.
 - [#697](https://github.com/XenitAB/terraform-modules/pull/697) Set default environment in datadog agent.
 - [#700](https://github.com/XenitAB/terraform-modules/pull/700) Fix node-ttl OCI registry.
+- [#701](https://github.com/XenitAB/terraform-modules/pull/701) Datadog nginx-ingress-controller log config.
 
 ### Added
 

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -66,9 +66,9 @@ controller:
   %{~ if datadog_enabled || linkerd_enabled ~}
   podAnnotations:
     %{~ if datadog_enabled ~}
-    ad.datadoghq.com/controller.check_names: '["nginx", "nginx_ingress_controller"]'
-    ad.datadoghq.com/controller.init_configs: '[{}]'
-    ad.datadoghq.com/controller.instances: '[{"prometheus_url": "http://%%host%%:%%port_metrics%%/metrics"}]'
+    ad.datadoghq.com/nginx-ingress-controller.check_names: '["nginx", "nginx_ingress_controller"]'
+    ad.datadoghq.com/nginx-ingress-controller.init_configs: '[{}]'
+    ad.datadoghq.com/nginx-ingress-controller.instances: '[{"prometheus_url": "http://%%host%%:%%port_metrics%%/metrics"}]'
     ad.datadoghq.com/nginx-ingress-controller.logs: '[{"service": "controller", "source":"nginx-ingress-controller"}]'
     %{~ endif ~}
     %{~ if linkerd_enabled ~}

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -66,9 +66,10 @@ controller:
   %{~ if datadog_enabled || linkerd_enabled ~}
   podAnnotations:
     %{~ if datadog_enabled ~}
-    ad.datadoghq.com/controller.check_names: '["nginx_ingress_controller"]'
+    ad.datadoghq.com/controller.check_names: '["nginx", "nginx_ingress_controller"]'
     ad.datadoghq.com/controller.init_configs: '[{}]'
     ad.datadoghq.com/controller.instances: '[{"prometheus_url": "http://%%host%%:%%port_metrics%%/metrics"}]'
+    ad.datadoghq.com/nginx-ingress-controller.logs: '[{"service": "controller", "source":"nginx-ingress-controller"}]'
     %{~ endif ~}
     %{~ if linkerd_enabled ~}
     linkerd.io/inject: "ingress"

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -66,10 +66,10 @@ controller:
   %{~ if datadog_enabled || linkerd_enabled ~}
   podAnnotations:
     %{~ if datadog_enabled ~}
-    ad.datadoghq.com/nginx-ingress-controller.check_names: '["nginx", "nginx_ingress_controller"]'
-    ad.datadoghq.com/nginx-ingress-controller.init_configs: '[{}]'
-    ad.datadoghq.com/nginx-ingress-controller.instances: '[{"prometheus_url": "http://%%host%%:%%port_metrics%%/metrics"}]'
-    ad.datadoghq.com/nginx-ingress-controller.logs: '[{"service": "controller", "source":"nginx-ingress-controller"}]'
+    ad.datadoghq.com/controller.check_names: '["nginx", "nginx_ingress_controller"]'
+    ad.datadoghq.com/controller.init_configs: '[{},{}]'
+    ad.datadoghq.com/controller.instances: '[{"prometheus_url": "http://%%host%%:%%port_metrics%%/metrics"}]'
+    ad.datadoghq.com/controller.logs: '[{"service": "controller", "source": "nginx-ingress-controller"}]'
     %{~ endif ~}
     %{~ if linkerd_enabled ~}
     linkerd.io/inject: "ingress"


### PR DESCRIPTION
This config is needed to make datadog to work with the nginx ingress controller
automatically.