### PR TITLE
Update terraform and tooling

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: Setup TFLint
         uses: lablabs/setup-tflint@v1.1.0
         with:
-          tflint_version: v0.34.1
+          tflint_version: v0.39.2
       - name: Run lint
         run: |
           make lint

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.1.7
+          terraform_version: 1.2.6
       - name: Run fmt
         run: |
           sudo apt-get install parallel
@@ -95,7 +95,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 1.1.7
+          terraform_version: 1.2.6
       - name: Run terraform validate
         run: |
           sudo apt-get install parallel

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -71,8 +71,8 @@ jobs:
         uses: actions/checkout@master
       - name: Setup tfsec
         env:
-          TFSEC_VERSION: "v1.8.0"
-          TFSEC_SHA: "6f0ffcc204a73991fb2b47561bbdf473e98a9566036c0f36b95d9574fd5ab4ce"
+          TFSEC_VERSION: "v1.27.1"
+          TFSEC_SHA: "edf06ce4897a3113dda6393b31345aea8b70626dac4c67df87ef0b69fd6c83f0"
         run: |
           wget https://github.com/tfsec/tfsec/releases/download/${TFSEC_VERSION}/tfsec-linux-amd64
           DOWNLOAD_TFSEC_SHA=$(openssl sha1 -sha256 tfsec-linux-amd64 | awk '{print $2}')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#756](https://github.com/XenitAB/terraform-modules/pull/756) Update terraform and tooling.
+
 ## 2022.07.2
 
 ### Added

--- a/LOCAL_DEVELOPMENT.md
+++ b/LOCAL_DEVELOPMENT.md
@@ -1,0 +1,58 @@
+# Local Development
+
+Follow these instructions to install the tools you need.
+
+## Installing tools
+
+### Terraform
+
+```shell
+TFENV_VERSION=v3.0.0
+git clone -b ${TFENV_VERSION} https://github.com/tfutils/tfenv.git /opt/tfenv
+ln -s /opt/tfenv/bin/* /usr/local/bin
+chown <user>:<group> /opt/tfenv
+```
+
+```shell
+TF_VERSION=1.2.6
+tfenv install ${TF_VERSION}
+tfenv use ${TF_VERSION}
+```
+
+### tflint
+
+```shell
+TFLINT_VERSION=v0.39.2
+cd /tmp
+wget https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/tflint_linux_amd64.zip
+unzip tflint_linux_amd64.zip
+mv tflint /usr/bin/tflint
+```
+
+### tfsec
+
+```shell
+TFSEC_VERSION=v1.27.1
+cd /tmp
+wget https://github.com/tfsec/tfsec/releases/download/${TFSEC_VERSION}/tfsec-linux-amd64
+chmod +x tfsec-linux-amd64
+mv tfsec-linux-amd64 /usr/bin/tfsec
+```
+
+### terraform-docs
+
+```shell
+TERRAFORM_DOCS_VERSION=v0.16.0
+cd /tmp
+wget https://github.com/terraform-docs/terraform-docs/releases/download/${TERRAFORM_DOCS_VERSION}/terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz
+tar xzvf terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz terraform-docs
+mv terraform-docs /usr/bin/terraform-docs
+```
+
+### paralell
+
+Use package manager of choice for your distribution.
+
+```shell
+sudo pacman -S parallel
+```

--- a/modules/aws/.tflint.hcl
+++ b/modules/aws/.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "aws" {
   enabled = true
-  version = "0.12.0"
+  version = "0.15.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/modules/aws/core/README.md
+++ b/modules/aws/core/README.md
@@ -6,7 +6,7 @@ This module is used to configure a standard public/private VPC and accompanying 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.9.0 |
 
 ## Providers

--- a/modules/aws/core/main.tf
+++ b/modules/aws/core/main.tf
@@ -6,7 +6,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/aws/eks-core/README.md
+++ b/modules/aws/eks-core/README.md
@@ -6,7 +6,7 @@ This module is used to configure an opinionated VPC for XKS.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.9.0 |
 
 ## Providers

--- a/modules/aws/eks-core/main.tf
+++ b/modules/aws/eks-core/main.tf
@@ -6,7 +6,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/aws/eks-global/README.md
+++ b/modules/aws/eks-global/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.9.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.19.1 |
 

--- a/modules/aws/eks-global/main.tf
+++ b/modules/aws/eks-global/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/aws/eks/README.md
+++ b/modules/aws/eks/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.9.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | 3.1.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | 3.1.0 |

--- a/modules/aws/eks/eks.tf
+++ b/modules/aws/eks/eks.tf
@@ -112,7 +112,7 @@ data "aws_eks_cluster_auth" "this" {
 # and then it installs the Calico CNI.
 resource "null_resource" "update_eks_cni" {
   triggers = {
-    script_hash = "${sha256(local.cni_script_check)}"
+    script_hash = sha256(local.cni_script_check)
   }
 
   provisioner "local-exec" {

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/aws/irsa/README.md
+++ b/modules/aws/irsa/README.md
@@ -8,7 +8,7 @@ to assume the specific role.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.9.0 |
 
 ## Providers

--- a/modules/aws/irsa/main.tf
+++ b/modules/aws/irsa/main.tf
@@ -7,7 +7,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/azure-ad/azad-kube-proxy/README.md
+++ b/modules/azure-ad/azad-kube-proxy/README.md
@@ -6,7 +6,7 @@ This module is used to configure the Azure AD Application used by [`azad-kube-pr
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.19.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |
 

--- a/modules/azure-ad/azad-kube-proxy/main.tf
+++ b/modules/azure-ad/azad-kube-proxy/main.tf
@@ -5,7 +5,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     azuread = {

--- a/modules/azure/.tflint.hcl
+++ b/modules/azure/.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "azurerm" {
   enabled = true
-  version = "0.14.0"
+  version = "0.17.1"
   source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
 }
 

--- a/modules/azure/aks-global/README.md
+++ b/modules/azure/aks-global/README.md
@@ -6,7 +6,7 @@ This module is used to create resources that are used by AKS clusters.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.19.1 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.8.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |

--- a/modules/azure/aks-global/main.tf
+++ b/modules/azure/aks-global/main.tf
@@ -5,7 +5,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     azurerm = {

--- a/modules/azure/aks/README.md
+++ b/modules/azure/aks/README.md
@@ -13,7 +13,7 @@ https://pumpingco.de/blog/modify-aks-default-node-pool-in-terraform-without-rede
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.19.1 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.8.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |

--- a/modules/azure/aks/main.tf
+++ b/modules/azure/aks/main.tf
@@ -13,7 +13,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     azurerm = {

--- a/modules/azure/azure-pipelines-agent-vmss/README.md
+++ b/modules/azure/azure-pipelines-agent-vmss/README.md
@@ -10,7 +10,7 @@ Follow this guide to setup the agent pool (manually): https://docs.microsoft.com
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.8.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | 3.1.0 |
 

--- a/modules/azure/azure-pipelines-agent-vmss/main.tf
+++ b/modules/azure/azure-pipelines-agent-vmss/main.tf
@@ -9,7 +9,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     azurerm = {

--- a/modules/azure/core/README.md
+++ b/modules/azure/core/README.md
@@ -6,7 +6,7 @@ This module is used to create core resources like virtual network for the subscr
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.19.1 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.8.0 |
 

--- a/modules/azure/core/main.tf
+++ b/modules/azure/core/main.tf
@@ -5,7 +5,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     azurerm = {

--- a/modules/azure/github-runner/README.md
+++ b/modules/azure/github-runner/README.md
@@ -12,7 +12,7 @@ Setup an image using Packer according [github-runner](https://github.com/XenitAB
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.8.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | 3.1.0 |
 

--- a/modules/azure/github-runner/main.tf
+++ b/modules/azure/github-runner/main.tf
@@ -11,7 +11,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     azurerm = {

--- a/modules/azure/governance-global/README.md
+++ b/modules/azure/governance-global/README.md
@@ -6,7 +6,7 @@ This module is used for governance on a global level and not using any specific 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.19.1 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.8.0 |
 | <a name="requirement_pal"></a> [pal](#requirement\_pal) | 0.2.5 |

--- a/modules/azure/governance-global/main.tf
+++ b/modules/azure/governance-global/main.tf
@@ -5,7 +5,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     azurerm = {

--- a/modules/azure/governance-regional/README.md
+++ b/modules/azure/governance-regional/README.md
@@ -6,7 +6,7 @@ This module is used for governance on a regional level and not using any specifi
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.19.1 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.8.0 |
 | <a name="requirement_pal"></a> [pal](#requirement\_pal) | 0.2.5 |

--- a/modules/azure/governance-regional/main.tf
+++ b/modules/azure/governance-regional/main.tf
@@ -5,7 +5,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     azurerm = {

--- a/modules/azure/hub/README.md
+++ b/modules/azure/hub/README.md
@@ -10,7 +10,7 @@ Use together with the `core` module to create a peered network where SPOF (singl
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.19.1 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.8.0 |
 

--- a/modules/azure/hub/main.tf
+++ b/modules/azure/hub/main.tf
@@ -9,7 +9,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     azurerm = {

--- a/modules/kubernetes/.tflint.hcl
+++ b/modules/kubernetes/.tflint.hcl
@@ -1,12 +1,12 @@
 plugin "azurerm" {
   enabled = true
-  version = "0.14.0"
+  version = "0.17.1"
   source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
 }
 
 plugin "aws" {
   enabled = true
-  version = "0.12.0"
+  version = "0.15.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/modules/kubernetes/aad-pod-identity/README.md
+++ b/modules/kubernetes/aad-pod-identity/README.md
@@ -6,7 +6,7 @@ This module is used to add [`aad-pod-identity`](https://github.com/Azure/aad-pod
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/aad-pod-identity/main.tf
+++ b/modules/kubernetes/aad-pod-identity/main.tf
@@ -5,7 +5,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/aks-core/README.md
+++ b/modules/kubernetes/aks-core/README.md
@@ -6,7 +6,7 @@ This module is used to create AKS clusters.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.19.1 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.8.0 |
 | <a name="requirement_flux"></a> [flux](#requirement\_flux) | 0.11.2 |

--- a/modules/kubernetes/aks-core/main.tf
+++ b/modules/kubernetes/aks-core/main.tf
@@ -5,7 +5,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     azurerm = {

--- a/modules/kubernetes/azad-kube-proxy/README.md
+++ b/modules/kubernetes/azad-kube-proxy/README.md
@@ -23,7 +23,7 @@ module "aks\_core" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/azad-kube-proxy/main.tf
+++ b/modules/kubernetes/azad-kube-proxy/main.tf
@@ -22,7 +22,7 @@
 */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/azure-metrics/README.md
+++ b/modules/kubernetes/azure-metrics/README.md
@@ -7,7 +7,7 @@ We are using: https://github.com/webdevops/azure-metrics-exporter to gather the 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/azure-metrics/main.tf
+++ b/modules/kubernetes/azure-metrics/main.tf
@@ -6,7 +6,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/cert-manager/README.md
+++ b/modules/kubernetes/cert-manager/README.md
@@ -6,7 +6,7 @@ This module is used to add [`cert-manager`](https://github.com/jetstack/cert-man
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/cert-manager/main.tf
+++ b/modules/kubernetes/cert-manager/main.tf
@@ -5,7 +5,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/cluster-autoscaler/README.md
+++ b/modules/kubernetes/cluster-autoscaler/README.md
@@ -6,7 +6,7 @@ This module is used to add [`cluster-autoscaler`](https://github.com/kubernetes/
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/cluster-autoscaler/main.tf
+++ b/modules/kubernetes/cluster-autoscaler/main.tf
@@ -5,7 +5,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/csi-secrets-store-provider-aws/README.md
+++ b/modules/kubernetes/csi-secrets-store-provider-aws/README.md
@@ -6,7 +6,7 @@ Adds [csi-secrets-store-provider-aws](https://github.com/aws/secrets-store-csi-d
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/csi-secrets-store-provider-aws/main.tf
+++ b/modules/kubernetes/csi-secrets-store-provider-aws/main.tf
@@ -5,7 +5,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/csi-secrets-store-provider-azure/README.md
+++ b/modules/kubernetes/csi-secrets-store-provider-azure/README.md
@@ -6,7 +6,7 @@ Adds [csi-secrets-store-provider-azure](https://github.com/Azure/secrets-store-c
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/csi-secrets-store-provider-azure/main.tf
+++ b/modules/kubernetes/csi-secrets-store-provider-azure/main.tf
@@ -5,7 +5,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/datadog/README.md
+++ b/modules/kubernetes/datadog/README.md
@@ -11,7 +11,7 @@ https://docs.datadoghq.com/account_management/api-app-keys/
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/datadog/main.tf
+++ b/modules/kubernetes/datadog/main.tf
@@ -10,7 +10,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/eks-core/README.md
+++ b/modules/kubernetes/eks-core/README.md
@@ -6,7 +6,7 @@ This module is used to configure EKS clusters.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.9.0 |
 | <a name="requirement_flux"></a> [flux](#requirement\_flux) | 0.11.2 |
 | <a name="requirement_github"></a> [github](#requirement\_github) | 4.21.0 |

--- a/modules/kubernetes/eks-core/main.tf
+++ b/modules/kubernetes/eks-core/main.tf
@@ -5,7 +5,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     aws = {

--- a/modules/kubernetes/external-dns/README.md
+++ b/modules/kubernetes/external-dns/README.md
@@ -6,7 +6,7 @@ This module is used to add [`external-dns`](https://github.com/kubernetes-sigs/e
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/external-dns/main.tf
+++ b/modules/kubernetes/external-dns/main.tf
@@ -5,7 +5,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/falco/README.md
+++ b/modules/kubernetes/falco/README.md
@@ -8,7 +8,7 @@ to expose event metrics.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/falco/main.tf
+++ b/modules/kubernetes/falco/main.tf
@@ -7,7 +7,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/fluxcd-v1/README.md
+++ b/modules/kubernetes/fluxcd-v1/README.md
@@ -14,7 +14,7 @@ Will be deprecated as soon as Flux v2 module is finished and tested.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |

--- a/modules/kubernetes/fluxcd-v1/main.tf
+++ b/modules/kubernetes/fluxcd-v1/main.tf
@@ -13,7 +13,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     random = {

--- a/modules/kubernetes/fluxcd-v2-azdo/README.md
+++ b/modules/kubernetes/fluxcd-v2-azdo/README.md
@@ -17,7 +17,7 @@ the bootstrap configuration.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | 0.5.0 |
 | <a name="requirement_flux"></a> [flux](#requirement\_flux) | 0.11.2 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |

--- a/modules/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/main.tf
@@ -16,7 +16,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     helm = {

--- a/modules/kubernetes/fluxcd-v2-github/README.md
+++ b/modules/kubernetes/fluxcd-v2-github/README.md
@@ -17,7 +17,7 @@ the bootstrap configuration.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_flux"></a> [flux](#requirement\_flux) | 0.11.2 |
 | <a name="requirement_github"></a> [github](#requirement\_github) | 4.21.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |

--- a/modules/kubernetes/fluxcd-v2-github/main.tf
+++ b/modules/kubernetes/fluxcd-v2-github/main.tf
@@ -16,7 +16,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     helm = {

--- a/modules/kubernetes/grafana-agent/README.md
+++ b/modules/kubernetes/grafana-agent/README.md
@@ -54,7 +54,7 @@ module "aks_core" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/grafana-agent/main.tf
+++ b/modules/kubernetes/grafana-agent/main.tf
@@ -54,7 +54,7 @@
 */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/helm-crd/README.md
+++ b/modules/kubernetes/helm-crd/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | 1.14.0 |
 

--- a/modules/kubernetes/helm-crd/main.tf
+++ b/modules/kubernetes/helm-crd/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     helm = {

--- a/modules/kubernetes/ingress-healthz/README.md
+++ b/modules/kubernetes/ingress-healthz/README.md
@@ -8,7 +8,7 @@ automatic DNS creation and certificate creation, without depending on the stabil
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/ingress-healthz/main.tf
+++ b/modules/kubernetes/ingress-healthz/main.tf
@@ -7,7 +7,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/ingress-nginx/README.md
+++ b/modules/kubernetes/ingress-nginx/README.md
@@ -6,7 +6,7 @@ This module is used to add [`ingress-nginx`](https://github.com/kubernetes/ingre
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/ingress-nginx/main.tf
+++ b/modules/kubernetes/ingress-nginx/main.tf
@@ -5,7 +5,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/linkerd/README.md
+++ b/modules/kubernetes/linkerd/README.md
@@ -50,7 +50,7 @@ The [Linkerd CNI](https://linkerd.io/2.10/features/cni/) is required to if the l
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | 3.1.0 |

--- a/modules/kubernetes/linkerd/main.tf
+++ b/modules/kubernetes/linkerd/main.tf
@@ -50,7 +50,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/node-local-dns/README.md
+++ b/modules/kubernetes/node-local-dns/README.md
@@ -6,7 +6,7 @@ This module is used to add [`node-local-dns`](https://kubernetes.io/docs/tasks/a
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/node-local-dns/main.tf
+++ b/modules/kubernetes/node-local-dns/main.tf
@@ -5,7 +5,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/node-ttl/README.md
+++ b/modules/kubernetes/node-ttl/README.md
@@ -6,7 +6,7 @@ This module is used to add [`node-ttl`](https://github.com/XenitAB/node-ttl) to 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/node-ttl/main.tf
+++ b/modules/kubernetes/node-ttl/main.tf
@@ -5,7 +5,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/opa-gatekeeper/README.md
+++ b/modules/kubernetes/opa-gatekeeper/README.md
@@ -86,7 +86,7 @@ as the same values are passed to both of the charts, there will never be a diffe
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/opa-gatekeeper/main.tf
+++ b/modules/kubernetes/opa-gatekeeper/main.tf
@@ -85,7 +85,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/prometheus/README.md
+++ b/modules/kubernetes/prometheus/README.md
@@ -7,7 +7,7 @@ If you are running on AWS we also install [Metrics server](https://aws.amazon.co
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/prometheus/main.tf
+++ b/modules/kubernetes/prometheus/main.tf
@@ -6,7 +6,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/promtail/README.md
+++ b/modules/kubernetes/promtail/README.md
@@ -6,7 +6,7 @@ Adds [Promtail](https://github.com/grafana/helm-charts/tree/main/charts/promtail
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/promtail/main.tf
+++ b/modules/kubernetes/promtail/main.tf
@@ -5,7 +5,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/reloader/README.md
+++ b/modules/kubernetes/reloader/README.md
@@ -6,7 +6,7 @@ Adds [`Reloader`](https://github.com/stakater/Reloader) to a Kubernetes clusters
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/reloader/main.tf
+++ b/modules/kubernetes/reloader/main.tf
@@ -6,7 +6,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/starboard/README.md
+++ b/modules/kubernetes/starboard/README.md
@@ -14,7 +14,7 @@ trivy metrics from starboard CRD:s.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/starboard/main.tf
+++ b/modules/kubernetes/starboard/main.tf
@@ -13,7 +13,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/velero/README.md
+++ b/modules/kubernetes/velero/README.md
@@ -6,7 +6,7 @@ This module is used to add [`velero`](https://github.com/vmware-tanzu/velero) to
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/velero/main.tf
+++ b/modules/kubernetes/velero/main.tf
@@ -5,7 +5,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {

--- a/modules/kubernetes/vpa/README.md
+++ b/modules/kubernetes/vpa/README.md
@@ -10,7 +10,7 @@ VPA config to all kinds of workloads. This will help us generate metrics for our
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.8.0 |
 

--- a/modules/kubernetes/vpa/main.tf
+++ b/modules/kubernetes/vpa/main.tf
@@ -9,7 +9,7 @@
   */
 
 terraform {
-  required_version = ">= 1.1.7"
+  required_version = ">= 1.2.6"
 
   required_providers {
     kubernetes = {


### PR DESCRIPTION
Changes:
- Update terraform: `1.1.7` -> `1.2.6`
- Update tflint: `v0.34.1` -> `v0.39.2`
- Update tfsec: `v1.8.0` -> `v1.27.1`
- Add readme for local development (how to install tools locally)
- Fix one linting error

After this PR, it is required to use `ghcr.io/xenitab/github-actions/tools:2022.08.2` or later.