### PR TITLE
OPA mutatingWebhookCustomRules trigger ephemeralContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#878](https://github.com/XenitAB/terraform-modules/pull/878) Disable collecting API Server metrics.
 - [#879](https://github.com/XenitAB/terraform-modules/pull/879) Update Promtail Helm chart to 6.6.2.
 - [#881](https://github.com/XenitAB/terraform-modules/pull/881) Set OPA mutatingWebhookReinvocationPolicy: IfNeeded.
+- [#885](https://github.com/XenitAB/terraform-modules/pull/885) OPA mutatingWebhookCustomRules trigger ephemeralContainer.
 
 ## 2022.12.1
 

--- a/modules/kubernetes/opa-gatekeeper/templates/gatekeeper-values.yaml.tpl
+++ b/modules/kubernetes/opa-gatekeeper/templates/gatekeeper-values.yaml.tpl
@@ -38,15 +38,6 @@ mutatingWebhookCustomRules:
     - UPDATE
     resources:
     - '*'
-  - apiGroups:
-    - '*'
-    apiVersions:
-    - '*'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - '*'
     - pods/ephemeralcontainers
     - pods/exec
     - pods/log

--- a/modules/kubernetes/opa-gatekeeper/templates/gatekeeper-values.yaml.tpl
+++ b/modules/kubernetes/opa-gatekeeper/templates/gatekeeper-values.yaml.tpl
@@ -27,3 +27,39 @@ psp:
 upgradeCRDs:
   enabled: false
 mutatingWebhookReinvocationPolicy: IfNeeded
+
+mutatingWebhookCustomRules:
+  - apiGroups:
+    - '*'
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - '*'
+  - apiGroups:
+    - '*'
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - '*'
+    - pods/ephemeralcontainers
+    - pods/exec
+    - pods/log
+    - pods/eviction
+    - pods/portforward
+    - pods/proxy
+    - pods/attach
+    - pods/binding
+    - deployments/scale
+    - replicasets/scale
+    - statefulsets/scale
+    - replicationcontrollers/scale
+    - services/proxy
+    - nodes/proxy
+    - services/status
+    scope: '*'


### PR DESCRIPTION
The reason why we need a custom rule is that the default rule only triggers on resources `*`

```.yaml
  - apiGroups:
    - '*'
    apiVersions:
    - '*'
    operations:
    - CREATE
    - UPDATE
    resources:
    - '*'
```

But the thing with `*` is that it doesn't take sub resources in to account. So to trigger on a subresource we have to define it specifically. 