### PR TITLE
Give tenant access to read VPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - [#735](https://github.com/XenitAB/terraform-modules/pull/735) [Breaking] Add the possibility to ignore unique suffix in key-vault creation.
+- [#739](https://github.com/XenitAB/terraform-modules/pull/739) Enable tenants to read VPA config in there namespace.
 
 ### Changed
 

--- a/modules/kubernetes/aks-core/README.md
+++ b/modules/kubernetes/aks-core/README.md
@@ -70,6 +70,7 @@ This module is used to create AKS clusters.
 | [helm_release.aks_core_extras](https://registry.terraform.io/providers/hashicorp/helm/2.5.1/docs/resources/release) | resource |
 | [kubernetes_cluster_role.custom_resource_edit](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role.get_nodes](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role) | resource |
+| [kubernetes_cluster_role.get_vpa](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role.helm_release](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role.list_namespaces](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role.starboard_reports](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role) | resource |
@@ -93,6 +94,7 @@ This module is used to create AKS clusters.
 | [kubernetes_role_binding.starboard_reports](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.top](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.view](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
+| [kubernetes_role_binding.vpa](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_service_account.tenant](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/service_account) | resource |
 | [kubernetes_storage_class.zrs_premium](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/storage_class) | resource |
 | [kubernetes_storage_class.zrs_standard](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/storage_class) | resource |

--- a/modules/kubernetes/aks-core/k8s-cluster-role.tf
+++ b/modules/kubernetes/aks-core/k8s-cluster-role.tf
@@ -95,3 +95,17 @@ resource "kubernetes_cluster_role" "get_nodes" {
     verbs      = ["get", "list", "watch"]
   }
 }
+
+resource "kubernetes_cluster_role" "get_vpa" {
+  metadata {
+    name = "get-vpa"
+    labels = {
+      "xkf.xenit.io/kind" = "platform"
+    }
+  }
+  rule {
+    api_groups = ["autoscaling.k8s.io"]
+    resources  = ["verticalpodautoscalers"]
+    verbs      = ["get", "list", "watch"]
+  }
+}

--- a/modules/kubernetes/aks-core/k8s-role-binding.tf
+++ b/modules/kubernetes/aks-core/k8s-role-binding.tf
@@ -188,3 +188,30 @@ resource "kubernetes_role_binding" "starboard_reports" {
     name      = var.aad_groups.edit[each.key].id
   }
 }
+
+resource "kubernetes_role_binding" "vpa" {
+  for_each = {
+    for ns in var.namespaces :
+    ns.name => ns
+  }
+
+  metadata {
+    name      = "${each.value.name}-vpa"
+    namespace = kubernetes_namespace.tenant[each.key].metadata[0].name
+
+    labels = {
+      "aad-group-name"    = var.aad_groups.edit[each.key].name
+      "xkf.xenit.io/kind" = "platform"
+    }
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role.get_vpa.metadata[0].name
+  }
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Group"
+    name      = var.aad_groups.edit[each.key].id
+  }
+}

--- a/modules/kubernetes/eks-core/README.md
+++ b/modules/kubernetes/eks-core/README.md
@@ -64,6 +64,7 @@ This module is used to configure EKS clusters.
 | [helm_release.aks_core_extras](https://registry.terraform.io/providers/hashicorp/helm/2.5.1/docs/resources/release) | resource |
 | [kubernetes_cluster_role.custom_resource_edit](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role.get_node](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role) | resource |
+| [kubernetes_cluster_role.get_vpa](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role.helm_release](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role.list_namespaces](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role.starboard_reports](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/cluster_role) | resource |
@@ -87,6 +88,7 @@ This module is used to configure EKS clusters.
 | [kubernetes_role_binding.starboard_reports](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.top](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.view](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
+| [kubernetes_role_binding.vpa](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_service_account.tenant](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/service_account) | resource |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/4.9.0/docs/data-sources/region) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/4.9.0/docs/data-sources/route53_zone) | data source |

--- a/modules/kubernetes/eks-core/k8s-cluster-role.tf
+++ b/modules/kubernetes/eks-core/k8s-cluster-role.tf
@@ -94,3 +94,17 @@ resource "kubernetes_cluster_role" "get_node" {
     verbs      = ["get", "list", "watch"]
   }
 }
+
+resource "kubernetes_cluster_role" "get_vpa" {
+  metadata {
+    name = "get-vpa"
+    labels = {
+      "xkf.xenit.io/kind" = "platform"
+    }
+  }
+  rule {
+    api_groups = ["autoscaling.k8s.io"]
+    resources  = ["verticalpodautoscalers"]
+    verbs      = ["get", "list", "watch"]
+  }
+}

--- a/modules/kubernetes/eks-core/k8s-role-binding.tf
+++ b/modules/kubernetes/eks-core/k8s-role-binding.tf
@@ -210,3 +210,30 @@ resource "kubernetes_role_binding" "get_node" {
     name      = var.aad_groups.edit[each.key].id
   }
 }
+
+resource "kubernetes_role_binding" "vpa" {
+  for_each = {
+    for ns in var.namespaces :
+    ns.name => ns
+  }
+
+  metadata {
+    name      = "${each.value.name}-vpa"
+    namespace = kubernetes_namespace.tenant[each.key].metadata[0].name
+
+    labels = {
+      "aad-group-name"    = var.aad_groups.edit[each.key].name
+      "xkf.xenit.io/kind" = "platform"
+    }
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role.get_vpa.metadata[0].name
+  }
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Group"
+    name      = var.aad_groups.edit[each.key].id
+  }
+}


### PR DESCRIPTION
The tenants needs access to VPA to be able to easily get help with resource suggestions.