### PR TITLE
AWS Add custom tags to match node labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#882](https://github.com/XenitAB/terraform-modules/pull/882) Platform workloads ignore taints and labels.
 - [#883](https://github.com/XenitAB/terraform-modules/pull/883) Fix promtail configuration.
 - [#884](https://github.com/XenitAB/terraform-modules/pull/884) Fix cluster-role-binding for get-nodes role in eks.
+- [#887](https://github.com/XenitAB/terraform-modules/pull/887) Add label and taint tags to eks node group.
 
 ### Changed
 

--- a/modules/aws/eks/eks.tf
+++ b/modules/aws/eks/eks.tf
@@ -183,9 +183,6 @@ resource "aws_launch_template" "eks_node_group" {
   tags = local.global_tags
 }
 
-
-
-
 resource "aws_eks_node_group" "this" {
   provider = aws.eks_admin
   for_each = {

--- a/modules/aws/eks/eks.tf
+++ b/modules/aws/eks/eks.tf
@@ -214,7 +214,7 @@ resource "aws_eks_node_group" "this" {
 
   tags = merge(
     local.global_tags,
-    local.node_labels[np.name]
+    local.node_labels[each.key]
   )
 
   dynamic "taint" {

--- a/modules/aws/eks/eks.tf
+++ b/modules/aws/eks/eks.tf
@@ -13,7 +13,8 @@ locals {
     token          = "foobar"
     calico_version = local.calico_version
   })
-  node_labels = {for np in var.eks_config.node_pools : np.name => {for key, value in np.node_labels: "k8s.io/cluster-autoscaler/node-template/label/${key}" => value}}
+  node_labels = { for np in var.eks_config.node_pools : np.name => { for key, value in np.node_labels : "k8s.io/cluster-autoscaler/node-template/label/${key}" => value } }
+  node_taints = { for np in var.eks_config.node_taints : np.name => { for key, value in np.node_taints : "k8s.io/cluster-autoscaler/node-template/taint/${key}" => "${value}:${effect}" } }
 }
 
 data "aws_subnet" "cluster" {
@@ -214,7 +215,8 @@ resource "aws_eks_node_group" "this" {
 
   tags = merge(
     local.global_tags,
-    local.node_labels[each.key]
+    local.node_labels[each.key],
+    local.node_taints[each.key],
   )
 
   dynamic "taint" {

--- a/modules/aws/eks/eks.tf
+++ b/modules/aws/eks/eks.tf
@@ -14,7 +14,7 @@ locals {
     calico_version = local.calico_version
   })
   node_labels = { for np in var.eks_config.node_pools : np.name => { for key, value in np.node_labels : "k8s.io/cluster-autoscaler/node-template/label/${key}" => value } }
-  node_taints = { for np in var.eks_config.node_taints : np.name => { for key, value in np.node_taints : "k8s.io/cluster-autoscaler/node-template/taint/${key}" => "${value}:${effect}" } }
+  node_taints = { for np in var.eks_config.node_pools : np.name => { for node_taint in np.node_taints : "k8s.io/cluster-autoscaler/node-template/taint/${node_taint["key"]}" => "${node_taint["value"]}:${node_taint["effect"]}" } }
 }
 
 data "aws_subnet" "cluster" {


### PR DESCRIPTION
This to make AutoScalingGroup detect the labels needed for cluster autoscaler.

For more information see: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-scale-a-node-group-to-0

https://github.com/kubernetes/autoscaler/issues/3780
