### PR TITLE
Make falco use priorityClassName again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+
+- [#835](https://github.com/XenitAB/terraform-modules/pull/835) Make falco use priorityClassName again.
+
 ## 2022.10.2
 
 ### Changed

--- a/modules/kubernetes/falco/templates/falco-values.yaml.tpl
+++ b/modules/kubernetes/falco/templates/falco-values.yaml.tpl
@@ -16,7 +16,7 @@ falco:
     actions:
       - log
 
-priorityClassName: platform-high
+podPriorityClassName: platform-high
 
 scc:
   # -- Create OpenShift's Security Context Constraint.


### PR DESCRIPTION
Upstream had changed the varaible name when upgrading to v2.
