### PR TITLE
Add secrets-store.csi.x-k8s.io to EKS tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#797](https://github.com/XenitAB/terraform-modules/pull/797) [Breaking] Add option to configure extra headers in Ingress NGINX.
 - [#796](https://github.com/XenitAB/terraform-modules/pull/796) Add custom resource edit rights to tenant service account.
 - [#791](https://github.com/XenitAB/terraform-modules/pull/791) Add control-plane output solution for Azure.
+- [#823](https://github.com/XenitAB/terraform-modules/pull/823) Add secrets-store.csi.x-k8s.io to EKS tenants.
 
 ### Changed
 

--- a/modules/kubernetes/eks-core/k8s-cluster-role.tf
+++ b/modules/kubernetes/eks-core/k8s-cluster-role.tf
@@ -41,6 +41,7 @@ resource "kubernetes_cluster_role" "custom_resource_edit" {
       "notification.toolkit.fluxcd.io",
       "datadogmetrics.datadoghq.com",
       "datadogmonitors.datadoghq.com",
+      "secrets-store.csi.x-k8s.io",
     ]
     resources = ["*"]
     verbs     = ["*"]


### PR DESCRIPTION
This was managed in another PR for AKS and it should have been done in EKS as well but we missed it.