### PR TITLE
Add cert permissions to group owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#756](https://github.com/XenitAB/terraform-modules/pull/756) Update terraform and tooling.
 
+### Fixed
+
+- [#743](https://github.com/XenitAB/terraform-modules/pull/743) Add cert permissions to group owners.
+
 ## 2022.07.2
 
 ### Added

--- a/modules/azure/governance-regional/delegate-kv.tf
+++ b/modules/azure/governance-regional/delegate-kv.tf
@@ -78,11 +78,12 @@ resource "azurerm_key_vault_access_policy" "ap_sub_aad_group_owner" {
     if rg.delegate_key_vault == true
   }
 
-  key_vault_id       = azurerm_key_vault.delegate_kv[each.key].id
-  tenant_id          = data.azurerm_client_config.current.tenant_id
-  object_id          = var.azuread_groups.sub_owner.id
-  key_permissions    = local.key_vault_default_permissions.key_permissions
-  secret_permissions = local.key_vault_default_permissions.secret_permissions
+  key_vault_id            = azurerm_key_vault.delegate_kv[each.key].id
+  tenant_id               = data.azurerm_client_config.current.tenant_id
+  object_id               = var.azuread_groups.sub_owner.id
+  key_permissions         = local.key_vault_default_permissions.key_permissions
+  secret_permissions      = local.key_vault_default_permissions.secret_permissions
+  certificate_permissions = local.key_vault_default_permissions.certificate_permissions
 }
 
 resource "azurerm_key_vault_access_policy" "ap_sub_aad_group_contributor" {

--- a/modules/azure/governance-regional/locals.tf
+++ b/modules/azure/governance-regional/locals.tf
@@ -28,5 +28,23 @@ locals {
       "Restore",
       "Set"
     ]
+    certificate_permissions = [
+      "Backup",
+      "Create",
+      "Delete",
+      "DeleteIssuers",
+      "Get",
+      "GetIssuers",
+      "Import",
+      "List",
+      "ListIssuers",
+      "ManageContacts",
+      "ManageIssuers",
+      "Purge",
+      "Recover",
+      "Restore",
+      "SetIssuers",
+      "Update"
+    ]
   }
 }


### PR DESCRIPTION
When adding a certificate to a Azure Key Vault you have to manually change the permissions to be able to do so event if you are in the owners group. This PR gives owners all certificate permission in the same way as we already have for keys and secrets.