### PR TITLE
Remove create before destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#716](https://github.com/XenitAB/terraform-modules/pull/716) Set resource requests for datadog-cluster-agent, starboard-operator, ingress-nginx, external-dns, azure-metrics and goldilocks-controller.
 - [#717](https://github.com/XenitAB/terraform-modules/pull/717) Remove force conflicts from CRD resource.
+- [#718](https://github.com/XenitAB/terraform-modules/pull/718) Remove node pool create before destroy.
 
 ## 2022.06.2
 

--- a/modules/aws/eks/eks.tf
+++ b/modules/aws/eks/eks.tf
@@ -194,8 +194,7 @@ resource "aws_eks_node_group" "this" {
   tags = local.global_tags
 
   lifecycle {
-    create_before_destroy = true
-    ignore_changes        = [scaling_config[0].desired_size]
+    ignore_changes = [scaling_config[0].desired_size]
   }
 
   timeouts {

--- a/modules/azure/aks/aks.tf
+++ b/modules/azure/aks/aks.tf
@@ -94,10 +94,6 @@ resource "azurerm_kubernetes_cluster_node_pool" "this" {
   upgrade_settings {
     max_surge = "33%"
   }
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 # Replace this with a datasource when availible in the AzureRM provider.


### PR DESCRIPTION
Remove create before destroy on node pools as this has just caused issues when recreating node pools. We should look for an alternative solution to make sure that developers do not remove node pools before adding a new one.