### PR TITLE
Upgrade azad-kube-proxy to 0.0.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#714](https://github.com/XenitAB/terraform-modules/pull/714) Ingress-nginx helm chart 4.1.4 and use the chroot functionality.
 - [#721](https://github.com/XenitAB/terraform-modules/pull/721) Allow datadog ingress by default to tenant namespace.
+- [#724](https://github.com/XenitAB/terraform-modules/pull/724) Upgrade azad-kube-proxy to 0.0.34.
 
 ### Fixed
 

--- a/modules/kubernetes/azad-kube-proxy/main.tf
+++ b/modules/kubernetes/azad-kube-proxy/main.tf
@@ -75,7 +75,7 @@ resource "helm_release" "azad_kube_proxy" {
   chart       = "azad-kube-proxy"
   name        = "azad-kube-proxy"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "v0.0.33"
+  version     = "v0.0.34"
   max_history = 3
   values      = [local.values]
 }


### PR DESCRIPTION
Uses: https://github.com/XenitAB/azad-kube-proxy/releases/tag/v0.0.34
