### PR TITLE
Update falco to v0.33.0 and falco-exporter v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fix
+
+- [#856](https://github.com/XenitAB/terraform-modules/pull/856) Update falco to v0.33.0 and falco-exporter to v0.8.0.
+
 ## 2023.01.2
 
 ### Changed

--- a/modules/kubernetes/falco/main.tf
+++ b/modules/kubernetes/falco/main.tf
@@ -36,7 +36,7 @@ resource "helm_release" "falco" {
   chart       = "falco"
   name        = "falco"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "2.0.16"
+  version     = "2.3.0"
   max_history = 3
   values = [templatefile("${path.module}/templates/falco-values.yaml.tpl", {
     provider = var.cloud_provider
@@ -48,7 +48,7 @@ resource "helm_release" "falco_exporter" {
   chart       = "falco-exporter"
   name        = "falco-exporter"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "0.8.2"
+  version     = "0.9.1"
   max_history = 3
   values      = [templatefile("${path.module}/templates/falco-exporter-values.yaml.tpl", {})]
 }

--- a/modules/kubernetes/falco/templates/falco-values.yaml.tpl
+++ b/modules/kubernetes/falco/templates/falco-values.yaml.tpl
@@ -5,7 +5,7 @@ driver:
 falco:
   grpc:
     enabled: true
-  grpcOutput:
+  grpc_output:
     enabled: true
 
   # This should be further explored in the future but seems


### PR DESCRIPTION
Also change from `falco.grpcOutput.enabled` to `falco.grpc_output.enabled`.
This to use the new configmap injection that the helm chart uses now a days.