### PR TITLE
Add custom resource edit rights to tenant service account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#787](https://github.com/XenitAB/terraform-modules/pull/787) Add support for kubernetes 1.24 in Azure.
 - [#797](https://github.com/XenitAB/terraform-modules/pull/797) [Breaking] Add option to configure extra headers in Ingress NGINX.
+- [#796](https://github.com/XenitAB/terraform-modules/pull/796) Add custom resource edit rights to tenant service account.
 
 ### Changed
 

--- a/modules/kubernetes/aks-core/README.md
+++ b/modules/kubernetes/aks-core/README.md
@@ -89,6 +89,7 @@ This module is used to create AKS clusters.
 | [kubernetes_role_binding.custom_resource_edit](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.edit](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.helm_release](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
+| [kubernetes_role_binding.sa_custom_resource](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.sa_edit](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.sa_helm_release](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.starboard_reports](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |

--- a/modules/kubernetes/aks-core/k8s-role-binding.tf
+++ b/modules/kubernetes/aks-core/k8s-role-binding.tf
@@ -139,6 +139,29 @@ resource "kubernetes_role_binding" "sa_helm_release" {
     namespace = kubernetes_namespace.service_accounts.metadata[0].name
   }
 }
+
+resource "kubernetes_role_binding" "sa_custom_resource" {
+  for_each = { for ns in var.namespaces : ns.name => ns }
+
+  metadata {
+    name      = "sa-${each.value.name}-custom-resource"
+    namespace = each.value.name
+    labels = {
+      "xkf.xenit.io/kind" = "platform"
+    }
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role.custom_resource_edit.metadata[0].name
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.tenant[each.key].metadata[0].name
+    namespace = kubernetes_namespace.service_accounts.metadata[0].name
+  }
+}
+
 resource "kubernetes_role_binding" "top" {
   for_each = { for ns in var.namespaces : ns.name => ns }
   metadata {

--- a/modules/kubernetes/eks-core/README.md
+++ b/modules/kubernetes/eks-core/README.md
@@ -83,6 +83,7 @@ This module is used to configure EKS clusters.
 | [kubernetes_role_binding.edit](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.get_node](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.helm_release](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
+| [kubernetes_role_binding.sa_custom_resource](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.sa_edit](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.sa_helm_release](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.starboard_reports](https://registry.terraform.io/providers/hashicorp/kubernetes/2.8.0/docs/resources/role_binding) | resource |

--- a/modules/kubernetes/eks-core/k8s-role-binding.tf
+++ b/modules/kubernetes/eks-core/k8s-role-binding.tf
@@ -139,6 +139,29 @@ resource "kubernetes_role_binding" "sa_helm_release" {
     namespace = kubernetes_namespace.service_accounts.metadata[0].name
   }
 }
+
+resource "kubernetes_role_binding" "sa_custom_resource" {
+  for_each = { for ns in var.namespaces : ns.name => ns }
+
+  metadata {
+    name      = "sa-${each.value.name}-custom-resource"
+    namespace = each.value.name
+    labels = {
+      "xkf.xenit.io/kind" = "platform"
+    }
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role.custom_resource_edit.metadata[0].name
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.tenant[each.key].metadata[0].name
+    namespace = kubernetes_namespace.service_accounts.metadata[0].name
+  }
+}
+
 resource "kubernetes_role_binding" "top" {
   for_each = { for ns in var.namespaces : ns.name => ns }
   metadata {


### PR DESCRIPTION
This is part of work to support legacy deployments. All of this will be removed when the need for external tenant access to the cluster is removed.