### PR TITLE
Make region optinal in ingress-health fqdn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#765](https://github.com/XenitAB/terraform-modules/pull/764) Replace Linkerd image registry with ghcr.
 - [#766](https://github.com/XenitAB/terraform-modules/pull/766) Skip Linkerd proxy for Ingress Nginx webhook.
 - [#768](https://github.com/XenitAB/terraform-modules/pull/768) Use linkerd-fork OCI helm charts and update linkerd to 2.12.0.
+- [#771](https://github.com/XenitAB/terraform-modules/pull/771) Make region optinal in ingress-health fqdn.
 
 ## 2022.08.2
 

--- a/modules/kubernetes/ingress-healthz/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-healthz/templates/values.yaml.tpl
@@ -27,7 +27,11 @@ service:
 
 ingress:
   enabled: true
+  %{ if location_short == "" }
+  hostname: ingress-healthz.${dns_zone}
+  %{ else }
   hostname: ingress-healthz-${location_short}.${dns_zone}
+  %{ endif }
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
     %{ if linkerd_enabled }
@@ -37,7 +41,11 @@ ingress:
     %{ endif }
   extraTls:
     - hosts:
+       %{ if location_short == "" }
+        - ingress-healthz.${dns_zone}
+       %{ else }
         - ingress-healthz-${location_short}.${dns_zone}
+       %{ endif }
       secretName: ingress-healthz-cert
 
 %{ if linkerd_enabled }


### PR DESCRIPTION
We don't need region in AWS until we support multi region