### PR TITLE
Run helm chart in client_only mode to fix linkerd CRD install issues.

### DIFF
--- a/modules/kubernetes/helm-crd/main.tf
+++ b/modules/kubernetes/helm-crd/main.tf
@@ -19,6 +19,7 @@ data "helm_template" "this" {
   name         = var.chart_name
   version      = var.chart_version
   include_crds = true
+  validate     = true
   api_versions = ["apiextensions.k8s.io/v1/CustomResourceDefinition"]
 
   dynamic "set" {

--- a/modules/kubernetes/helm-crd/main.tf
+++ b/modules/kubernetes/helm-crd/main.tf
@@ -30,6 +30,11 @@ data "helm_template" "this" {
       value = set.value
     }
   }
+  lifecycle {
+    ignore_changes = [
+      metadata[0].labels,
+    ]
+  }
 }
 
 data "kubectl_file_documents" "this" {

--- a/modules/kubernetes/linkerd/main.tf
+++ b/modules/kubernetes/linkerd/main.tf
@@ -227,7 +227,6 @@ resource "helm_release" "linkerd" {
   namespace   = kubernetes_namespace.this.metadata[0].name
   version     = "1.5.4-edge"
   max_history = 3
-  client_only = true
   values = [
     templatefile("${path.module}/templates/values.yaml.tpl", {
       linkerd_trust_anchor_pem = indent(2, tls_self_signed_cert.linkerd_trust_anchor.cert_pem),

--- a/modules/kubernetes/linkerd/main.tf
+++ b/modules/kubernetes/linkerd/main.tf
@@ -227,6 +227,7 @@ resource "helm_release" "linkerd" {
   namespace   = kubernetes_namespace.this.metadata[0].name
   version     = "1.5.4-edge"
   max_history = 3
+  client_only = true
   values = [
     templatefile("${path.module}/templates/values.yaml.tpl", {
       linkerd_trust_anchor_pem = indent(2, tls_self_signed_cert.linkerd_trust_anchor.cert_pem),


### PR DESCRIPTION
The linkerd helm chart have defined which versions of k8s it supports.
Sadly the helm provider have hardcoded API k8s client version that it uses to apply the config. Thanks to this we are unable to apply the latest linkerd config through terraform.

This is a try to workaround this issue.