### PR TITLE
Remove default value on unique_suffix in core module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#774](https://github.com/XenitAB/terraform-modules/pull/774) [Breaking] Add extra_config to ingress nginx config object.
 
+### Changed
+
+- [#776](https://github.com/XenitAB/terraform-modules/pull/776) [Breaking] Remove default value for unique_suffix in Azure core module.
+
 ## 2022.08.3
 
 ### Added

--- a/modules/azure/core/README.md
+++ b/modules/azure/core/README.md
@@ -58,7 +58,7 @@ No modules.
 | <a name="input_route_config"></a> [route\_config](#input\_route\_config) | Route configuration. Not applied to AKS subnets | <pre>list(object({<br>    subnet_name = string # Short name for the subnet<br>    routes = list(object({<br>      name                   = string # Name of the route<br>      address_prefix         = string # Example: 192.168.0.0/24<br>      next_hop_type          = string # VirtualNetworkGateway, VnetLocal, Internet, VirtualAppliance and None<br>      next_hop_in_ip_address = string # Only set if next_hop_type is VirtualAppliance<br>    }))<br><br>  }))</pre> | `[]` | no |
 | <a name="input_subnet_private_endpoints"></a> [subnet\_private\_endpoints](#input\_subnet\_private\_endpoints) | Enable private enpoint for specific subnet names | `map(bool)` | `{}` | no |
 | <a name="input_subscription_name"></a> [subscription\_name](#input\_subscription\_name) | The subscription commonName to use for the deploy | `string` | n/a | yes |
-| <a name="input_unique_suffix"></a> [unique\_suffix](#input\_unique\_suffix) | Unique suffix that is used in globally unique resources names | `string` | `""` | no |
+| <a name="input_unique_suffix"></a> [unique\_suffix](#input\_unique\_suffix) | Unique suffix that is used in globally unique resources names | `string` | n/a | yes |
 | <a name="input_vnet_config"></a> [vnet\_config](#input\_vnet\_config) | Address spaces used by virtual network | <pre>object({<br>    address_space = list(string)<br>    dns_servers   = list(string)<br>    subnets = list(object({<br>      name              = string<br>      cidr              = string<br>      service_endpoints = list(string)<br>      aks_subnet        = bool<br>    }))<br>  })</pre> | n/a | yes |
 
 ## Outputs

--- a/modules/azure/core/variables.tf
+++ b/modules/azure/core/variables.tf
@@ -96,5 +96,4 @@ variable "enable_storage_account" {
 variable "unique_suffix" {
   description = "Unique suffix that is used in globally unique resources names"
   type        = string
-  default     = ""
 }

--- a/validation/azure/core/main.tf
+++ b/validation/azure/core/main.tf
@@ -13,6 +13,7 @@ module "core" {
   location_short    = "we"
   subscription_name = "xks"
   name              = "core"
+  unique_suffix     = ""
   vnet_config = {
     address_space = ["10.180.0.0/16"]
     dns_servers   = []


### PR DESCRIPTION
It's really easy to make configuration mistakes thanks to this default value.
For people not defining it you will need to set

```
unique_suffix = ""
``` 