### PR TITLE
Update gatekeeper to 3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - [#745](https://github.com/XenitAB/terraform-modules/pull/745) Update ingress-nginx to 4.2.0 and disable chroot image in AWS.
+- [#748](https://github.com/XenitAB/terraform-modules/pull/748) Update gatekeeper to 3.9.0.
 
 ### Fixed
 

--- a/modules/kubernetes/opa-gatekeeper/main.tf
+++ b/modules/kubernetes/opa-gatekeeper/main.tf
@@ -123,7 +123,7 @@ resource "helm_release" "gatekeeper" {
   chart       = "gatekeeper"
   name        = "gatekeeper"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "3.8.1"
+  version     = "3.9.0"
   max_history = 3
   skip_crds   = true
   values = [templatefile("${path.module}/templates/gatekeeper-values.yaml.tpl", {
@@ -138,7 +138,7 @@ resource "helm_release" "gatekeeper_templates" {
   chart       = "gatekeeper-library-templates"
   name        = "gatekeeper-library-templates"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "v0.12.1"
+  version     = "v0.13.0"
   max_history = 3
   values      = [local.values]
 }
@@ -150,7 +150,7 @@ resource "helm_release" "gatekeeper_constraints" {
   chart       = "gatekeeper-library-constraints"
   name        = "gatekeeper-library-constraints"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "v0.12.1"
+  version     = "v0.13.0"
   max_history = 3
   values      = [local.values]
 }


### PR DESCRIPTION
Update to latest gatekeeper-lib.
These settings include support for debug containers in k8s 1.23.