### PR TITLE
linkerd-viz ignore opa

### DIFF
--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -14,6 +14,7 @@ locals {
     "ingress-nginx",
     "linkerd",
     "linkerd-cni",
+    "linkerd-viz",
     "reloader",
     "starboard-operator",
     "tigera-operator",


### PR DESCRIPTION
noop container destroys securityContext: https://github.com/linkerd/linkerd2/issues/9671