### PR TITLE
Fix Linkerd cert expiring 8 years too early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#715](https://github.com/XenitAB/terraform-modules/pull/715) Long term storage of AKS audit logs.
 
+### Fixed
+
+- [#764](https://github.com/XenitAB/terraform-modules/pull/764) Fix Linkerd cert expiring 8 years too early.
+
 ## 2022.08.2
 
 ### Changed

--- a/modules/kubernetes/linkerd/main.tf
+++ b/modules/kubernetes/linkerd/main.tf
@@ -125,7 +125,7 @@ resource "tls_private_key" "linkerd_trust_anchor" {
 resource "tls_self_signed_cert" "linkerd_trust_anchor" {
   private_key_pem       = tls_private_key.linkerd_trust_anchor.private_key_pem
   validity_period_hours = 87600
-  early_renewal_hours   = 78840
+  early_renewal_hours   = 8760
   is_ca_certificate     = true
 
   subject {
@@ -162,7 +162,7 @@ resource "tls_private_key" "webhook_issuer_tls" {
 resource "tls_self_signed_cert" "webhook_issuer_tls" {
   private_key_pem       = tls_private_key.webhook_issuer_tls.private_key_pem
   validity_period_hours = 87600
-  early_renewal_hours   = 78840
+  early_renewal_hours   = 8760
   is_ca_certificate     = true
 
   subject {


### PR DESCRIPTION
This change fixes an hones mistake of setting `early_renewal_hours` to 9 years instead of 1 year. I think the intent was to force renewal a year early but the result was renewing the certificate 8 years early instead.

This change fixes the mistake.