### PR TITLE
Skip Linkerd proxy for Ingress Nginx webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#764](https://github.com/XenitAB/terraform-modules/pull/764) Fix Linkerd cert expiring 8 years too early.
 - [#765](https://github.com/XenitAB/terraform-modules/pull/764) Replace Linkerd image registry with ghcr.
+- [#766](https://github.com/XenitAB/terraform-modules/pull/766) Skip Linkerd proxy for Ingress Nginx webhook.
 
 ## 2022.08.2
 

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -86,7 +86,7 @@ controller:
     linkerd.io/inject: "ingress"
     # It's required to skip inbound ports for the ingress or whitelist of IPs won't work:
     # https://github.com/linkerd/linkerd2/issues/3334#issuecomment-565135188
-    config.linkerd.io/skip-inbound-ports: "80,443"
+    config.linkerd.io/skip-inbound-ports: "80,443,8443"
     %{~ endif ~}
   %{~ endif ~}
 


### PR DESCRIPTION
This change skips Linkerd for traffic to port 8443 in Ingress Nginx. The reason for this is that the traffic coming from the Kubernetes API cannot go through Linkerd.