### PR TITLE
Set resource requests for datadog-cluster-agent, starboard-operator, ingress-nginx and goldilocks-controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - [#714](https://github.com/XenitAB/terraform-modules/pull/714) Ingress-nginx helm chart 4.1.4 and use the chroot functionality.
-- [#716](https://github.com/XenitAB/terraform-modules/pull/716) Set resource requests for datadog-cluster-agent, starboard-operator, ingress-nginx, external-dns, azure-metrics and goldilocks-controller.
 
 ### Fixed
 
+- [#716](https://github.com/XenitAB/terraform-modules/pull/716) Set resource requests for datadog-cluster-agent, starboard-operator, ingress-nginx, external-dns, azure-metrics and goldilocks-controller.
 - [#717](https://github.com/XenitAB/terraform-modules/pull/717) Remove force conflicts from CRD resource.
 
 ## 2022.06.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - [#714](https://github.com/XenitAB/terraform-modules/pull/714) Ingress-nginx helm chart 4.1.4 and use the chroot functionality.
-- [#716](https://github.com/XenitAB/terraform-modules/pull/716) Set resource requests for datadog-cluster-agent, starboard-operator, ingress-nginx and goldilocks-controller.
+- [#716](https://github.com/XenitAB/terraform-modules/pull/716) Set resource requests for datadog-cluster-agent, starboard-operator, ingress-nginx, external-dns and goldilocks-controller.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - [#714](https://github.com/XenitAB/terraform-modules/pull/714) Ingress-nginx helm chart 4.1.4 and use the chroot functionality.
+- [#716](https://github.com/XenitAB/terraform-modules/pull/716) Set resource requests for datadog-cluster-agent, starboard-operator, ingress-nginx and goldilocks-controller.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - [#714](https://github.com/XenitAB/terraform-modules/pull/714) Ingress-nginx helm chart 4.1.4 and use the chroot functionality.
-- [#716](https://github.com/XenitAB/terraform-modules/pull/716) Set resource requests for datadog-cluster-agent, starboard-operator, ingress-nginx, external-dns and goldilocks-controller.
+- [#716](https://github.com/XenitAB/terraform-modules/pull/716) Set resource requests for datadog-cluster-agent, starboard-operator, ingress-nginx, external-dns, azure-metrics and goldilocks-controller.
 
 ### Fixed
 

--- a/modules/kubernetes/azure-metrics/charts/azure-metrics-exporter/values.yaml
+++ b/modules/kubernetes/azure-metrics/charts/azure-metrics-exporter/values.yaml
@@ -32,17 +32,9 @@ service:
   port: 80
 
 resources:
-  {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  requests:
+    cpu: 15m
+    memory: 25Mi
 
 nodeSelector: {}
 

--- a/modules/kubernetes/datadog/charts/datadog-extras/Chart.yaml
+++ b/modules/kubernetes/datadog/charts/datadog-extras/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/datadog/charts/datadog-extras/templates/datadogagent.yaml
+++ b/modules/kubernetes/datadog/charts/datadog-extras/templates/datadogagent.yaml
@@ -50,6 +50,11 @@ spec:
   clusterAgent:
     replicas: 2
     priorityClassName: platform-low
+    config:
+      resources:
+        requests:
+          cpu: 60m
+          memory: 200Mi
     image:
       name: "gcr.io/datadoghq/cluster-agent:latest"
   features:

--- a/modules/kubernetes/external-dns/templates/values.yaml.tpl
+++ b/modules/kubernetes/external-dns/templates/values.yaml.tpl
@@ -28,3 +28,8 @@ registry: "txt"
 txtOwnerId: "${txt_owner_id}"
 
 priorityClassName: "platform-low"
+
+resources:
+  requests:
+    cpu: 15m
+    memory: 78Mi

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -4,6 +4,11 @@ controller:
 
   replicaCount: 3
 
+  resources:
+    requests:
+      cpu: 100m
+      memory: 110Mi
+
   priorityClassName: platform-medium
 
   ingressClassResource:

--- a/modules/kubernetes/starboard/templates/starboard-values.yaml.tpl
+++ b/modules/kubernetes/starboard/templates/starboard-values.yaml.tpl
@@ -36,7 +36,7 @@ starboard:
   scanJobPodTemplateLabels: "aadpodidbinding=trivy"
 %{~ endif ~}
 
-resources: {}
+resources:
   requests:
     cpu: 15m
     memory: 200Mi

--- a/modules/kubernetes/starboard/templates/starboard-values.yaml.tpl
+++ b/modules/kubernetes/starboard/templates/starboard-values.yaml.tpl
@@ -35,3 +35,8 @@ starboard:
   # labeled with. Example: `foo=bar,env=stage` will labeled the scanner pods with the labels `foo: bar` and `env: stage`
   scanJobPodTemplateLabels: "aadpodidbinding=trivy"
 %{~ endif ~}
+
+resources: {}
+  requests:
+    cpu: 15m
+    memory: 200Mi

--- a/modules/kubernetes/vpa/templates/goldilocks-values.yaml.tpl
+++ b/modules/kubernetes/vpa/templates/goldilocks-values.yaml.tpl
@@ -17,8 +17,8 @@ controller:
           - 'watch'
   resources:
     limits:
-      cpu: 50m
-      memory: 100Mi
+      cpu: 100m
+      memory: 300Mi
     requests:
-      cpu: 25m
-      memory: 32Mi
+      cpu: 60m
+      memory: 200Mi


### PR DESCRIPTION
This to lower the amount of eviction that can happen in our cluster due to none definition of resources.
Have looked at VPA to get a good hint of what the values should be.
