### PR TITLE
Move secrets-store-csi-driver-provider-azure helm chart location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#756](https://github.com/XenitAB/terraform-modules/pull/756) Update terraform and tooling.
 - [#759](https://github.com/XenitAB/terraform-modules/pull/759) Update Terraform tls provider to 4.0.1.
+- [#760](https://github.com/XenitAB/terraform-modules/pull/760) Move secrets-store-csi-driver-provider-azure helm chart location.
 
 ### Fixed
 

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -348,7 +348,7 @@ module "velero" {
 module "csi_secrets_store_provider_azure_crd" {
   source = "../../kubernetes/helm-crd"
 
-  chart_repository = "https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts"
+  chart_repository = "https://azure.github.io/secrets-store-csi-driver-provider-azure/charts"
   chart_name       = "csi-secrets-store-provider-azure"
   chart_version    = "1.0.1"
 }

--- a/modules/kubernetes/csi-secrets-store-provider-azure/main.tf
+++ b/modules/kubernetes/csi-secrets-store-provider-azure/main.tf
@@ -30,7 +30,7 @@ resource "kubernetes_namespace" "this" {
 }
 
 resource "helm_release" "csi_secrets_store_provider_azure" {
-  repository  = "https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts"
+  repository  = "https://azure.github.io/secrets-store-csi-driver-provider-azure/charts"
   version     = "1.0.1"
   chart       = "csi-secrets-store-provider-azure"
   name        = "csi-secrets-store-provider-azure"


### PR DESCRIPTION
Changes:
* The helm chart repository URL has changed from `https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts` to `https://azure.github.io/secrets-store-csi-driver-provider-azure/charts`