### PR TITLE
Use OCI helm chart in xenit linkerd fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#764](https://github.com/XenitAB/terraform-modules/pull/764) Fix Linkerd cert expiring 8 years too early.
 - [#765](https://github.com/XenitAB/terraform-modules/pull/764) Replace Linkerd image registry with ghcr.
 - [#766](https://github.com/XenitAB/terraform-modules/pull/766) Skip Linkerd proxy for Ingress Nginx webhook.
+- [#768](https://github.com/XenitAB/terraform-modules/pull/768) Use linkerd-fork OCI helm charts.
 
 ## 2022.08.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#764](https://github.com/XenitAB/terraform-modules/pull/764) Fix Linkerd cert expiring 8 years too early.
 - [#765](https://github.com/XenitAB/terraform-modules/pull/764) Replace Linkerd image registry with ghcr.
 - [#766](https://github.com/XenitAB/terraform-modules/pull/766) Skip Linkerd proxy for Ingress Nginx webhook.
-- [#768](https://github.com/XenitAB/terraform-modules/pull/768) Use linkerd-fork OCI helm charts.
+- [#768](https://github.com/XenitAB/terraform-modules/pull/768) Use linkerd-fork OCI helm charts and update linkerd to 2.12.0.
 
 ## 2022.08.2
 

--- a/modules/kubernetes/aks-core/README.md
+++ b/modules/kubernetes/aks-core/README.md
@@ -48,7 +48,7 @@ This module is used to create AKS clusters.
 | <a name="module_ingress_healthz"></a> [ingress\_healthz](#module\_ingress\_healthz) | ../../kubernetes/ingress-healthz | n/a |
 | <a name="module_ingress_nginx"></a> [ingress\_nginx](#module\_ingress\_nginx) | ../../kubernetes/ingress-nginx | n/a |
 | <a name="module_linkerd"></a> [linkerd](#module\_linkerd) | ../../kubernetes/linkerd | n/a |
-| <a name="module_linkerd_crd"></a> [linkerd\_crd](#module\_linkerd\_crd) | ../../kubernetes/helm-crd | n/a |
+| <a name="module_linkerd_crd"></a> [linkerd\_crd](#module\_linkerd\_crd) | ../../kubernetes/helm-crd-oci | n/a |
 | <a name="module_node_local_dns"></a> [node\_local\_dns](#module\_node\_local\_dns) | ../../kubernetes/node-local-dns | n/a |
 | <a name="module_node_ttl"></a> [node\_ttl](#module\_node\_ttl) | ../../kubernetes/node-ttl | n/a |
 | <a name="module_opa_gatekeeper"></a> [opa\_gatekeeper](#module\_opa\_gatekeeper) | ../../kubernetes/opa-gatekeeper | n/a |

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -206,7 +206,7 @@ module "linkerd_crd" {
 
   chart_repository = "https://helm.linkerd.io/edge"
   chart_name       = "linkerd-crds"
-  chart_version    = "1.1.1-edge"
+  chart_version    = "2.12.0"
 }
 
 module "linkerd" {

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -204,8 +204,8 @@ module "linkerd_crd" {
     if var.linkerd_enabled
   }
 
-  chart_name    = "oci://ghcr.io/xenitab/helm-charts/linkerd-crds"
-  name          = "linkerd-crd"
+  chart         = "oci://ghcr.io/xenitab/helm-charts/linkerd-crds"
+  chart_name    = "linkerd-crd"
   chart_version = "2.12.0"
 }
 

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -196,7 +196,7 @@ module "azure_metrics" {
 
 # linkerd
 module "linkerd_crd" {
-  source = "../../kubernetes/helm-crd"
+  source = "../../kubernetes/helm-crd-oci"
 
   for_each = {
     for s in ["linkerd"] :
@@ -204,9 +204,9 @@ module "linkerd_crd" {
     if var.linkerd_enabled
   }
 
-  chart_repository = "https://helm.linkerd.io/edge"
-  chart_name       = "linkerd-crds"
-  chart_version    = "2.12.0"
+  chart_name    = "oci://ghcr.io/xenitab/helm-charts/linkerd-crds"
+  name          = "linkerd-crd"
+  chart_version = "2.12.0"
 }
 
 module "linkerd" {

--- a/modules/kubernetes/linkerd/main.tf
+++ b/modules/kubernetes/linkerd/main.tf
@@ -192,10 +192,11 @@ resource "kubernetes_secret" "webhook_issuer_tls" {
 # Install linkerd-cni helm chart
 #tf-latest-version:ignore
 resource "helm_release" "linkerd_cni" {
-  chart       = "oci://ghcr.io/xenitab/helm-charts/linkerd2-cni"
+  repository  = "https://helm.linkerd.io/stable"
+  chart       = "linkerd-control-plane"
   name        = "linkerd-cni"
   namespace   = kubernetes_namespace.cni.metadata[0].name
-  version     = "2.12.0"
+  version     = "30.3.0"
   max_history = 3
 
   values = [
@@ -220,10 +221,11 @@ resource "helm_release" "linkerd_extras" {
 resource "helm_release" "linkerd" {
   depends_on = [helm_release.linkerd_extras, helm_release.linkerd_cni]
 
-  chart       = "oci://ghcr.io/xenitab/helm-charts/linkerd-control-plane"
+  repository  = "https://helm.linkerd.io/stable"
+  chart       = "linkerd-control-plane"
   name        = "linkerd"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "2.12.0"
+  version     = "1.9.0"
   max_history = 3
   values = [
     templatefile("${path.module}/templates/values.yaml.tpl", {
@@ -238,10 +240,11 @@ resource "helm_release" "linkerd" {
 resource "helm_release" "linkerd_viz" {
   depends_on = [helm_release.linkerd]
 
-  chart       = "oci://ghcr.io/xenitab/helm-charts/linkerd-viz"
+  repository  = "https://helm.linkerd.io/stable"
+  chart       = "linkerd-viz"
   name        = "linkerd-viz"
   namespace   = kubernetes_namespace.viz.metadata[0].name
-  version     = "2.12.0"
+  version     = "30.3.0"
   max_history = 3
   values = [
     templatefile("${path.module}/templates/values-viz.yaml.tpl", {}),

--- a/modules/kubernetes/linkerd/main.tf
+++ b/modules/kubernetes/linkerd/main.tf
@@ -192,11 +192,10 @@ resource "kubernetes_secret" "webhook_issuer_tls" {
 # Install linkerd-cni helm chart
 #tf-latest-version:ignore
 resource "helm_release" "linkerd_cni" {
-  repository  = "https://helm.linkerd.io/stable"
-  chart       = "linkerd2-cni"
+  chart       = "oci://ghcr.io/xenitab/helm-charts/linkerd2-cni"
   name        = "linkerd-cni"
   namespace   = kubernetes_namespace.cni.metadata[0].name
-  version     = "2.11.3"
+  version     = "2.12.0"
   max_history = 3
 
   values = [
@@ -221,11 +220,10 @@ resource "helm_release" "linkerd_extras" {
 resource "helm_release" "linkerd" {
   depends_on = [helm_release.linkerd_extras, helm_release.linkerd_cni]
 
-  repository  = "https://helm.linkerd.io/edge"
-  chart       = "linkerd-control-plane"
+  chart       = "oci://ghcr.io/xenitab/helm-charts/linkerd-control-plane"
   name        = "linkerd"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "1.5.4-edge"
+  version     = "2.12.0"
   max_history = 3
   values = [
     templatefile("${path.module}/templates/values.yaml.tpl", {
@@ -240,11 +238,10 @@ resource "helm_release" "linkerd" {
 resource "helm_release" "linkerd_viz" {
   depends_on = [helm_release.linkerd]
 
-  repository  = "https://helm.linkerd.io/stable"
-  chart       = "linkerd-viz"
+  chart       = "oci://ghcr.io/xenitab/helm-charts/linkerd-viz"
   name        = "linkerd-viz"
   namespace   = kubernetes_namespace.viz.metadata[0].name
-  version     = "2.11.3"
+  version     = "2.12.0"
   max_history = 3
   values = [
     templatefile("${path.module}/templates/values-viz.yaml.tpl", {}),


### PR DESCRIPTION
In the linkerd fork we have removed the helm chart k8s version limitation.
We also provide the helm chart through OCI.

It uses the helm-crd-oci that is fixed in: https://github.com/XenitAB/terraform-modules/pull/767
