### PR TITLE
Add XKF prefix to node pool label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#838](https://github.com/XenitAB/terraform-modules/pull/838) Update git-auth-proxy to v0.8.1.
 - [#840](https://github.com/XenitAB/terraform-modules/pull/840) Add support for ARM VMs in AKS.
 - [#841](https://github.com/XenitAB/terraform-modules/pull/841) Change ACR SKU to Standard.
+- [#846](https://github.com/XenitAB/terraform-modules/pull/846) Add XKF prefix to node pool label.
 
 ### Added
 

--- a/modules/aws/eks/eks.tf
+++ b/modules/aws/eks/eks.tf
@@ -206,7 +206,7 @@ resource "aws_eks_node_group" "this" {
     version = aws_launch_template.eks_node_group[each.key].latest_version
   }
 
-  labels = merge({ "xkf.xenit.io/node-ttl" = "168h" }, each.value.node_labels, { "node-pool" = each.value.name })
+  labels = merge({ "xkf.xenit.io/node-ttl" = "168h" }, each.value.node_labels, { "xkf.xenit.io/node-pool" = each.value.name })
 
   tags = local.global_tags
 

--- a/modules/azure/aks/aks.tf
+++ b/modules/azure/aks/aks.tf
@@ -100,7 +100,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "this" {
   spot_max_price       = each.value.spot_max_price
 
   node_taints = each.value.node_taints
-  node_labels = merge({ "xkf.xenit.io/node-ttl" = "168h" }, each.value.node_labels, { "node-pool" = each.value.name })
+  node_labels = merge({ "xkf.xenit.io/node-ttl" = "168h" }, each.value.node_labels, { "xkf.xenit.io/node-pool" = each.value.name })
 
   kubelet_config {
     pod_max_pid = 1000


### PR DESCRIPTION
This changes the default label added to nodes indicating the node pool it is part of. The reason is to make it obvious that it is a label set by XKF. This change could be considered breaking if people have node selectors for the `node-pool` label, but as far as I know it should not be an issue.