### PR TITLE
Increase nginx ingress min availible from one to two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#789](https://github.com/XenitAB/terraform-modules/pull/789) [Breaking] Image gallery support for Azure Pipelines module.
 - [#801](https://github.com/XenitAB/terraform-modules/pull/801) [Breaking] Image gallery support for Github Runners module.
 - [#802](https://github.com/XenitAB/terraform-modules/pull/802) Ignore commit message changes in Flux installations.
+- [#807](https://github.com/XenitAB/terraform-modules/pull/807) Increase NGINX Ingress min availible from one to two.
 
 ### Fixed
 

--- a/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/values.yaml.tpl
@@ -3,6 +3,7 @@ controller:
     chroot: true
 
   replicaCount: 3
+  minAvailable: 2
 
   resources:
     requests:


### PR DESCRIPTION
The default value for the nginx PDB is 1, which I do not like. Would rather have it to be 2 so that only one instance is replaced at a time.