### PR TITLE
Revert "upgrade AWS calico to 3.24 (#778)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- [#778](https://github.com/XenitAB/terraform-modules/pull/778) Upgrade AWS calico to 3.24.
 - [#776](https://github.com/XenitAB/terraform-modules/pull/776) [Breaking] Remove default value for unique_suffix in Azure core module.
 - [#775](https://github.com/XenitAB/terraform-modules/pull/775) Update falco helm chart to 2.0.16.
 - [#777](https://github.com/XenitAB/terraform-modules/pull/777) Update Flux 2.0 to v0.33.0 which bumps the source controller from v1beta1 to v1betav2.

--- a/modules/aws/eks/eks.tf
+++ b/modules/aws/eks/eks.tf
@@ -1,5 +1,5 @@
 locals {
-  calico_version = "v3.24"
+  calico_version = "v3.19"
   cni_script = templatefile("${path.module}/templates/update-eks-cni.sh.tpl", {
     b64_cluster_ca = aws_eks_cluster.this.certificate_authority[0].data,
     api_server_url = aws_eks_cluster.this.endpoint


### PR DESCRIPTION
This reverts commit c16fef60f834ae22ce5f7a36e1d5edf730269bbe.