### PR TITLE
Disable collecting API Server metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- [#879](https://github.com/XenitAB/terraform-modules/pull/874) Update Promtail Helm chart to 6.6.2.
 - [#877](https://github.com/XenitAB/terraform-modules/pull/877) Update Kube Prometheus Stack to 42.1.1.
+- [#878](https://github.com/XenitAB/terraform-modules/pull/878) Disable collecting API Server metrics.
+- [#879](https://github.com/XenitAB/terraform-modules/pull/874) Update Promtail Helm chart to 6.6.2.
 
 ## 2022.12.1
 

--- a/modules/kubernetes/prometheus/templates/values.yaml.tpl
+++ b/modules/kubernetes/prometheus/templates/values.yaml.tpl
@@ -17,6 +17,12 @@ kubeScheduler:
 kubeEtcd:
   enabled: false
 
+# We do not control the API Server so there is little value to monitor it.
+# Additionally metrics like apiserver_request_duration_seconds_bucket and apiserver_request_slo_duration_seconds_bucket produce large amounts of timeseries.
+# If this is enabled only the metrics that are actually needed should be kept. All other metrics should be dropped.
+kubeApiServer:
+  enabled: false
+
 # Specific for AKS kube-proxy label
 kubeProxy:
   service:


### PR DESCRIPTION
This change disables API Server metrics as they produce a large amount of time series which we do not use.