### PR TITLE
Enable chroot in AWS again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - [#745](https://github.com/XenitAB/terraform-modules/pull/745) Update ingress-nginx to 4.2.0 and disable chroot image in AWS.
+- [#748](https://github.com/XenitAB/terraform-modules/pull/748) Enable chroot image on AWS and set a custom internal-logger-address when running in AWS and multiple internal_load_balancer.
 
 ### Fixed
 

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -1,8 +1,6 @@
 controller:
-  %{~ if provider != "aws" ~}
   image:
     chroot: true
-  %{~ endif ~}
 
   replicaCount: 3
 

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -127,6 +127,8 @@ controller:
     status-port: 10346
     # Port to use for the lua TCP/UDP endpoint configuration. (default 10247)
     stream-port: 10347
+    # Port to use for the internal syslog server when chroot is enabled. (default 127.0.0.1:11514)
+    internal-logger-address: 127.0.0.1:11515
 
   livenessProbe:
     httpGet:


### PR DESCRIPTION
In AWS overwrite the default internal-logger-address when having one internal and external ingress defined.
This makes it possible for us to enable chroot again.