### PR TITLE
Update node local dns version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#812](https://github.com/XenitAB/terraform-modules/pull/812) Upgrade terraform to 1.3.0.
 - [#810](https://github.com/XenitAB/terraform-modules/pull/810) Update provider versions.
 - [#814](https://github.com/XenitAB/terraform-modules/pull/814) Possible to use data source as policy input to Irsa.
+- [#816](https://github.com/XenitAB/terraform-modules/pull/816) Update node local dns version.
 
 ### Fixed
 

--- a/modules/kubernetes/node-local-dns/charts/node-local-dns/templates/nodelocaldns.yaml
+++ b/modules/kubernetes/node-local-dns/charts/node-local-dns/templates/nodelocaldns.yaml
@@ -132,7 +132,7 @@ spec:
           operator: "Exists"
       containers:
         - name: node-cache
-          image: k8s.gcr.io/dns/k8s-dns-node-cache:1.21.1
+          image: k8s.gcr.io/dns/k8s-dns-node-cache:1.22.11
           resources:
             requests:
               cpu: 25m


### PR DESCRIPTION
No real changes more than it is now built with Go 1.18 and has some dependency updates. Have tested the new version with no real improvement or worsening of performance.