### PR TITLE
Update Falco helm chart to 2.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#778](https://github.com/XenitAB/terraform-modules/pull/778) Upgrade AWS calico to 3.24.
 - [#776](https://github.com/XenitAB/terraform-modules/pull/776) [Breaking] Remove default value for unique_suffix in Azure core module.
+- [#775](https://github.com/XenitAB/terraform-modules/pull/775) Update falco helm chart to 2.0.16.
 
 ## 2022.08.3
 

--- a/modules/kubernetes/falco/main.tf
+++ b/modules/kubernetes/falco/main.tf
@@ -32,12 +32,13 @@ resource "kubernetes_namespace" "this" {
 }
 
 resource "helm_release" "falco" {
-  repository  = "https://falcosecurity.github.io/charts"
-  chart       = "falco"
-  name        = "falco"
-  namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "2.0.16"
-  max_history = 3
+  repository   = "https://falcosecurity.github.io/charts"
+  chart        = "falco"
+  name         = "falco"
+  namespace    = kubernetes_namespace.this.metadata[0].name
+  version      = "2.0.16"
+  max_history  = 3
+  force_update = true
   values = [templatefile("${path.module}/templates/falco-values.yaml.tpl", {
     provider = var.cloud_provider
   })]

--- a/modules/kubernetes/falco/main.tf
+++ b/modules/kubernetes/falco/main.tf
@@ -32,13 +32,12 @@ resource "kubernetes_namespace" "this" {
 }
 
 resource "helm_release" "falco" {
-  repository   = "https://falcosecurity.github.io/charts"
-  chart        = "falco"
-  name         = "falco"
-  namespace    = kubernetes_namespace.this.metadata[0].name
-  version      = "2.0.16"
-  max_history  = 3
-  force_update = true
+  repository  = "https://falcosecurity.github.io/charts"
+  chart       = "falco"
+  name        = "falco"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "2.0.16"
+  max_history = 3
   values = [templatefile("${path.module}/templates/falco-values.yaml.tpl", {
     provider = var.cloud_provider
   })]

--- a/modules/kubernetes/falco/main.tf
+++ b/modules/kubernetes/falco/main.tf
@@ -36,7 +36,7 @@ resource "helm_release" "falco" {
   chart       = "falco"
   name        = "falco"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "1.17.4"
+  version     = "2.0.16"
   max_history = 3
   values = [templatefile("${path.module}/templates/falco-values.yaml.tpl", {
     provider = var.cloud_provider
@@ -48,7 +48,7 @@ resource "helm_release" "falco_exporter" {
   chart       = "falco-exporter"
   name        = "falco-exporter"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "0.8.0"
+  version     = "0.8.2"
   max_history = 3
   values      = [templatefile("${path.module}/templates/falco-exporter-values.yaml.tpl", {})]
 }

--- a/modules/kubernetes/falco/templates/falco-values.yaml.tpl
+++ b/modules/kubernetes/falco/templates/falco-values.yaml.tpl
@@ -1,9 +1,3 @@
-auditLog:
-  enabled: false
-
-docker:
-  enabled: false
-
 # Use EBPF instead of kernel module
 ebpf:
   enabled: true
@@ -23,6 +17,16 @@ falco:
       - log
 
 priorityClassName: platform-high
+
+scc:
+  # -- Create OpenShift's Security Context Constraint.
+  create: false
+
+collectors:
+  docker:
+    enabled: false
+  crio:
+    enabled: false
 
 customRules:
   # Applications which are expected to communicate with the Kubernetes API

--- a/modules/kubernetes/falco/templates/falco-values.yaml.tpl
+++ b/modules/kubernetes/falco/templates/falco-values.yaml.tpl
@@ -1,6 +1,6 @@
 # Use EBPF instead of kernel module
-ebpf:
-  enabled: true
+driver:
+  kind: ebpf
 
 falco:
   grpc:


### PR DESCRIPTION
The 2.0 chart contains multiple breaking changes.


Manual work is needed due to updates in DS label selector.

```
│ Error: cannot patch "falco" with kind DaemonSet: DaemonSet.apps "falco" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/instance":"falco", "app.kubernetes.io/name":"falco"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
│ 
│   with module.aks1_core.module.falco["falco"].helm_release.falco,
│   on .terraform/modules/aks1_core/modules/kubernetes/falco/main.tf line 34, in resource "helm_release" "falco":
│   34: resource "helm_release" "falco" {
```

Run

```shell
k delete ds falco -n falco
```

And then update the falco module.