### PR TITLE
[Breaking] Image gallery support for Azure Pipelines module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - [#783](https://github.com/XenitAB/terraform-modules/pull/783) Upgrade azurerm and azuread providers.
-- [#789](https://github.com/XenitAB/terraform-modules/pull/789) Image gallery support for Azure Pipelines module.
+- [#789](https://github.com/XenitAB/terraform-modules/pull/789) [Breaking] Image gallery support for Azure Pipelines module.
 
 ## 2022.09.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - [#783](https://github.com/XenitAB/terraform-modules/pull/783) Upgrade azurerm and azuread providers.
+- [#789](https://github.com/XenitAB/terraform-modules/pull/789) Image gallery support for Azure Pipelines module.
 
 ## 2022.09.1
 

--- a/modules/azure/aks-global/README.md
+++ b/modules/azure/aks-global/README.md
@@ -4,14 +4,14 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.21.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.22.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.28.1 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.21.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.22.0 |
 
 ## Modules
 
@@ -21,14 +21,14 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/container_registry) | resource |
-| [azurerm_dns_zone.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/dns_zone) | resource |
-| [azurerm_management_lock.rg](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/management_lock) | resource |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/resource_group) | resource |
-| [azurerm_role_assignment.acr_pull](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.acr_push](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.acr_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
+| [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/container_registry) | resource |
+| [azurerm_dns_zone.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/dns_zone) | resource |
+| [azurerm_management_lock.rg](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/management_lock) | resource |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/resource_group) | resource |
+| [azurerm_role_assignment.acr_pull](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.acr_push](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.acr_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
 | [azuread_group.acr_pull](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/group) | data source |
 | [azuread_group.acr_push](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/group) | data source |
 | [azuread_group.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/group) | data source |

--- a/modules/azure/aks-global/main.tf
+++ b/modules/azure/aks-global/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.1.7"
   required_providers {
     azurerm = {
-      version = "3.21.1"
+      version = "3.22.0"
       source  = "hashicorp/azurerm"
     }
     azuread = {

--- a/modules/azure/aks-regional/README.md
+++ b/modules/azure/aks-regional/README.md
@@ -8,7 +8,7 @@ This module is used to create resources that are used by AKS clusters.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.21.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.22.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | 4.0.1 |
 
@@ -17,7 +17,7 @@ This module is used to create resources that are used by AKS clusters.
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.28.1 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.21.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.22.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.1 |
 
 ## Modules
@@ -35,36 +35,36 @@ This module is used to create resources that are used by AKS clusters.
 | [azuread_group_member.aad_pod_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/resources/group_member) | resource |
 | [azuread_group_member.helm_operator](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/resources/group_member) | resource |
 | [azuread_service_principal.helm_operator](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/resources/service_principal) | resource |
-| [azurerm_key_vault_access_policy.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_secret.ssh_key](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/key_vault_secret) | resource |
-| [azurerm_public_ip_prefix.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/public_ip_prefix) | resource |
-| [azurerm_role_assignment.aad_pod_identity](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.external_dns_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.external_dns_msi](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.external_dns_rg_read](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.external_storage_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.trivy_acr](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.trivy_managed](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.velero_msi](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.velero_rg_read](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_storage_account.velero](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/storage_account) | resource |
-| [azurerm_storage_container.velero](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/storage_container) | resource |
-| [azurerm_user_assigned_identity.aad_pod_identity](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/user_assigned_identity) | resource |
-| [azurerm_user_assigned_identity.azure_metrics](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/user_assigned_identity) | resource |
-| [azurerm_user_assigned_identity.external_dns](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/user_assigned_identity) | resource |
-| [azurerm_user_assigned_identity.trivy](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/user_assigned_identity) | resource |
-| [azurerm_user_assigned_identity.velero](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/user_assigned_identity) | resource |
-| [azurerm_user_assigned_identity.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/user_assigned_identity) | resource |
+| [azurerm_key_vault_access_policy.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_secret.ssh_key](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_public_ip_prefix.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/public_ip_prefix) | resource |
+| [azurerm_role_assignment.aad_pod_identity](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.external_dns_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.external_dns_msi](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.external_dns_rg_read](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.external_storage_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.trivy_acr](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.trivy_managed](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.velero_msi](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.velero_rg_read](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_storage_account.velero](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/storage_account) | resource |
+| [azurerm_storage_container.velero](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/storage_container) | resource |
+| [azurerm_user_assigned_identity.aad_pod_identity](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/user_assigned_identity) | resource |
+| [azurerm_user_assigned_identity.azure_metrics](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/user_assigned_identity) | resource |
+| [azurerm_user_assigned_identity.external_dns](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/user_assigned_identity) | resource |
+| [azurerm_user_assigned_identity.trivy](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/user_assigned_identity) | resource |
+| [azurerm_user_assigned_identity.velero](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/user_assigned_identity) | resource |
+| [azurerm_user_assigned_identity.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/user_assigned_identity) | resource |
 | [tls_private_key.ssh_key](https://registry.terraform.io/providers/hashicorp/tls/4.0.1/docs/resources/private_key) | resource |
 | [azuread_group.acr_pull](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/group) | data source |
 | [azuread_group.resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/group) | data source |
-| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/client_config) | data source |
-| [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/container_registry) | data source |
-| [azurerm_dns_zone.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/dns_zone) | data source |
-| [azurerm_key_vault.core](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/key_vault) | data source |
-| [azurerm_resource_group.global](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/resource_group) | data source |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/resource_group) | data source |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/client_config) | data source |
+| [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/container_registry) | data source |
+| [azurerm_dns_zone.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/dns_zone) | data source |
+| [azurerm_key_vault.core](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/key_vault) | data source |
+| [azurerm_resource_group.global](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 

--- a/modules/azure/aks-regional/main.tf
+++ b/modules/azure/aks-regional/main.tf
@@ -9,7 +9,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      version = "3.21.1"
+      version = "3.22.0"
       source  = "hashicorp/azurerm"
     }
     azuread = {

--- a/modules/azure/aks/README.md
+++ b/modules/azure/aks/README.md
@@ -15,7 +15,7 @@ https://pumpingco.de/blog/modify-aks-default-node-pool-in-terraform-without-rede
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.21.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.22.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |
 
 ## Providers
@@ -23,7 +23,7 @@ https://pumpingco.de/blog/modify-aks-default-node-pool-in-terraform-without-rede
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.28.1 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.21.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.22.0 |
 
 ## Modules
 
@@ -34,24 +34,24 @@ No modules.
 | Name | Type |
 |------|------|
 | [azuread_group_member.aks_managed_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/resources/group_member) | resource |
-| [azurerm_kubernetes_cluster.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/kubernetes_cluster) | resource |
-| [azurerm_kubernetes_cluster_node_pool.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/kubernetes_cluster_node_pool) | resource |
-| [azurerm_monitor_diagnostic_setting.log_storage_account_audit](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/monitor_diagnostic_setting) | resource |
-| [azurerm_role_assignment.aks_managed_identity_noderg_managed_identity_operator](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.aks_managed_identity_noderg_virtual_machine_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.azure_metrics](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.azure_metrics_aks_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.azure_metrics_lb_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.cluster_admin](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.cluster_view](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.edit](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.view](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/client_config) | data source |
-| [azurerm_resource_group.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/resource_group) | data source |
-| [azurerm_resource_group.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/resource_group) | data source |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/resource_group) | data source |
-| [azurerm_storage_account.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/storage_account) | data source |
-| [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/subnet) | data source |
+| [azurerm_kubernetes_cluster.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/kubernetes_cluster) | resource |
+| [azurerm_kubernetes_cluster_node_pool.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/kubernetes_cluster_node_pool) | resource |
+| [azurerm_monitor_diagnostic_setting.log_storage_account_audit](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/monitor_diagnostic_setting) | resource |
+| [azurerm_role_assignment.aks_managed_identity_noderg_managed_identity_operator](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.aks_managed_identity_noderg_virtual_machine_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.azure_metrics](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.azure_metrics_aks_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.azure_metrics_lb_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.cluster_admin](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.cluster_view](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.edit](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.view](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/client_config) | data source |
+| [azurerm_resource_group.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/resource_group) | data source |
+| [azurerm_storage_account.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/storage_account) | data source |
+| [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/subnet) | data source |
 
 ## Inputs
 

--- a/modules/azure/aks/main.tf
+++ b/modules/azure/aks/main.tf
@@ -17,7 +17,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      version = "3.21.1"
+      version = "3.22.0"
       source  = "hashicorp/azurerm"
     }
     azuread = {

--- a/modules/azure/azure-pipelines-agent-vmss/README.md
+++ b/modules/azure/azure-pipelines-agent-vmss/README.md
@@ -11,14 +11,14 @@ Follow this guide to setup the agent pool (manually): https://docs.microsoft.com
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.21.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.22.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | 4.0.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.21.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.22.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.1 |
 
 ## Modules
@@ -29,25 +29,23 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_key_vault_secret.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/key_vault_secret) | resource |
-| [azurerm_linux_virtual_machine_scale_set.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/linux_virtual_machine_scale_set) | resource |
+| [azurerm_key_vault_secret.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_linux_virtual_machine_scale_set.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/linux_virtual_machine_scale_set) | resource |
 | [tls_private_key.this](https://registry.terraform.io/providers/hashicorp/tls/4.0.1/docs/resources/private_key) | resource |
-| [azurerm_image.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/image) | data source |
-| [azurerm_key_vault.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/key_vault) | data source |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/resource_group) | data source |
+| [azurerm_key_vault.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/key_vault) | data source |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_azure_pipelines_agent_image_name"></a> [azure\_pipelines\_agent\_image\_name](#input\_azure\_pipelines\_agent\_image\_name) | The Azure Pipelines agent image name | `string` | n/a | yes |
-| <a name="input_azure_pipelines_agent_image_resource_group_name"></a> [azure\_pipelines\_agent\_image\_resource\_group\_name](#input\_azure\_pipelines\_agent\_image\_resource\_group\_name) | The Azure Pipelines agent image resource group name | `string` | `""` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment name to use for the deploy | `string` | n/a | yes |
 | <a name="input_keyvault_name"></a> [keyvault\_name](#input\_keyvault\_name) | The keyvault name | `string` | `""` | no |
 | <a name="input_keyvault_resource_group_name"></a> [keyvault\_resource\_group\_name](#input\_keyvault\_resource\_group\_name) | The keyvault resource group name | `string` | `""` | no |
 | <a name="input_location_short"></a> [location\_short](#input\_location\_short) | The Azure region short name | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The commonName to use for the deploy | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The resource group name | `string` | `""` | no |
+| <a name="input_source_image_id"></a> [source\_image\_id](#input\_source\_image\_id) | The Azure Pipelines agent image id | `string` | n/a | yes |
 | <a name="input_unique_suffix"></a> [unique\_suffix](#input\_unique\_suffix) | Unique suffix that is used in globally unique resources names | `string` | `""` | no |
 | <a name="input_vmss_admin_username"></a> [vmss\_admin\_username](#input\_vmss\_admin\_username) | The admin username | `string` | `"azpagent"` | no |
 | <a name="input_vmss_disk_size_gb"></a> [vmss\_disk\_size\_gb](#input\_vmss\_disk\_size\_gb) | The disk size (in GB) for the VMSS instances | `number` | `128` | no |

--- a/modules/azure/azure-pipelines-agent-vmss/locals.tf
+++ b/modules/azure/azure-pipelines-agent-vmss/locals.tf
@@ -1,6 +1,5 @@
 locals {
-  resource_group_name                             = var.resource_group_name == "" ? "rg-${var.environment}-${var.location_short}-${var.name}" : var.resource_group_name
-  keyvault_name                                   = var.keyvault_name == "" ? join("-", compact(["kv-${var.environment}-${var.location_short}-${var.name}", var.unique_suffix])) : var.keyvault_name
-  keyvault_resource_group_name                    = var.keyvault_resource_group_name == "" ? local.resource_group_name : var.keyvault_resource_group_name
-  azure_pipelines_agent_image_resource_group_name = var.azure_pipelines_agent_image_resource_group_name == "" ? local.resource_group_name : var.azure_pipelines_agent_image_resource_group_name
+  resource_group_name          = var.resource_group_name == "" ? "rg-${var.environment}-${var.location_short}-${var.name}" : var.resource_group_name
+  keyvault_name                = var.keyvault_name == "" ? join("-", compact(["kv-${var.environment}-${var.location_short}-${var.name}", var.unique_suffix])) : var.keyvault_name
+  keyvault_resource_group_name = var.keyvault_resource_group_name == "" ? local.resource_group_name : var.keyvault_resource_group_name
 }

--- a/modules/azure/azure-pipelines-agent-vmss/main.tf
+++ b/modules/azure/azure-pipelines-agent-vmss/main.tf
@@ -13,7 +13,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      version = "3.21.1"
+      version = "3.22.0"
       source  = "hashicorp/azurerm"
     }
     tls = {
@@ -45,11 +45,6 @@ resource "azurerm_key_vault_secret" "this" {
   content_type = "application/json"
 }
 
-data "azurerm_image" "this" {
-  name                = var.azure_pipelines_agent_image_name
-  resource_group_name = local.azure_pipelines_agent_image_resource_group_name
-}
-
 resource "azurerm_linux_virtual_machine_scale_set" "this" {
   name                            = "vmss-${var.environment}-${var.location_short}-${var.name}"
   resource_group_name             = data.azurerm_resource_group.this.name
@@ -66,7 +61,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
     public_key = tls_private_key.this.public_key_openssh
   }
 
-  source_image_id = data.azurerm_image.this.id
+  source_image_id = var.source_image_id
 
   os_disk {
     caching              = "ReadOnly"

--- a/modules/azure/azure-pipelines-agent-vmss/variables.tf
+++ b/modules/azure/azure-pipelines-agent-vmss/variables.tf
@@ -31,15 +31,9 @@ variable "keyvault_resource_group_name" {
   default     = ""
 }
 
-variable "azure_pipelines_agent_image_name" {
-  description = "The Azure Pipelines agent image name"
+variable "source_image_id" {
+  description = "The Azure Pipelines agent image id"
   type        = string
-}
-
-variable "azure_pipelines_agent_image_resource_group_name" {
-  description = "The Azure Pipelines agent image resource group name"
-  type        = string
-  default     = ""
 }
 
 variable "vmss_admin_username" {

--- a/modules/azure/core/README.md
+++ b/modules/azure/core/README.md
@@ -8,14 +8,14 @@ This module is used to create core resources like virtual network for the subscr
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.21.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.22.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.28.1 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.21.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.22.0 |
 
 ## Modules
 
@@ -25,23 +25,23 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_network_security_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/network_security_group) | resource |
-| [azurerm_role_assignment.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_definition.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_definition) | resource |
-| [azurerm_route.not_virtual_appliance](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/route) | resource |
-| [azurerm_route.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/route) | resource |
-| [azurerm_route_table.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/route_table) | resource |
-| [azurerm_storage_account.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/storage_account) | resource |
-| [azurerm_storage_account.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/storage_account) | resource |
-| [azurerm_subnet.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/subnet) | resource |
-| [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/subnet) | resource |
-| [azurerm_subnet_network_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/subnet_network_security_group_association) | resource |
-| [azurerm_subnet_route_table_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/subnet_route_table_association) | resource |
-| [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/virtual_network) | resource |
-| [azurerm_virtual_network_peering.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/virtual_network_peering) | resource |
+| [azurerm_network_security_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/network_security_group) | resource |
+| [azurerm_role_assignment.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_definition.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_definition) | resource |
+| [azurerm_route.not_virtual_appliance](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/route) | resource |
+| [azurerm_route.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/route) | resource |
+| [azurerm_route_table.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/route_table) | resource |
+| [azurerm_storage_account.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/storage_account) | resource |
+| [azurerm_storage_account.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/storage_account) | resource |
+| [azurerm_subnet.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/subnet) | resource |
+| [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/subnet) | resource |
+| [azurerm_subnet_network_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/subnet_network_security_group_association) | resource |
+| [azurerm_subnet_route_table_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/subnet_route_table_association) | resource |
+| [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/virtual_network) | resource |
+| [azurerm_virtual_network_peering.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/virtual_network_peering) | resource |
 | [azuread_group.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/group) | data source |
-| [azurerm_resource_group.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/resource_group) | data source |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 

--- a/modules/azure/core/main.tf
+++ b/modules/azure/core/main.tf
@@ -9,7 +9,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      version = "3.21.1"
+      version = "3.22.0"
       source  = "hashicorp/azurerm"
     }
     azuread = {

--- a/modules/azure/github-runner/README.md
+++ b/modules/azure/github-runner/README.md
@@ -13,14 +13,14 @@ Setup an image using Packer according [github-runner](https://github.com/XenitAB
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.21.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.22.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | 4.0.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.21.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.22.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.1 |
 
 ## Modules
@@ -31,16 +31,16 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_key_vault_access_policy.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_secret.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/key_vault_secret) | resource |
-| [azurerm_linux_virtual_machine_scale_set.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/linux_virtual_machine_scale_set) | resource |
+| [azurerm_key_vault_access_policy.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_secret.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_linux_virtual_machine_scale_set.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/linux_virtual_machine_scale_set) | resource |
 | [tls_private_key.this](https://registry.terraform.io/providers/hashicorp/tls/4.0.1/docs/resources/private_key) | resource |
-| [azurerm_image.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/image) | data source |
-| [azurerm_key_vault.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/key_vault) | data source |
-| [azurerm_key_vault_secret.github_secrets](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/key_vault_secret) | data source |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/resource_group) | data source |
-| [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/subnet) | data source |
-| [azurerm_subscription.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/subscription) | data source |
+| [azurerm_image.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/image) | data source |
+| [azurerm_key_vault.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/key_vault) | data source |
+| [azurerm_key_vault_secret.github_secrets](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/resource_group) | data source |
+| [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/subnet) | data source |
+| [azurerm_subscription.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/subscription) | data source |
 
 ## Inputs
 

--- a/modules/azure/github-runner/main.tf
+++ b/modules/azure/github-runner/main.tf
@@ -15,7 +15,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      version = "3.21.1"
+      version = "3.22.0"
       source  = "hashicorp/azurerm"
     }
     tls = {

--- a/modules/azure/governance-global/README.md
+++ b/modules/azure/governance-global/README.md
@@ -8,7 +8,7 @@ This module is used for governance on a global level and not using any specific 
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.21.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.22.0 |
 | <a name="requirement_pal"></a> [pal](#requirement\_pal) | 0.2.5 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |
 
@@ -17,7 +17,7 @@ This module is used for governance on a global level and not using any specific 
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.28.1 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.21.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.22.0 |
 | <a name="provider_pal"></a> [pal](#provider\_pal) | 0.2.5 |
 
 ## Modules
@@ -59,10 +59,10 @@ No modules.
 | [azuread_service_principal.aad_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/resources/service_principal) | resource |
 | [azuread_service_principal.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/resources/service_principal) | resource |
 | [azuread_service_principal.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/resources/service_principal) | resource |
-| [azurerm_role_assignment.sub_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.sub_owner](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.sub_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.sub_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.sub_owner](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.sub_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
 | [pal_management_partner.aad_sp](https://registry.terraform.io/providers/xenitab/pal/0.2.5/docs/resources/management_partner) | resource |
 | [pal_management_partner.owner_spn](https://registry.terraform.io/providers/xenitab/pal/0.2.5/docs/resources/management_partner) | resource |
 | [azuread_application.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/application) | data source |
@@ -70,7 +70,7 @@ No modules.
 | [azuread_group.all_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/group) | data source |
 | [azuread_group.all_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/group) | data source |
 | [azuread_service_principal.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/service_principal) | data source |
-| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/subscription) | data source |
+| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/subscription) | data source |
 
 ## Inputs
 

--- a/modules/azure/governance-global/main.tf
+++ b/modules/azure/governance-global/main.tf
@@ -9,7 +9,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      version = "3.21.1"
+      version = "3.22.0"
       source  = "hashicorp/azurerm"
     }
     azuread = {

--- a/modules/azure/governance-regional/README.md
+++ b/modules/azure/governance-regional/README.md
@@ -8,7 +8,7 @@ This module is used for governance on a regional level and not using any specifi
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.21.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.22.0 |
 | <a name="requirement_pal"></a> [pal](#requirement\_pal) | 0.2.5 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |
 
@@ -17,7 +17,7 @@ This module is used for governance on a regional level and not using any specifi
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.28.1 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.21.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.22.0 |
 
 ## Modules
 
@@ -29,25 +29,25 @@ No modules.
 |------|------|
 | [azuread_application_password.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/resources/application_password) | resource |
 | [azuread_application_password.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/resources/application_password) | resource |
-| [azurerm_key_vault.delegate_kv](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/key_vault) | resource |
-| [azurerm_key_vault_access_policy.ap_kvreader_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_access_policy.ap_owner_spn](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_access_policy.ap_rg_aad_group](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_access_policy.ap_rg_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_access_policy.ap_sub_aad_group_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_access_policy.ap_sub_aad_group_owner](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_secret.aad_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/key_vault_secret) | resource |
-| [azurerm_key_vault_secret.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/key_vault_secret) | resource |
-| [azurerm_key_vault_secret.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/key_vault_secret) | resource |
-| [azurerm_management_lock.rg](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/management_lock) | resource |
-| [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/resource_group) | resource |
-| [azurerm_role_assignment.aad_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.rg_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.rg_owner](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.rg_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
+| [azurerm_key_vault.delegate_kv](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/key_vault) | resource |
+| [azurerm_key_vault_access_policy.ap_kvreader_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.ap_owner_spn](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.ap_rg_aad_group](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.ap_rg_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.ap_sub_aad_group_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.ap_sub_aad_group_owner](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_secret.aad_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_management_lock.rg](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/management_lock) | resource |
+| [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/resource_group) | resource |
+| [azurerm_role_assignment.aad_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.rg_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.rg_owner](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.rg_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
 | [azuread_service_principal.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/service_principal) | data source |
-| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/client_config) | data source |
-| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/subscription) | data source |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/client_config) | data source |
+| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/subscription) | data source |
 
 ## Inputs
 

--- a/modules/azure/governance-regional/main.tf
+++ b/modules/azure/governance-regional/main.tf
@@ -9,7 +9,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      version = "3.21.1"
+      version = "3.22.0"
       source  = "hashicorp/azurerm"
     }
     azuread = {

--- a/modules/azure/hub/README.md
+++ b/modules/azure/hub/README.md
@@ -12,14 +12,14 @@ Use together with the `core` module to create a peered network where SPOF (singl
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.21.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.22.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.28.1 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.21.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.22.0 |
 
 ## Modules
 
@@ -29,19 +29,19 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_nat_gateway.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/nat_gateway) | resource |
-| [azurerm_nat_gateway_public_ip_prefix_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/nat_gateway_public_ip_prefix_association) | resource |
-| [azurerm_network_security_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/network_security_group) | resource |
-| [azurerm_public_ip_prefix.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/public_ip_prefix) | resource |
-| [azurerm_role_assignment.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_assignment) | resource |
-| [azurerm_role_definition.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/role_definition) | resource |
-| [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/subnet) | resource |
-| [azurerm_subnet_nat_gateway_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/subnet_nat_gateway_association) | resource |
-| [azurerm_subnet_network_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/subnet_network_security_group_association) | resource |
-| [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/virtual_network) | resource |
-| [azurerm_virtual_network_peering.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/resources/virtual_network_peering) | resource |
+| [azurerm_nat_gateway.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/nat_gateway) | resource |
+| [azurerm_nat_gateway_public_ip_prefix_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/nat_gateway_public_ip_prefix_association) | resource |
+| [azurerm_network_security_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/network_security_group) | resource |
+| [azurerm_public_ip_prefix.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/public_ip_prefix) | resource |
+| [azurerm_role_assignment.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_definition.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/role_definition) | resource |
+| [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/subnet) | resource |
+| [azurerm_subnet_nat_gateway_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/subnet_nat_gateway_association) | resource |
+| [azurerm_subnet_network_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/subnet_network_security_group_association) | resource |
+| [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/virtual_network) | resource |
+| [azurerm_virtual_network_peering.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/resources/virtual_network_peering) | resource |
 | [azuread_group.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/group) | data source |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 

--- a/modules/azure/hub/main.tf
+++ b/modules/azure/hub/main.tf
@@ -13,7 +13,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      version = "3.21.1"
+      version = "3.22.0"
       source  = "hashicorp/azurerm"
     }
     azuread = {

--- a/modules/azure/xkf-governance-global-data/README.md
+++ b/modules/azure/xkf-governance-global-data/README.md
@@ -4,7 +4,7 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.21.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.22.0 |
 
 ## Providers
 

--- a/modules/azure/xkf-governance-global-data/main.tf
+++ b/modules/azure/xkf-governance-global-data/main.tf
@@ -6,7 +6,7 @@ terraform {
       source  = "hashicorp/azuread"
     }
     azurerm = {
-      version = "3.21.1"
+      version = "3.22.0"
       source  = "hashicorp/azurerm"
     }
   }

--- a/modules/azure/xkf-governance-global/README.md
+++ b/modules/azure/xkf-governance-global/README.md
@@ -4,7 +4,7 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.21.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.22.0 |
 
 ## Providers
 

--- a/modules/azure/xkf-governance-global/main.tf
+++ b/modules/azure/xkf-governance-global/main.tf
@@ -6,7 +6,7 @@ terraform {
       source  = "hashicorp/azuread"
     }
     azurerm = {
-      version = "3.21.1"
+      version = "3.22.0"
       source  = "hashicorp/azurerm"
     }
   }

--- a/modules/kubernetes/aks-core/README.md
+++ b/modules/kubernetes/aks-core/README.md
@@ -8,7 +8,7 @@ This module is used to create AKS clusters.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.21.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.22.0 |
 | <a name="requirement_flux"></a> [flux](#requirement\_flux) | 0.17.0 |
 | <a name="requirement_github"></a> [github](#requirement\_github) | 4.21.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.5.1 |
@@ -20,7 +20,7 @@ This module is used to create AKS clusters.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.21.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.22.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.5.1 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.8.0 |
 
@@ -98,9 +98,9 @@ This module is used to create AKS clusters.
 | [kubernetes_service_account.tenant](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/service_account) | resource |
 | [kubernetes_storage_class.zrs_premium](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/storage_class) | resource |
 | [kubernetes_storage_class.zrs_standard](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/storage_class) | resource |
-| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/client_config) | data source |
-| [azurerm_resource_group.global](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/resource_group) | data source |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.1/docs/data-sources/resource_group) | data source |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/client_config) | data source |
+| [azurerm_resource_group.global](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.22.0/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 

--- a/modules/kubernetes/aks-core/main.tf
+++ b/modules/kubernetes/aks-core/main.tf
@@ -9,7 +9,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      version = "3.21.1"
+      version = "3.22.0"
       source  = "hashicorp/azurerm"
     }
     azuread = {

--- a/validation/azure/azure-pipelines-agent-vmss/main.tf
+++ b/validation/azure/azure-pipelines-agent-vmss/main.tf
@@ -7,11 +7,11 @@ provider "azurerm" {
 module "azpagent" {
   source = "../../../modules/azure/azure-pipelines-agent-vmss"
 
-  environment                      = "dev"
-  location_short                   = "we"
-  unique_suffix                    = "1234"
-  name                             = "azpagent"
-  azure_pipelines_agent_image_name = "azp-agent-2020-11-16T22-24-11Z"
-  vmss_sku                         = "Standard_B2s"
-  vmss_subnet_id                   = "some_id"
+  environment     = "dev"
+  location_short  = "we"
+  unique_suffix   = "1234"
+  name            = "azpagent"
+  source_image_id = "/communityGalleries/xenit-d09d1810-7622-4864-9236-1a32035d35f0/images/azdo-agent/versions/1.0.0"
+  vmss_sku        = "Standard_B2s"
+  vmss_subnet_id  = "some_id"
 }


### PR DESCRIPTION
When using images from a Community Image Gallery, the image need to be referred to by a source image ID, e.g. ` source_image_id = "/communityGalleries/xenit-d09d1810-7622-4864-9236-1a32035d35f0/images/azdo-agent/versions/1.0.0"`.

For this to work, `azurerm` provider also need to be upgraded to 3.22.0.

Upgrade instructions:
Instead of using `azure_pipelines_agent_image_name` and `azure_pipelines_agent_image_resource_group_name` for identifying the image, use `source_image_id`. Use `Resource ID` of the actual image as the value for  `source_image_id`.


Fixes: https://github.com/XenitAB/terraform-modules/issues/781
