### PR TITLE
Enable a seperate helm-crd for oci helm charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - [#715](https://github.com/XenitAB/terraform-modules/pull/715) Long term storage of AKS audit logs.
+- [#767](https://github.com/XenitAB/terraform-modules/pull/767) Helm-crd-oci module to support helm charts located in OCI.
 
 ### Fixed
 

--- a/modules/kubernetes/README.md
+++ b/modules/kubernetes/README.md
@@ -33,6 +33,7 @@ This directory contains all the Kubernetes Terraform modules.
 - [`node-ttl`](node-ttl/README.md)
 - [`promtail`](promtail/README.md)
 - [`helm-crd`](helm-crd/README.md)
+- [`helm-crd-oci`](helm-crd-oci/README.md)
 
 ## Style Guide
 

--- a/modules/kubernetes/helm-crd-oci/README.md
+++ b/modules/kubernetes/helm-crd-oci/README.md
@@ -29,6 +29,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_chart"></a> [chart](#input\_chart) | Helm Chart OCI URI | `string` | n/a | yes |
 | <a name="input_chart_name"></a> [chart\_name](#input\_chart\_name) | Helm Chart repository | `string` | n/a | yes |
 | <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | Helm Chart repository | `string` | n/a | yes |
 | <a name="input_values"></a> [values](#input\_values) | Extra values to pass when templating | `map(any)` | `{}` | no |

--- a/modules/kubernetes/helm-crd-oci/README.md
+++ b/modules/kubernetes/helm-crd-oci/README.md
@@ -1,0 +1,38 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | 1.14.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.5.1 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | 1.14.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [kubectl_manifest.this](https://registry.terraform.io/providers/gavinbunney/kubectl/1.14.0/docs/resources/manifest) | resource |
+| [helm_template.this](https://registry.terraform.io/providers/hashicorp/helm/2.5.1/docs/data-sources/template) | data source |
+| [kubectl_file_documents.this](https://registry.terraform.io/providers/gavinbunney/kubectl/1.14.0/docs/data-sources/file_documents) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_chart_name"></a> [chart\_name](#input\_chart\_name) | Helm Chart repository | `string` | n/a | yes |
+| <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | Helm Chart repository | `string` | n/a | yes |
+| <a name="input_values"></a> [values](#input\_values) | Extra values to pass when templating | `map(any)` | `{}` | no |
+
+## Outputs
+
+No outputs.

--- a/modules/kubernetes/helm-crd-oci/main.tf
+++ b/modules/kubernetes/helm-crd-oci/main.tf
@@ -1,0 +1,46 @@
+terraform {
+  required_version = ">= 1.2.6"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "2.5.1"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "1.14.0"
+    }
+  }
+}
+
+data "helm_template" "this" {
+  chart        = var.chart_name
+  name         = var.chart_name
+  version      = var.chart_version
+  include_crds = true
+  api_versions = ["apiextensions.k8s.io/v1/CustomResourceDefinition"]
+
+  dynamic "set" {
+    for_each = var.values
+
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
+}
+
+data "kubectl_file_documents" "this" {
+  content = data.helm_template.this.manifest
+}
+
+resource "kubectl_manifest" "this" {
+  for_each = {
+    for k, v in data.kubectl_file_documents.this.manifests :
+    k => v
+    if can(regex("^/apis/apiextensions.k8s.io/v1/customresourcedefinitions/", k))
+  }
+  server_side_apply = true
+  apply_only        = true
+  yaml_body         = each.value
+}

--- a/modules/kubernetes/helm-crd-oci/main.tf
+++ b/modules/kubernetes/helm-crd-oci/main.tf
@@ -14,7 +14,7 @@ terraform {
 }
 
 data "helm_template" "this" {
-  chart        = var.chart_name
+  chart        = var.chart
   name         = var.chart_name
   version      = var.chart_version
   include_crds = true

--- a/modules/kubernetes/helm-crd-oci/variables.tf
+++ b/modules/kubernetes/helm-crd-oci/variables.tf
@@ -1,3 +1,8 @@
+variable "chart" {
+  description = "Helm Chart OCI URI"
+  type        = string
+}
+
 variable "chart_name" {
   description = "Helm Chart repository"
   type        = string

--- a/modules/kubernetes/helm-crd-oci/variables.tf
+++ b/modules/kubernetes/helm-crd-oci/variables.tf
@@ -1,0 +1,15 @@
+variable "chart_name" {
+  description = "Helm Chart repository"
+  type        = string
+}
+
+variable "chart_version" {
+  description = "Helm Chart repository"
+  type        = string
+}
+
+variable "values" {
+  description = "Extra values to pass when templating"
+  type        = map(any)
+  default     = {}
+}

--- a/validation/kubernetes/helm-crd-oci/main.tf
+++ b/validation/kubernetes/helm-crd-oci/main.tf
@@ -3,6 +3,7 @@ terraform {}
 module "helm_crd" {
   source = "../../../modules/kubernetes/helm-crd-oci"
 
+  chart         = "oci://ghcr.io/example/helm-charts/example"
   chart_name    = "bar"
   chart_version = "baz"
 }

--- a/validation/kubernetes/helm-crd-oci/main.tf
+++ b/validation/kubernetes/helm-crd-oci/main.tf
@@ -3,6 +3,6 @@ terraform {}
 module "helm_crd" {
   source = "../../../modules/kubernetes/helm-crd-oci"
 
-  chart_name       = "bar"
-  chart_version    = "baz"
+  chart_name    = "bar"
+  chart_version = "baz"
 }

--- a/validation/kubernetes/helm-crd-oci/main.tf
+++ b/validation/kubernetes/helm-crd-oci/main.tf
@@ -1,0 +1,8 @@
+terraform {}
+
+module "helm_crd" {
+  source = "../../../modules/kubernetes/helm-crd-oci"
+
+  chart_name       = "bar"
+  chart_version    = "baz"
+}


### PR DESCRIPTION
A simple workaround to be able to use oci helm charts from terraform.