### PR TITLE
Make datadog tolerate all node taints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#810](https://github.com/XenitAB/terraform-modules/pull/810) Upgrade terraform to 1.3.0.
 - [#810](https://github.com/XenitAB/terraform-modules/pull/810) Update provider versions.
 
+### Fixed
+
+- [#815](https://github.com/XenitAB/terraform-modules/pull/815) Make datadog tolerate all node taints.
+
 ## 2022.09.2
 
 ### Added

--- a/modules/kubernetes/datadog/charts/datadog-extras/templates/datadogagent.yaml
+++ b/modules/kubernetes/datadog/charts/datadog-extras/templates/datadogagent.yaml
@@ -31,6 +31,8 @@ spec:
       - name: DD_CONTAINER_EXCLUDE
         value: "kube_namespace:.*"
     config:
+      tolerations:
+        - operator: Exists
       tags:
         - env:{{ .Values.environment }}
       kubelet:


### PR DESCRIPTION
Datadog DS agents should run on all nodes even if tainted.