### PR TITLE
Increase max AD group in azad-kube-proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+
+- [#864](https://github.com/XenitAB/terraform-modules/pull/864) Increase max AD group in azad-kube-proxy.
+
 ## 2022.11.1
 
 ### Fixed

--- a/modules/kubernetes/azad-kube-proxy/templates/values.yaml.tpl
+++ b/modules/kubernetes/azad-kube-proxy/templates/values.yaml.tpl
@@ -25,6 +25,8 @@ podEnv:
     value: "OBJECTID"
   - name: AZURE_AD_GROUP_PREFIX
     value: "${azure_ad_group_prefix}"
+  - name: AZURE_AD_MAX_GROUP_COUNT
+    value: "200"
 
 secret:
   create: false


### PR DESCRIPTION
The max AD group limit has to be increased as there are now users who are a member of >100 groups with the prefix. To avoid having different values for different customers I suggest just setting a hard coded value here.