### PR TITLE
[Breaking] Upgrade linkerd CNI to 2.11.2 and control-plane to edge-22.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - [#640](https://github.com/XenitAB/terraform-modules/pull/640) [Breaking] AKS set kubelet config default max pod pid to 1000.
+- [#709](https://github.com/XenitAB/terraform-modules/pull/709) [Breaking] Upgrade linkerd CNI to 2.11.2 and control-plane to edge-22.6.1.
 
 ## 2022.06.1
 

--- a/modules/kubernetes/aks-core/README.md
+++ b/modules/kubernetes/aks-core/README.md
@@ -48,6 +48,7 @@ This module is used to create AKS clusters.
 | <a name="module_ingress_healthz"></a> [ingress\_healthz](#module\_ingress\_healthz) | ../../kubernetes/ingress-healthz | n/a |
 | <a name="module_ingress_nginx"></a> [ingress\_nginx](#module\_ingress\_nginx) | ../../kubernetes/ingress-nginx | n/a |
 | <a name="module_linkerd"></a> [linkerd](#module\_linkerd) | ../../kubernetes/linkerd | n/a |
+| <a name="module_linkerd_crd"></a> [linkerd\_crd](#module\_linkerd\_crd) | ../../kubernetes/helm-crd | n/a |
 | <a name="module_node_local_dns"></a> [node\_local\_dns](#module\_node\_local\_dns) | ../../kubernetes/node-local-dns | n/a |
 | <a name="module_node_ttl"></a> [node\_ttl](#module\_node\_ttl) | ../../kubernetes/node-ttl | n/a |
 | <a name="module_opa_gatekeeper"></a> [opa\_gatekeeper](#module\_opa\_gatekeeper) | ../../kubernetes/opa-gatekeeper | n/a |

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -195,20 +195,6 @@ module "azure_metrics" {
 }
 
 # linkerd
-module "linkerd_crd" {
-  source = "../../kubernetes/helm-crd"
-
-  for_each = {
-    for s in ["linkerd"] :
-    s => s
-    if var.linkerd_enabled
-  }
-
-  chart_repository = "https://helm.linkerd.io/stable"
-  chart_name       = "linkerd2"
-  chart_version    = "2.11.2"
-}
-
 module "linkerd" {
   depends_on = [module.opa_gatekeeper, module.cert_manager_crd]
 

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -205,7 +205,7 @@ module "linkerd_crd" {
   }
 
   chart_repository = "https://helm.linkerd.io/edge"
-  chart_name       = "linkerd"
+  chart_name       = "linkerd-crds"
   chart_version    = "edge-22.06.1"
 }
 

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -195,8 +195,22 @@ module "azure_metrics" {
 }
 
 # linkerd
+module "linkerd_crd" {
+  source = "../../kubernetes/helm-crd"
+
+  for_each = {
+    for s in ["linkerd"] :
+    s => s
+    if var.linkerd_enabled
+  }
+
+  chart_repository = "https://helm.linkerd.io/edge"
+  chart_name       = "linkerd"
+  chart_version    = "edge-22.06.1"
+}
+
 module "linkerd" {
-  depends_on = [module.opa_gatekeeper, module.cert_manager_crd]
+  depends_on = [module.opa_gatekeeper, module.cert_manager_crd, module.linkerd_crd]
 
   for_each = {
     for s in ["linkerd"] :

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -205,7 +205,7 @@ module "linkerd_crd" {
   }
 
   chart_repository = "https://helm.linkerd.io/stable"
-  chart_name       = "linkerd"
+  chart_name       = "linkerd2"
   chart_version    = "2.11.2"
 }
 

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -195,6 +195,20 @@ module "azure_metrics" {
 }
 
 # linkerd
+module "linkerd_crd" {
+  source = "../../kubernetes/helm-crd"
+
+  for_each = {
+    for s in ["linkerd"] :
+    s => s
+    if var.linkerd_enabled
+  }
+
+  chart_repository = "https://helm.linkerd.io/stable"
+  chart_name       = "linkerd"
+  chart_version    = "2.11.2"
+}
+
 module "linkerd" {
   depends_on = [module.opa_gatekeeper, module.cert_manager_crd]
 

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -206,7 +206,7 @@ module "linkerd_crd" {
 
   chart_repository = "https://helm.linkerd.io/edge"
   chart_name       = "linkerd-crds"
-  chart_version    = "edge-22.06.1"
+  chart_version    = "1.1.1-edge"
 }
 
 module "linkerd" {

--- a/modules/kubernetes/eks-core/README.md
+++ b/modules/kubernetes/eks-core/README.md
@@ -42,6 +42,7 @@ This module is used to configure EKS clusters.
 | <a name="module_ingress_healthz"></a> [ingress\_healthz](#module\_ingress\_healthz) | ../../kubernetes/ingress-healthz | n/a |
 | <a name="module_ingress_nginx"></a> [ingress\_nginx](#module\_ingress\_nginx) | ../../kubernetes/ingress-nginx | n/a |
 | <a name="module_linkerd"></a> [linkerd](#module\_linkerd) | ../../kubernetes/linkerd | n/a |
+| <a name="module_linkerd_crd"></a> [linkerd\_crd](#module\_linkerd\_crd) | ../../kubernetes/helm-crd | n/a |
 | <a name="module_node_local_dns"></a> [node\_local\_dns](#module\_node\_local\_dns) | ../../kubernetes/node-local-dns | n/a |
 | <a name="module_node_ttl"></a> [node\_ttl](#module\_node\_ttl) | ../../kubernetes/node-ttl | n/a |
 | <a name="module_opa_gatekeeper"></a> [opa\_gatekeeper](#module\_opa\_gatekeeper) | ../../kubernetes/opa-gatekeeper | n/a |

--- a/modules/kubernetes/eks-core/modules.tf
+++ b/modules/kubernetes/eks-core/modules.tf
@@ -122,6 +122,21 @@ module "fluxcd_v2_github" {
   }]
 }
 
+# linkerd
+module "linkerd_crd" {
+  source = "../../kubernetes/helm-crd"
+
+  for_each = {
+    for s in ["linkerd"] :
+    s => s
+    if var.linkerd_enabled
+  }
+
+  chart_repository = "https://helm.linkerd.io/stable"
+  chart_name       = "linkerd"
+  chart_version    = "2.11.2"
+}
+
 module "linkerd" {
   depends_on = [module.opa_gatekeeper, module.cert_manager]
 

--- a/modules/kubernetes/eks-core/modules.tf
+++ b/modules/kubernetes/eks-core/modules.tf
@@ -134,7 +134,7 @@ module "linkerd_crd" {
 
   chart_repository = "https://helm.linkerd.io/edge"
   chart_name       = "linkerd-crds"
-  chart_version    = "edge-22.06.1"
+  chart_version    = "1.1.1-edge"
 }
 
 module "linkerd" {

--- a/modules/kubernetes/eks-core/modules.tf
+++ b/modules/kubernetes/eks-core/modules.tf
@@ -123,20 +123,6 @@ module "fluxcd_v2_github" {
 }
 
 # linkerd
-module "linkerd_crd" {
-  source = "../../kubernetes/helm-crd"
-
-  for_each = {
-    for s in ["linkerd"] :
-    s => s
-    if var.linkerd_enabled
-  }
-
-  chart_repository = "https://helm.linkerd.io/stable"
-  chart_name       = "linkerd2"
-  chart_version    = "2.11.2"
-}
-
 module "linkerd" {
   depends_on = [module.opa_gatekeeper, module.cert_manager]
 

--- a/modules/kubernetes/eks-core/modules.tf
+++ b/modules/kubernetes/eks-core/modules.tf
@@ -133,7 +133,7 @@ module "linkerd_crd" {
   }
 
   chart_repository = "https://helm.linkerd.io/edge"
-  chart_name       = "linkerd"
+  chart_name       = "linkerd-crds"
   chart_version    = "edge-22.06.1"
 }
 

--- a/modules/kubernetes/eks-core/modules.tf
+++ b/modules/kubernetes/eks-core/modules.tf
@@ -123,8 +123,22 @@ module "fluxcd_v2_github" {
 }
 
 # linkerd
+module "linkerd_crd" {
+  source = "../../kubernetes/helm-crd"
+
+  for_each = {
+    for s in ["linkerd"] :
+    s => s
+    if var.linkerd_enabled
+  }
+
+  chart_repository = "https://helm.linkerd.io/edge"
+  chart_name       = "linkerd"
+  chart_version    = "edge-22.06.1"
+}
+
 module "linkerd" {
-  depends_on = [module.opa_gatekeeper, module.cert_manager]
+  depends_on = [module.opa_gatekeeper, module.cert_manager, module.linkerd_crd]
 
   for_each = {
     for s in ["linkerd"] :

--- a/modules/kubernetes/eks-core/modules.tf
+++ b/modules/kubernetes/eks-core/modules.tf
@@ -133,7 +133,7 @@ module "linkerd_crd" {
   }
 
   chart_repository = "https://helm.linkerd.io/stable"
-  chart_name       = "linkerd"
+  chart_name       = "linkerd2"
   chart_version    = "2.11.2"
 }
 

--- a/modules/kubernetes/linkerd/main.tf
+++ b/modules/kubernetes/linkerd/main.tf
@@ -243,7 +243,7 @@ resource "helm_release" "linkerd_viz" {
   chart       = "linkerd-viz"
   name        = "linkerd-viz"
   namespace   = kubernetes_namespace.viz.metadata[0].name
-  version     = "edge-22.6.1"
+  version     = "30.2.4-edge"
   max_history = 3
   values = [
     templatefile("${path.module}/templates/values-viz.yaml.tpl", {}),

--- a/modules/kubernetes/linkerd/main.tf
+++ b/modules/kubernetes/linkerd/main.tf
@@ -225,7 +225,7 @@ resource "helm_release" "linkerd" {
   chart       = "linkerd-control-plane"
   name        = "linkerd"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "1.4.2-edge"
+  version     = "1.4.3-edge"
   max_history = 3
   values = [
     templatefile("${path.module}/templates/values.yaml.tpl", {

--- a/modules/kubernetes/linkerd/main.tf
+++ b/modules/kubernetes/linkerd/main.tf
@@ -225,7 +225,7 @@ resource "helm_release" "linkerd" {
   chart       = "linkerd-control-plane"
   name        = "linkerd"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "edge-22.6.1"
+  version     = "1.4.2-edge"
   max_history = 3
   values = [
     templatefile("${path.module}/templates/values.yaml.tpl", {

--- a/modules/kubernetes/linkerd/main.tf
+++ b/modules/kubernetes/linkerd/main.tf
@@ -192,8 +192,6 @@ resource "kubernetes_secret" "webhook_issuer_tls" {
 }
 
 # Install linkerd-cni helm chart
-# Tmp use edge version until 2.11.0 is released where we will get the helm chart feature we need.
-#tf-latest-version:ignore
 resource "helm_release" "linkerd_cni" {
   repository  = "https://helm.linkerd.io/stable"
   chart       = "linkerd2-cni"

--- a/modules/kubernetes/linkerd/main.tf
+++ b/modules/kubernetes/linkerd/main.tf
@@ -221,11 +221,11 @@ resource "helm_release" "linkerd_extras" {
 resource "helm_release" "linkerd" {
   depends_on = [helm_release.linkerd_extras, helm_release.linkerd_cni]
 
-  repository  = "https://helm.linkerd.io/stable"
+  repository  = "https://helm.linkerd.io/edge"
   chart       = "linkerd2"
   name        = "linkerd"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "2.11.2"
+  version     = "22.6.1"
   max_history = 3
   values = [
     templatefile("${path.module}/templates/values.yaml.tpl", {

--- a/modules/kubernetes/linkerd/main.tf
+++ b/modules/kubernetes/linkerd/main.tf
@@ -195,11 +195,11 @@ resource "kubernetes_secret" "webhook_issuer_tls" {
 # Tmp use edge version until 2.11.0 is released where we will get the helm chart feature we need.
 #tf-latest-version:ignore
 resource "helm_release" "linkerd_cni" {
-  repository  = "https://helm.linkerd.io/edge"
+  repository  = "https://helm.linkerd.io/stable"
   chart       = "linkerd2-cni"
   name        = "linkerd-cni"
   namespace   = kubernetes_namespace.cni.metadata[0].name
-  version     = "21.7.5"
+  version     = "2.11.2"
   max_history = 3
 
   values = [
@@ -227,7 +227,7 @@ resource "helm_release" "linkerd" {
   chart       = "linkerd2"
   name        = "linkerd"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "2.10.2"
+  version     = "2.11.2"
   max_history = 3
   values = [
     templatefile("${path.module}/templates/values.yaml.tpl", {
@@ -245,7 +245,7 @@ resource "helm_release" "linkerd_viz" {
   chart       = "linkerd-viz"
   name        = "linkerd-viz"
   namespace   = kubernetes_namespace.viz.metadata[0].name
-  version     = "2.10.2"
+  version     = "2.11.2"
   max_history = 3
   values = [
     templatefile("${path.module}/templates/values-viz.yaml.tpl", {}),

--- a/modules/kubernetes/linkerd/main.tf
+++ b/modules/kubernetes/linkerd/main.tf
@@ -239,11 +239,11 @@ resource "helm_release" "linkerd" {
 resource "helm_release" "linkerd_viz" {
   depends_on = [helm_release.linkerd]
 
-  repository  = "https://helm.linkerd.io/stable"
+  repository  = "https://helm.linkerd.io/edge"
   chart       = "linkerd-viz"
   name        = "linkerd-viz"
   namespace   = kubernetes_namespace.viz.metadata[0].name
-  version     = "2.11.2"
+  version     = "edge-22.6.1"
   max_history = 3
   values = [
     templatefile("${path.module}/templates/values-viz.yaml.tpl", {}),

--- a/modules/kubernetes/linkerd/main.tf
+++ b/modules/kubernetes/linkerd/main.tf
@@ -222,7 +222,7 @@ resource "helm_release" "linkerd" {
   depends_on = [helm_release.linkerd_extras, helm_release.linkerd_cni]
 
   repository  = "https://helm.linkerd.io/edge"
-  chart       = "linkerd2"
+  chart       = "linkerd-control-plane"
   name        = "linkerd"
   namespace   = kubernetes_namespace.this.metadata[0].name
   version     = "edge-22.6.1"

--- a/modules/kubernetes/linkerd/main.tf
+++ b/modules/kubernetes/linkerd/main.tf
@@ -225,7 +225,7 @@ resource "helm_release" "linkerd" {
   chart       = "linkerd2"
   name        = "linkerd"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "22.6.1"
+  version     = "edge-22.6.1"
   max_history = 3
   values = [
     templatefile("${path.module}/templates/values.yaml.tpl", {


### PR DESCRIPTION
Fix #407

Thanks to the default disable of automountServiceAccountToken for security reasons we get the following error in linkerd2:

To upgrade to this version you need to run kubernetes 1.22
This seems to be related on how env variables is unwrapped: https://discourse.linkerd.io/t/error-linkerd2-app-not-a-valid-identity-name/1020
else linkerd-viz won't start.

```shell
26m         Normal    InjectionSkipped         deployment/example                      Linkerd sidecar proxy injection skipped: automountServiceAccountToken set to "false"
```

This should have been solved with: https://github.com/linkerd/linkerd2/pull/7117
and in release: https://github.com/linkerd/linkerd2/releases/tag/edge-21.11.1

You can read a good blog about it: https://linkerd.io/2021/12/28/using-kubernetess-new-bound-service-account-tokens-for-secure-workload-identity/

I use the latest edge release to get as many fixes as possible.

## Explanation linkerd2 vs linkerd-control-plane

```shell
  linkerd2:
  - apiVersion: v1
    appVersion: edge-21.12.2
    created: "2021-12-20T16:44:11.363871486-05:00"
    dependencies:
    - name: partials
      repository: file://../partials
      version: 0.1.0
    deprecated: true
    description: 'DEPRECATED: Use linkerd-crds and linkerd-control-plane instead -
      Linkerd gives you observability, reliability, and security for your microservices
      — with no code change required.'
```
