### PR TITLE
Lift ingress-healthz nginx to 12.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#654](https://github.com/XenitAB/terraform-modules/pull/654) AWS specify last addon version in EKS.
 - [#698](https://github.com/XenitAB/terraform-modules/pull/698) Add premium ZRS storage class to AKS.
 - [#699](https://github.com/XenitAB/terraform-modules/pull/698) Update Helm Terraform provider to support OCI charts.
+- [#707](https://github.com/XenitAB/terraform-modules/pull/707) Update bitnami/nginx helm chart to 12.0.3 for ingress-healthz.
 
 ## 2022.05.4
 

--- a/modules/kubernetes/ingress-healthz/main.tf
+++ b/modules/kubernetes/ingress-healthz/main.tf
@@ -36,7 +36,7 @@ resource "helm_release" "ingress_healthz" {
   chart       = "nginx"
   name        = "ingress-healthz"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "9.5.10"
+  version     = "12.0.3"
   max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     environment     = var.environment


### PR DESCRIPTION
This pull request fixes #696.
The previous helm chart was pulled from bitnami's repository and the version in this PR is the latest available helm chart at the point of writing.
I didn't specifically test the 12.0.3 chart but the 12.0.0 chart does work.

Tested with:
- AKS kubernetes v1.22.6