### PR TITLE
Revert "VMSS source_image_reference provider bug workaround"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [830](https://github.com/XenitAB/terraform-modules/pull/830) Add unique_suffix to core delegate azurerm_role_definition service_endpoint_join.
 - [832](https://github.com/XenitAB/terraform-modules/pull/832) Upgrade azurerm provider to 3.28.0.
 
-### Fixed
-
-- [#827](https://github.com/XenitAB/terraform-modules/pull/827) VMSS source_image_reference provider bug workaround.
-
 ## 2022.10.1
 
 ### Added

--- a/modules/azure/azure-pipelines-agent-vmss/main.tf
+++ b/modules/azure/azure-pipelines-agent-vmss/main.tf
@@ -83,13 +83,10 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
     }
   }
 
-  # source_image_reference is added here due to a bug in the provider. It makes the instances to
-  # be re-created even though is not used: https://github.com/hashicorp/terraform-provider-azurerm/issues/18661
   lifecycle {
     ignore_changes = [
       tags,
-      instances,
-      source_image_reference
+      instances
     ]
   }
 }


### PR DESCRIPTION
Reverts XenitAB/terraform-modules#827. Problem solved in azurerm 3.27.0.