### PR TITLE
override public ip prefix name in aks global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+
+- [#728](https://github.com/XenitAB/terraform-modules/pull/728) Add the possibility to override public ip prefix name in aks global.
+
 ### Changed
 
 - [#714](https://github.com/XenitAB/terraform-modules/pull/714) Ingress-nginx helm chart 4.1.4 and use the chroot functionality.

--- a/modules/azure/aks-global/README.md
+++ b/modules/azure/aks-global/README.md
@@ -96,6 +96,7 @@ This module is used to create resources that are used by AKS clusters.
 | <a name="input_name"></a> [name](#input\_name) | The name to use for the deploy | `string` | n/a | yes |
 | <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | The namespaces that should be created in Kubernetes | <pre>list(<br>    object({<br>      name                    = string<br>      delegate_resource_group = bool<br>    })<br>  )</pre> | n/a | yes |
 | <a name="input_public_ip_prefix_configuration"></a> [public\_ip\_prefix\_configuration](#input\_public\_ip\_prefix\_configuration) | Configuration for public IP prefix | <pre>object({<br>    count         = number<br>    prefix_length = number<br>  })</pre> | <pre>{<br>  "count": 2,<br>  "prefix_length": 30<br>}</pre> | no |
+| <a name="input_public_ip_prefix_name_override"></a> [public\_ip\_prefix\_name\_override](#input\_public\_ip\_prefix\_name\_override) | Override the default public ip prefix name - the last digit | `string` | `""` | no |
 | <a name="input_service_principal_name_prefix"></a> [service\_principal\_name\_prefix](#input\_service\_principal\_name\_prefix) | Prefix for service principals | `string` | `"sp"` | no |
 | <a name="input_subscription_name"></a> [subscription\_name](#input\_subscription\_name) | The commonName for the subscription | `string` | n/a | yes |
 | <a name="input_unique_suffix"></a> [unique\_suffix](#input\_unique\_suffix) | Unique suffix that is used in globally unique resources names | `string` | `""` | no |

--- a/modules/azure/aks-global/locals.tf
+++ b/modules/azure/aks-global/locals.tf
@@ -1,6 +1,7 @@
 locals {
-  aks_public_ip_prefix_ids = [for prefix in azurerm_public_ip_prefix.aks : prefix.id]
-  aks_public_ip_prefix_ips = [for prefix in azurerm_public_ip_prefix.aks : prefix.ip_prefix]
+  aks_public_ip_prefix_ids  = [for prefix in azurerm_public_ip_prefix.aks : prefix.id]
+  aks_public_ip_prefix_ips  = [for prefix in azurerm_public_ip_prefix.aks : prefix.ip_prefix]
+  aks_public_ip_preifx_name = var.public_ip_prefix_name_override == "" ? "pip-prefix-${var.environment}-${var.location_short}-${var.name}-aks" : var.public_ip_prefix_name_override
   aad_pod_identity = {
     for k, v in azurerm_user_assigned_identity.aad_pod_identity :
     k => { id = v.id, client_id = v.client_id }

--- a/modules/azure/aks-global/outbound-ips.tf
+++ b/modules/azure/aks-global/outbound-ips.tf
@@ -1,7 +1,7 @@
 resource "azurerm_public_ip_prefix" "aks" {
   count = var.public_ip_prefix_configuration.count
 
-  name                = "pip-prefix-${var.environment}-${var.location_short}-${var.name}-aks-${count.index}"
+  name                = "${local.aks_public_ip_preifx_name}-${count.index}"
   resource_group_name = data.azurerm_resource_group.this.name
   location            = data.azurerm_resource_group.this.location
   prefix_length       = var.public_ip_prefix_configuration.prefix_length

--- a/modules/azure/aks-global/variables.tf
+++ b/modules/azure/aks-global/variables.tf
@@ -55,6 +55,12 @@ variable "public_ip_prefix_configuration" {
   }
 }
 
+variable "public_ip_prefix_name_override" {
+  description = "Override the default public ip prefix name - the last digit"
+  type        = string
+  default     = ""
+}
+
 variable "unique_suffix" {
   description = "Unique suffix that is used in globally unique resources names"
   type        = string


### PR DESCRIPTION
This is a workaround to make it possible for us to save a existing ip prefix.
In azure you can move a IP prefix, but you are unable to change the name of it.

To workaround this we have added a override variable, where you can define the name.

Ether before you create your cluster or if you have a existing cluster you need to do a few steps to make use of this variable assuming that you have moved your existing ip prefix to the aks RG.

Add the following to aks.global, assuming that you old prefix is called pip-prefix-dev-we-aks-test-0, for example.
This won't work if you don't have the `-` and a number after.

```.tf
public_ip_prefix_name_override = "pip-prefix-dev-we-aks-test"
```

```shell
# first remove the existing ip prefix
tf state rm 'module.aks_global.azurerm_public_ip_prefix.aks[0]'
# import the new ip prefix
terraform import --var-file ../global.tfvars --var-file ./variables/prod.tfvars --var-file ./variables/common.tfvars 'module.aks_global.azurerm_public_ip_prefix.aks[0]' /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/publicIPPrefixes/pip-prefix-dev-we-aks-test-0
```
