### PR TITLE
Change ACR SKU to Standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#837](https://github.com/XenitAB/terraform-modules/pull/837) Update TFLint to 0.42.
 - [#838](https://github.com/XenitAB/terraform-modules/pull/838) Update git-auth-proxy to v0.8.1.
 - [#840](https://github.com/XenitAB/terraform-modules/pull/840) Add support for ARM VMs in AKS.
+- [#841](https://github.com/XenitAB/terraform-modules/pull/841) Change ACR SKU to Standard.
 
 ### Added
 

--- a/modules/azure/aks-global/acr.tf
+++ b/modules/azure/aks-global/acr.tf
@@ -5,7 +5,7 @@ resource "azurerm_container_registry" "acr" {
   name                = "acr${var.environment}${var.location_short}${var.name}${var.unique_suffix}"
   resource_group_name = resource.azurerm_resource_group.this.name
   location            = resource.azurerm_resource_group.this.location
-  sku                 = "Basic"
+  sku                 = "Standard"
   admin_enabled       = false
 }
 


### PR DESCRIPTION
This sets all ACR SKUs to Premium. I do not see a point in running a Basic SKU as Premium includes a lot more storage. Plus the increased bandwidth does not hurt.