### PR TITLE
Bump azad-kube-proxy version to 0.0.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- [#849](https://github.com/XenitAB/terraform-modules/pull/849) Bump azad-kube-proxy version to 0.0.36.
 - [#848](https://github.com/XenitAB/terraform-modules/pull/848) Allow aks name suffix to be set to null.
 
 ## 2022.10.3

--- a/modules/kubernetes/azad-kube-proxy/main.tf
+++ b/modules/kubernetes/azad-kube-proxy/main.tf
@@ -75,7 +75,7 @@ resource "helm_release" "azad_kube_proxy" {
   chart       = "azad-kube-proxy"
   name        = "azad-kube-proxy"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "v0.0.34"
+  version     = "v0.0.36"
   max_history = 3
   values      = [local.values]
 }


### PR DESCRIPTION
New azad-kube-proxy version to fix HPA apiversion deprecations.