### PR TITLE
Stop role assignment recreation on AKS cluster update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#783](https://github.com/XenitAB/terraform-modules/pull/783) Upgrade azurerm and azuread providers.
 - [#789](https://github.com/XenitAB/terraform-modules/pull/789) [Breaking] Image gallery support for Azure Pipelines module.
 
+### Fixed
+
+- [#788](https://github.com/XenitAB/terraform-modules/pull/788) Stop role assignment recreation on AKS cluster update.
+
 ## 2022.09.1
 
 ### Added

--- a/modules/azure/aks/aad-group.tf
+++ b/modules/azure/aks/aad-group.tf
@@ -33,6 +33,17 @@ resource "azuread_group_member" "aks_managed_identity" {
   member_object_id = azurerm_kubernetes_cluster.this.kubelet_identity[0].object_id
 }
 
+# This is a work around to stop any update of the AKS cluster to force a recreation of the role assignments.
+# The reason this works is a bit tricky, but it gets Terraform to not reload the resource group data source.
+# https://github.com/hashicorp/terraform-provider-azurerm/issues/15557#issuecomment-1050654295
+locals {
+  node_resource_group = azurerm_kubernetes_cluster.this.node_resource_group
+}
+
+data "azurerm_resource_group" "aks" {
+  name = local.node_resource_group
+}
+
 resource "azurerm_role_assignment" "aks_managed_identity_noderg_managed_identity_operator" {
   scope                = data.azurerm_resource_group.aks.id
   role_definition_name = "Managed Identity Operator"

--- a/modules/azure/aks/main.tf
+++ b/modules/azure/aks/main.tf
@@ -37,10 +37,6 @@ data "azurerm_resource_group" "this" {
   name = "rg-${var.environment}-${var.location_short}-${var.name}"
 }
 
-data "azurerm_resource_group" "aks" {
-  name = azurerm_kubernetes_cluster.this.node_resource_group
-}
-
 data "azurerm_subnet" "this" {
   name                 = "sn-${var.environment}-${var.location_short}-${var.core_name}-${var.name}${var.aks_name_suffix}"
   virtual_network_name = "vnet-${var.environment}-${var.location_short}-${var.core_name}"


### PR DESCRIPTION
This is a work around which fixes a long standing issue of the role assignments being recreated when ever the AKS cluster resource is updated. 

You can read more about the work around here.
https://github.com/hashicorp/terraform-provider-azurerm/issues/15557#issuecomment-1050654295