### PR TITLE
Upgrade k8s to 1.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+
+- [#784](https://github.com/XenitAB/terraform-modules/pull/784) Add support for kubernetes version 1.24.
+
 ## 2022.09.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- [#784](https://github.com/XenitAB/terraform-modules/pull/784) Add support for kubernetes version 1.24.
+- [#784](https://github.com/XenitAB/terraform-modules/pull/784) Add support for kubernetes version 1.24 for AKS.
 
 ## 2022.09.1
 

--- a/modules/aws/eks/variables.tf
+++ b/modules/aws/eks/variables.tf
@@ -51,9 +51,9 @@ variable "eks_config" {
 
   validation {
     condition = alltrue([
-      for np in concat(var.eks_config.node_pools, [{ version : var.eks_config.version }]) : can(regex("^1.(21|22|23)", np.version))
+      for np in concat(var.eks_config.node_pools, [{ version : var.eks_config.version }]) : can(regex("^1.(22|23|24)", np.version))
     ])
-    error_message = "The Kubernetes version has not been validated yet, supported versions are 1.21, 1.22, 1.23."
+    error_message = "The Kubernetes version has not been validated yet, supported versions are 1.22, 1.23, 1.24."
   }
 
   validation {

--- a/modules/aws/eks/variables.tf
+++ b/modules/aws/eks/variables.tf
@@ -51,9 +51,9 @@ variable "eks_config" {
 
   validation {
     condition = alltrue([
-      for np in concat(var.eks_config.node_pools, [{ version : var.eks_config.version }]) : can(regex("^1.(22|23|24)", np.version))
+      for np in concat(var.eks_config.node_pools, [{ version : var.eks_config.version }]) : can(regex("^1.(21|22|23)", np.version))
     ])
-    error_message = "The Kubernetes version has not been validated yet, supported versions are 1.22, 1.23, 1.24."
+    error_message = "The Kubernetes version has not been validated yet, supported versions are 1.21, 1.22, 1.23."
   }
 
   validation {

--- a/modules/azure/aks/outputs.tf
+++ b/modules/azure/aks/outputs.tf
@@ -9,7 +9,7 @@ locals {
 
 output "kube_config" {
   description = "Kube config for the created AKS cluster"
-  sensitive   = false
+  sensitive   = true
   value = {
     host                   = local.host
     cluster_ca_certificate = base64decode(local.auth_data)

--- a/modules/azure/aks/outputs.tf
+++ b/modules/azure/aks/outputs.tf
@@ -1,10 +1,20 @@
+locals {
+  host       = yamldecode(azurerm_kubernetes_cluster.this.kube_config_raw)["clusters"][0].cluster.server
+  auth_data  = yamldecode(azurerm_kubernetes_cluster.this.kube_config_raw)["clusters"][0].cluster.certificate-authority-data
+  apiVersion = yamldecode(azurerm_kubernetes_cluster.this.kube_config_raw)["users"][0].user.exec.apiVersion
+  args       = yamldecode(azurerm_kubernetes_cluster.this.kube_config_raw)["users"][0].user.exec.args
+  command    = yamldecode(azurerm_kubernetes_cluster.this.kube_config_raw)["users"][0].user.exec.command
+}
+
+
 output "kube_config" {
   description = "Kube config for the created AKS cluster"
-  sensitive   = true
+  sensitive   = false
   value = {
-    host                   = azurerm_kubernetes_cluster.this.kube_config_raw.host
-    client_certificate     = base64decode(azurerm_kubernetes_cluster.this.kube_admin_config_raw.client_certificate)
-    client_key             = base64decode(azurerm_kubernetes_cluster.this.kube_admin_config_raw.client_key)
-    cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.this.kube_admin_config_raw.cluster_ca_certificate)
+    host                   = local.host
+    cluster_ca_certificate = base64decode(local.auth_data)
+    api_version            = local.apiVersion
+    args                   = local.args
+    command                = local.command
   }
 }

--- a/modules/azure/aks/outputs.tf
+++ b/modules/azure/aks/outputs.tf
@@ -2,9 +2,9 @@ output "kube_config" {
   description = "Kube config for the created AKS cluster"
   sensitive   = true
   value = {
-    host                   = azurerm_kubernetes_cluster.this.kube_config_raw.0.host
-    client_certificate     = base64decode(azurerm_kubernetes_cluster.this.kube_admin_config_raw.0.client_certificate)
-    client_key             = base64decode(azurerm_kubernetes_cluster.this.kube_admin_config_raw.0.client_key)
-    cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.this.kube_admin_config_raw.0.cluster_ca_certificate)
+    host                   = azurerm_kubernetes_cluster.this.kube_config_raw.host
+    client_certificate     = base64decode(azurerm_kubernetes_cluster.this.kube_admin_config_raw.client_certificate)
+    client_key             = base64decode(azurerm_kubernetes_cluster.this.kube_admin_config_raw.client_key)
+    cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.this.kube_admin_config_raw.cluster_ca_certificate)
   }
 }

--- a/modules/azure/aks/outputs.tf
+++ b/modules/azure/aks/outputs.tf
@@ -2,9 +2,9 @@ output "kube_config" {
   description = "Kube config for the created AKS cluster"
   sensitive   = true
   value = {
-    host                   = azurerm_kubernetes_cluster.this.kube_config[0].host
-    client_certificate     = base64decode(azurerm_kubernetes_cluster.this.kube_admin_config[0].client_certificate)
-    client_key             = base64decode(azurerm_kubernetes_cluster.this.kube_admin_config[0].client_key)
-    cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.this.kube_admin_config[0].cluster_ca_certificate)
+    host                   = azurerm_kubernetes_cluster.this.kube_config_raw.0.host
+    client_certificate     = base64decode(azurerm_kubernetes_cluster.this.kube_admin_config_raw.0.client_certificate)
+    client_key             = base64decode(azurerm_kubernetes_cluster.this.kube_admin_config_raw.0.client_key)
+    cluster_ca_certificate = base64decode(azurerm_kubernetes_cluster.this.kube_admin_config_raw.0.cluster_ca_certificate)
   }
 }

--- a/modules/azure/aks/variables.tf
+++ b/modules/azure/aks/variables.tf
@@ -55,9 +55,9 @@ variable "aks_config" {
 
   validation {
     condition = alltrue([
-      for np in concat(var.aks_config.node_pools, [{ version : var.aks_config.version }]) : can(regex("^1.(21|22|23)", np.version))
+      for np in concat(var.aks_config.node_pools, [{ version : var.aks_config.version }]) : can(regex("^1.(22|23|24)", np.version))
     ])
-    error_message = "The Kubernetes version has not been validated yet, supported versions are 1.21, 1.22, 1.23."
+    error_message = "The Kubernetes version has not been validated yet, supported versions are 1.22, 1.23, 1.24."
   }
 
   validation {

--- a/validation/aws/eks/main.tf
+++ b/validation/aws/eks/main.tf
@@ -23,12 +23,12 @@ module "eks" {
 
   eks_authorized_ips = ["0.0.0.0/0"]
   eks_config = {
-    version    = "1.21"
+    version    = "1.23"
     cidr_block = "10.0.16.0/20"
     node_pools = [
       {
         name           = "standard"
-        version        = "1.21.5-20220309"
+        version        = "1.23.5-20220309"
         min_size       = 1
         max_size       = 3
         instance_types = ["t3.large"]

--- a/validation/azure/aks/main.tf
+++ b/validation/azure/aks/main.tf
@@ -28,7 +28,7 @@ module "aks" {
   }
 
   aks_config = {
-    version          = "1.21.9"
+    version          = "1.24.3"
     production_grade = false
     default_node_pool = {
       node_labels = {
@@ -38,7 +38,7 @@ module "aks" {
     node_pools = [
       {
         name      = "pool1"
-        version   = "1.21.9"
+        version   = "1.24.3"
         vm_size   = "Standard_B2s"
         min_count = 1
         max_count = 1


### PR DESCRIPTION
Update your aks/main.tf to support the new version of 1.24.

```
provider "kubernetes" {
  alias                  = "aks1"
  host                   = module.aks1.kube_config.host
  cluster_ca_certificate = module.aks1.kube_config.cluster_ca_certificate
  exec {
    api_version = module.aks1.kube_config.api_version
    args = module.aks1.kube_config.args
    command = module.aks1.kube_config.command
  }
}

provider "helm" {
  alias = "aks1"
  kubernetes {
    host                   = module.aks1.kube_config.host
    cluster_ca_certificate = module.aks1.kube_config.cluster_ca_certificate
    exec {
      api_version = module.aks1.kube_config.api_version
      args = module.aks1.kube_config.args
      command = module.aks1.kube_config.command
    }
  }
}

provider "kubectl" {
  alias                  = "aks1"
  host                   = module.aks1.kube_config.host
  cluster_ca_certificate = module.aks1.kube_config.cluster_ca_certificate
  exec {
    api_version = module.aks1.kube_config.api_version
    args = module.aks1.kube_config.args
    command = module.aks1.kube_config.command
  }
  load_config_file       = false
}
```
