### PR TITLE
Exclude prometheus ns from gatekeeper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#690](https://github.com/XenitAB/terraform-modules/pull/690) Helm metrics-server extraArgs as list.
 - [#697](https://github.com/XenitAB/terraform-modules/pull/697) Set default environment in datadog agent.
 - [#700](https://github.com/XenitAB/terraform-modules/pull/700) Fix node-ttl OCI registry.
+- [#703](https://github.com/XenitAB/terraform-modules/pull/703) Exclude prometheus ns from gatekeeper config.
 
 ### Added
 

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -20,6 +20,7 @@ locals {
     "velero",
     "grafana-agent",
     "promtail",
+    "prometheus",
   ]
 }
 


### PR DESCRIPTION
Currently we exclude this namespace manually on each cluster. There is no reason to do that.
In the long run we should create more specific rules for each namespace but that is a future issue.