### PR TITLE
Update Kube Prometheus Stack version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - [#879](https://github.com/XenitAB/terraform-modules/pull/874) Update Promtail Helm chart to 6.6.2.
+- [#877](https://github.com/XenitAB/terraform-modules/pull/877) Update Kube Prometheus Stack to 42.1.1.
 
 ## 2022.12.1
 

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -474,7 +474,7 @@ module "prometheus_crd" {
 
   chart_repository = "https://prometheus-community.github.io/helm-charts"
   chart_name       = "kube-prometheus-stack"
-  chart_version    = "35.4.2"
+  chart_version    = "42.1.1"
 }
 
 module "prometheus" {

--- a/modules/kubernetes/eks-core/modules.tf
+++ b/modules/kubernetes/eks-core/modules.tf
@@ -338,7 +338,7 @@ module "prometheus_crd" {
 
   chart_repository = "https://prometheus-community.github.io/helm-charts"
   chart_name       = "kube-prometheus-stack"
-  chart_version    = "35.4.2"
+  chart_version    = "42.1.1"
 }
 
 module "prometheus" {

--- a/modules/kubernetes/prometheus/main.tf
+++ b/modules/kubernetes/prometheus/main.tf
@@ -36,12 +36,17 @@ resource "helm_release" "prometheus" {
   chart       = "kube-prometheus-stack"
   name        = "prometheus"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "35.4.2"
+  version     = "42.1.1"
   max_history = 3
   skip_crds   = true
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     vpa_enabled = var.vpa_enabled,
   })]
+
+  # This is needed while upgrading past v40.x.x as it contains a label change which requires replacing the Node Exporter Daemon Set
+  # Should be removed in the future when not required.
+  # https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-39x-to-40x
+  force_update = true
 }
 
 # EKS will not install metrics server out of the box so it has to be added.

--- a/modules/kubernetes/prometheus/templates/values.yaml.tpl
+++ b/modules/kubernetes/prometheus/templates/values.yaml.tpl
@@ -1,5 +1,10 @@
 # For more values see: https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml
-# grafana is managed by the grafana-operator
+
+# We do not monitor anything in clusters.
+defaultRules:
+  create: false
+
+# Grafana is managed by the grafana-operator
 grafana:
   enabled: false
 
@@ -72,7 +77,6 @@ kube-state-metrics:
     monitor:
       additionalLabels:
         xkf.xenit.io/monitoring: platform
-
 
 commonLabels:
   xkf.xenit.io/monitoring: platform


### PR DESCRIPTION
Contains a change which is breaking but solved with a force update in the helm release. This change will recreate the node exporter daemon set when updated.

 https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-39x-to-40x