### PR TITLE
Upgrade ingress-nginx helm chart to 4.1.4 and enable chroot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#714](https://github.com/XenitAB/terraform-modules/pull/714) Ingress-nginx helm chart 4.1.4 and use the chroot functionality.
+
 ## 2022.06.2
 
 ### Changed

--- a/modules/kubernetes/ingress-nginx/main.tf
+++ b/modules/kubernetes/ingress-nginx/main.tf
@@ -40,7 +40,7 @@ resource "helm_release" "ingress_nginx" {
   chart       = "ingress-nginx"
   name        = "ingress-nginx"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "4.1.0"
+  version     = "4.1.4"
   max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     http_snippet           = var.http_snippet
@@ -73,7 +73,7 @@ resource "helm_release" "ingress_nginx_public" {
   chart       = "ingress-nginx"
   name        = "ingress-nginx-public"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "4.1.0"
+  version     = "4.1.4"
   max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     http_snippet           = var.http_snippet
@@ -106,7 +106,7 @@ resource "helm_release" "ingress_nginx_private" {
   chart       = "ingress-nginx"
   name        = "ingress-nginx-private"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "4.1.0"
+  version     = "4.1.4"
   max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     http_snippet           = var.http_snippet

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -1,4 +1,7 @@
 controller:
+  image:
+    chroot: true
+
   replicaCount: 3
 
   priorityClassName: platform-medium


### PR DESCRIPTION
Using the new chroot feature in ingress-nginx 1.2.0: https://kubernetes.io/blog/2022/04/28/ingress-nginx-1-2-0/

Also solves: https://github.com/kubernetes/ingress-nginx/issues/8686 CVE-2021-25748

By upgrading to the latest image and supports use the chroot functionality.

According to the CVE issue we are not affected by this bug thanks to that we are using the https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#annotation-value-word-blocklist config.

But it's still good to patch the version.