### PR TITLE
Fix tf-latest-version

### DIFF
--- a/.github/workflows/latest-version.yaml
+++ b/.github/workflows/latest-version.yaml
@@ -9,8 +9,8 @@ jobs:
     steps:
       - name: Setup tf-latest-version
         env:
-          TF_LATEST_VERSION_VERSION: "0.1.0"
-          TF_LATEST_VERSION_SHA: "c49dcce03749ec6286347c154eb01b6223ebe9d81451ab7da19f9bce1fb5e686"
+          TF_LATEST_VERSION_VERSION: "0.1.1"
+          TF_LATEST_VERSION_SHA: "e36355a163a69a8fff9e4bf946db33171e7e085d6d33647353ab128b903e2c3d"
         run: |
           set -e
           wget https://github.com/XenitAB/tf-latest-version/releases/download/v${TF_LATEST_VERSION_VERSION}/tf-latest-version_${TF_LATEST_VERSION_VERSION}_linux_amd64.tar.gz

--- a/.github/workflows/latest-version.yaml
+++ b/.github/workflows/latest-version.yaml
@@ -32,7 +32,7 @@ jobs:
         run: |
           set -xe
           export PATH=${PATH}:~/.local/bin
-          RESULT=$(tf-latest-version modules)
+          RESULT=$(tf-latest-version --path ./)
           # Needed as set-output truncates multiline strings
           # https://github.community/t/set-output-truncates-multiline-strings/16852/4
           RESULT="${RESULT//'%'/'%25'}"

--- a/modules/kubernetes/linkerd/main.tf
+++ b/modules/kubernetes/linkerd/main.tf
@@ -192,6 +192,7 @@ resource "kubernetes_secret" "webhook_issuer_tls" {
 }
 
 # Install linkerd-cni helm chart
+#tf-latest-version:ignore
 resource "helm_release" "linkerd_cni" {
   repository  = "https://helm.linkerd.io/stable"
   chart       = "linkerd2-cni"
@@ -218,6 +219,7 @@ resource "helm_release" "linkerd_extras" {
   max_history = 3
 }
 
+#tf-latest-version:ignore
 resource "helm_release" "linkerd" {
   depends_on = [helm_release.linkerd_extras, helm_release.linkerd_cni]
 
@@ -236,6 +238,7 @@ resource "helm_release" "linkerd" {
 }
 
 # Install linkerd viz extension https://github.com/linkerd/linkerd2/tree/main/viz/charts/linkerd-viz
+#tf-latest-version:ignore
 resource "helm_release" "linkerd_viz" {
   depends_on = [helm_release.linkerd]
 


### PR DESCRIPTION
Changes:
* Update tf-latest-version: `v0.1.0` -> `v0.1.1`
* Fix tf-latest-version flag (was changed in earlier version)
* Ignore linkerd helm charts (they are using pre-release and shouldn't be updated automatically)