### PR TITLE
Ignore commit message changes in Flux installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#783](https://github.com/XenitAB/terraform-modules/pull/783) Upgrade azurerm and azuread providers.
 - [#789](https://github.com/XenitAB/terraform-modules/pull/789) [Breaking] Image gallery support for Azure Pipelines module.
 - [#801](https://github.com/XenitAB/terraform-modules/pull/801) [Breaking] Image gallery support for Github Runners module.
+- [#802](https://github.com/XenitAB/terraform-modules/pull/802) Ignore commit message changes in Flux installations.
 
 ### Fixed
 

--- a/modules/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/main.tf
@@ -148,6 +148,12 @@ resource "azuredevops_git_repository_file" "install" {
   content             = data.flux_install.this.content
   branch              = "refs/heads/${var.branch}"
   overwrite_on_create = true
+
+  lifecycle {
+    ignore_changes = [
+      commit_message,
+    ]
+  }
 }
 
 resource "azuredevops_git_repository_file" "sync" {
@@ -156,6 +162,12 @@ resource "azuredevops_git_repository_file" "sync" {
   content             = data.flux_sync.this.content
   branch              = "refs/heads/${var.branch}"
   overwrite_on_create = true
+
+  lifecycle {
+    ignore_changes = [
+      commit_message,
+    ]
+  }
 }
 
 resource "azuredevops_git_repository_file" "kustomize" {
@@ -164,6 +176,12 @@ resource "azuredevops_git_repository_file" "kustomize" {
   content             = file("${path.module}/templates/kustomization-override.yaml")
   branch              = "refs/heads/${var.branch}"
   overwrite_on_create = true
+
+  lifecycle {
+    ignore_changes = [
+      commit_message,
+    ]
+  }
 }
 
 resource "azuredevops_git_repository_file" "cluster_tenants" {
@@ -174,6 +192,12 @@ resource "azuredevops_git_repository_file" "cluster_tenants" {
   })
   branch              = "refs/heads/${var.branch}"
   overwrite_on_create = true
+
+  lifecycle {
+    ignore_changes = [
+      commit_message,
+    ]
+  }
 }
 
 # Tenants
@@ -195,4 +219,10 @@ resource "azuredevops_git_repository_file" "tenant" {
     create_crds = each.value.flux.create_crds
   })
   overwrite_on_create = true
+
+  lifecycle {
+    ignore_changes = [
+      commit_message,
+    ]
+  }
 }

--- a/modules/kubernetes/fluxcd-v2-github/main.tf
+++ b/modules/kubernetes/fluxcd-v2-github/main.tf
@@ -142,6 +142,12 @@ resource "github_repository_file" "install" {
   content             = data.flux_install.this.content
   branch              = var.branch
   overwrite_on_create = true
+
+  lifecycle {
+    ignore_changes = [
+      commit_message,
+    ]
+  }
 }
 
 resource "github_repository_file" "sync" {
@@ -150,6 +156,12 @@ resource "github_repository_file" "sync" {
   content             = data.flux_sync.this.content
   branch              = var.branch
   overwrite_on_create = true
+
+  lifecycle {
+    ignore_changes = [
+      commit_message,
+    ]
+  }
 }
 
 resource "github_repository_file" "kustomize" {
@@ -158,6 +170,12 @@ resource "github_repository_file" "kustomize" {
   content             = file("${path.module}/templates/kustomization-override.yaml")
   branch              = var.branch
   overwrite_on_create = true
+
+  lifecycle {
+    ignore_changes = [
+      commit_message,
+    ]
+  }
 }
 
 resource "github_repository_file" "cluster_tenants" {
@@ -168,6 +186,12 @@ resource "github_repository_file" "cluster_tenants" {
   })
   branch              = var.branch
   overwrite_on_create = true
+
+  lifecycle {
+    ignore_changes = [
+      commit_message,
+    ]
+  }
 }
 
 # Tenants
@@ -189,4 +213,10 @@ resource "github_repository_file" "tenant" {
     create_crds = false,
   })
   overwrite_on_create = true
+
+  lifecycle {
+    ignore_changes = [
+      commit_message,
+    ]
+  }
 }


### PR DESCRIPTION
Easy change which decreases state drift caused when the environment name is in the commit message.