### PR TITLE
Allow aks name suffix to be set to null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#821](https://github.com/XenitAB/terraform-modules/pull/821) Default ingressClassName for ingress_healthz.
 - [#847](https://github.com/XenitAB/terraform-modules/pull/847) Fix linkerd certificate forced recreation.
 
+### Changed
+
+- [#848](https://github.com/XenitAB/terraform-modules/pull/848) Allow aks name suffix to be set to null.
+
 ## 2022.10.3
 
 ### Changed

--- a/modules/azure/aks/aks.tf
+++ b/modules/azure/aks/aks.tf
@@ -1,5 +1,5 @@
 data "azurerm_subnet" "this" {
-  name                 = "sn-${var.environment}-${var.location_short}-${var.core_name}-${var.name}${var.aks_name_suffix}"
+  name                 = "sn-${var.environment}-${var.location_short}-${var.core_name}-${var.name}${local.aks_name_suffix}"
   virtual_network_name = "vnet-${var.environment}-${var.location_short}-${var.core_name}"
   resource_group_name  = "rg-${var.environment}-${var.location_short}-${var.core_name}"
 }
@@ -16,10 +16,10 @@ data "azurerm_storage_account" "log" {
 # azure-container-use-rbac-permissions is ignored because the rule has not been updated in tfsec
 #tfsec:ignore:azure-container-limit-authorized-ips tfsec:ignore:azure-container-logging tfsec:ignore:azure-container-use-rbac-permissions
 resource "azurerm_kubernetes_cluster" "this" {
-  name                            = "aks-${var.environment}-${var.location_short}-${var.name}${var.aks_name_suffix}"
+  name                            = "aks-${var.environment}-${var.location_short}-${var.name}${local.aks_name_suffix}"
   location                        = data.azurerm_resource_group.this.location
   resource_group_name             = data.azurerm_resource_group.this.name
-  dns_prefix                      = "aks-${var.environment}-${var.location_short}-${var.name}${var.aks_name_suffix}"
+  dns_prefix                      = "aks-${var.environment}-${var.location_short}-${var.name}${local.aks_name_suffix}"
   kubernetes_version              = var.aks_config.version
   sku_tier                        = var.aks_config.production_grade ? "Paid" : "Free"
   api_server_authorized_ip_ranges = var.aks_authorized_ips
@@ -112,7 +112,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "this" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "log_storage_account_audit" {
-  name               = "log-${var.environment}-${var.location_short}-${var.name}${var.aks_name_suffix}"
+  name               = "log-${var.environment}-${var.location_short}-${var.name}${local.aks_name_suffix}"
   target_resource_id = azurerm_kubernetes_cluster.this.id
   storage_account_id = data.azurerm_storage_account.log.id
 
@@ -237,7 +237,7 @@ resource "azurerm_monitor_diagnostic_setting" "log_storage_account_audit" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "log_eventhub_audit" {
-  name                           = "eventhub-${var.environment}-${var.location_short}-${var.name}${var.aks_name_suffix}-audit"
+  name                           = "eventhub-${var.environment}-${var.location_short}-${var.name}${local.aks_name_suffix}-audit"
   target_resource_id             = azurerm_kubernetes_cluster.this.id
   eventhub_name                  = var.log_eventhub_name
   eventhub_authorization_rule_id = var.log_eventhub_authorization_rule_id

--- a/modules/azure/aks/azure-metrics.tf
+++ b/modules/azure/aks/azure-metrics.tf
@@ -11,13 +11,13 @@ resource "azurerm_role_assignment" "azure_metrics" {
 }
 
 resource "azurerm_role_assignment" "azure_metrics_aks_reader" {
-  scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourcegroups/${data.azurerm_resource_group.this.name}/providers/Microsoft.ContainerService/managedClusters/aks-${var.environment}-${var.location_short}-${var.name}${var.aks_name_suffix}"
+  scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourcegroups/${data.azurerm_resource_group.this.name}/providers/Microsoft.ContainerService/managedClusters/aks-${var.environment}-${var.location_short}-${var.name}${local.aks_name_suffix}"
   role_definition_name = "Monitoring Reader"
   principal_id         = var.azure_metrics_identity.principal_id
 }
 
 resource "azurerm_role_assignment" "azure_metrics_lb_reader" {
-  scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/mc_${data.azurerm_resource_group.this.name}_aks-${var.environment}-${var.location_short}-${var.name}${var.aks_name_suffix}_${data.azurerm_resource_group.this.location}/providers/Microsoft.Network/loadBalancers/kubernetes"
+  scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/mc_${data.azurerm_resource_group.this.name}_aks-${var.environment}-${var.location_short}-${var.name}${local.aks_name_suffix}_${data.azurerm_resource_group.this.location}/providers/Microsoft.Network/loadBalancers/kubernetes"
   role_definition_name = "Monitoring Reader"
   principal_id         = var.azure_metrics_identity.principal_id
 }

--- a/modules/azure/aks/main.tf
+++ b/modules/azure/aks/main.tf
@@ -36,3 +36,8 @@ data "azurerm_client_config" "current" {}
 data "azurerm_resource_group" "this" {
   name = "rg-${var.environment}-${var.location_short}-${var.name}"
 }
+
+locals {
+  aks_name_suffix = var.aks_name_suffix != null ? var.aks_name_suffix : ""
+}
+

--- a/modules/kubernetes/aks-core/main.tf
+++ b/modules/kubernetes/aks-core/main.tf
@@ -52,3 +52,7 @@ data "azurerm_resource_group" "this" {
 data "azurerm_resource_group" "global" {
   name = "rg-${var.environment}-${var.global_location_short}-global"
 }
+
+locals {
+  aks_name_suffix = var.aks_name_suffix != null ? var.aks_name_suffix : ""
+}

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -88,7 +88,7 @@ module "fluxcd_v2_azure_devops" {
   source = "../../kubernetes/fluxcd-v2-azdo"
 
   environment       = var.environment
-  cluster_id        = "${var.location_short}-${var.environment}-${var.name}${var.aks_name_suffix}"
+  cluster_id        = "${var.location_short}-${var.environment}-${var.name}${local.aks_name_suffix}"
   azure_devops_pat  = var.fluxcd_v2_config.azure_devops.pat
   azure_devops_org  = var.fluxcd_v2_config.azure_devops.org
   azure_devops_proj = var.fluxcd_v2_config.azure_devops.proj
@@ -114,7 +114,7 @@ module "fluxcd_v2_github" {
   source = "../../kubernetes/fluxcd-v2-github"
 
   environment            = var.environment
-  cluster_id             = "${var.location_short}-${var.environment}-${var.name}${var.aks_name_suffix}"
+  cluster_id             = "${var.location_short}-${var.environment}-${var.name}${local.aks_name_suffix}"
   github_org             = var.fluxcd_v2_config.github.org
   github_app_id          = var.fluxcd_v2_config.github.app_id
   github_installation_id = var.fluxcd_v2_config.github.installation_id
@@ -258,7 +258,7 @@ module "external_dns" {
   source = "../../kubernetes/external-dns"
 
   dns_provider = "azure"
-  txt_owner_id = "${var.environment}-${var.location_short}-${var.name}${var.aks_name_suffix}"
+  txt_owner_id = "${var.environment}-${var.location_short}-${var.name}${local.aks_name_suffix}"
   azure_config = {
     tenant_id       = data.azurerm_client_config.current.tenant_id
     subscription_id = data.azurerm_client_config.current.subscription_id
@@ -409,7 +409,7 @@ module "grafana_agent" {
     traces_password  = var.grafana_agent_config.credentials.traces_password
   }
 
-  cluster_name      = "${var.name}${var.aks_name_suffix}"
+  cluster_name      = "${var.name}${local.aks_name_suffix}"
   environment       = var.environment
   vpa_enabled       = var.vpa_enabled
   namespace_include = compact(concat(var.namespaces[*].name, var.grafana_agent_config.extra_namespaces))
@@ -497,7 +497,7 @@ module "prometheus" {
     }
   }
 
-  cluster_name = "${var.name}${var.aks_name_suffix}"
+  cluster_name = "${var.name}${local.aks_name_suffix}"
   environment  = var.environment
   tenant_id    = var.prometheus_config.tenant_id
   region       = var.location_short
@@ -561,7 +561,7 @@ module "promtail" {
 
   source              = "../../kubernetes/promtail"
   cloud_provider      = "azure"
-  cluster_name        = "${var.name}${var.aks_name_suffix}"
+  cluster_name        = "${var.name}${local.aks_name_suffix}"
   environment         = var.environment
   region              = var.location_short
   excluded_namespaces = var.promtail_config.excluded_namespaces


### PR DESCRIPTION
This change begrudgingly adds support to set a null value for AKS name suffix due to legacy. Should be removed when no longer needed.