### PR TITLE
Revert role_definition_name changes in #790

### DIFF
--- a/modules/azure/aks/aad-group.tf
+++ b/modules/azure/aks/aad-group.tf
@@ -1,7 +1,7 @@
 resource "azurerm_role_assignment" "view" {
   for_each = { for ns in var.namespaces : ns.name => ns }
 
-  role_definition_name = "Azure Kubernetes Service View Role"
+  role_definition_name = "Azure Kubernetes Service Cluster User Role"
   scope                = azurerm_kubernetes_cluster.this.id
   principal_id         = var.aad_groups.view[each.key].id
 }
@@ -9,20 +9,20 @@ resource "azurerm_role_assignment" "view" {
 resource "azurerm_role_assignment" "edit" {
   for_each = { for ns in var.namespaces : ns.name => ns }
 
-  role_definition_name = "Azure Kubernetes Service Edit Role"
+  role_definition_name = "Azure Kubernetes Service Cluster User Role"
   scope                = azurerm_kubernetes_cluster.this.id
   principal_id         = var.aad_groups.edit[each.key].id
 }
 
 resource "azurerm_role_assignment" "cluster_admin" {
-  role_definition_name = "Azure Kubernetes Service Cluster Admin Role"
+  role_definition_name = "Azure Kubernetes Service Cluster User Role"
   scope                = azurerm_kubernetes_cluster.this.id
   principal_id         = var.aad_groups.cluster_admin.id
 }
 
 resource "azurerm_role_assignment" "cluster_view" {
   scope                = azurerm_kubernetes_cluster.this.id
-  role_definition_name = "Azure Kubernetes Service Cluster View Role"
+  role_definition_name = "Azure Kubernetes Service Cluster User Role"
   principal_id         = var.aad_groups.cluster_view.id
 }
 


### PR DESCRIPTION
Without this fix we get the following error:

```
│ Error: loading Role Definition List: could not find role 'Azure Kubernetes Service Edit Role'
│ 
│   with module.aks1.azurerm_role_assignment.edit["mimforum"],
│   on .terraform/modules/aks1/modules/azure/aks/aad-group.tf line 9, in resource "azurerm_role_assignment" "edit":
│    9: resource "azurerm_role_assignment" "edit" {
```
