### PR TITLE
Replace linkerd image registry with ghcr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - [#764](https://github.com/XenitAB/terraform-modules/pull/764) Fix Linkerd cert expiring 8 years too early.
+- [#765](https://github.com/XenitAB/terraform-modules/pull/764) Replace Linkerd image registry with ghcr.
 
 ## 2022.08.2
 

--- a/modules/kubernetes/linkerd/templates/values-cni.yaml.tpl
+++ b/modules/kubernetes/linkerd/templates/values-cni.yaml.tpl
@@ -3,6 +3,8 @@ installNamespace: false
 tolerations:
   - operator: "Exists"
 
+cniPluginImage: "ghcr.io/linkerd/cni-plugin"
+
 extraInitContainers:
   - name: wait-for-other-cni
     image: busybox:1.33

--- a/modules/kubernetes/linkerd/templates/values-viz.yaml.tpl
+++ b/modules/kubernetes/linkerd/templates/values-viz.yaml.tpl
@@ -1,1 +1,2 @@
 installNamespace: false
+defaultRegistry: ghcr.io/linkerd

--- a/modules/kubernetes/linkerd/templates/values.yaml.tpl
+++ b/modules/kubernetes/linkerd/templates/values.yaml.tpl
@@ -40,6 +40,8 @@ enablePodAntiAffinity: true
 
 # proxy configuration
 proxy:
+  image:
+    name: ghcr.io/linkerd/proxy
   # A better default for log collectors that require structured data
   logFormat: json
   resources:
@@ -50,6 +52,7 @@ proxy:
       request: 20Mi
 
 # controller configuration
+controllerImage: ghcr.io/linkerd/controller
 controllerReplicas: 3
 controllerResources: &controller_resources
   cpu: &controller_resources_cpu
@@ -76,3 +79,13 @@ webhookFailurePolicy: Fail
 
 # service profile validator configuration
 spValidatorResources: *controller_resources
+
+policyController:
+  image:
+    name: ghcr.io/linkerd/policy-controller
+debugContainer:
+  image:
+    name: ghcr.io/linkerd/debug
+proxyInit:
+  image:
+    name: ghcr.io/linkerd/proxy-init


### PR DESCRIPTION
This changes the registry used by Linkerd pods from its own registry to ghcr. The reason for this is that the default registry can cause large image pull duration at times.