### PR TITLE
Change the default Prometheus scrape interval to every minute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#892](https://github.com/XenitAB/terraform-modules/pull/892) Change the default Prometheus scrape interval to every minute.
+
 ## 2022.12.3
 
 ### Fix

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.44
+version: 0.1.45
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/templates/prometheus.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/templates/prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "prometheus-extras.labels" . | nindent 4 }}
 spec:
   version: v2.40.1
+  scrapeInterval: "1m"
   {{- if eq .Values.cloudProvider "azure" }}
   podMetadata:
     labels:


### PR DESCRIPTION
This is part of the work to reduce metrics usage. It seems like the Prometheus Operator defaults to 30s while Prometheus defaults to 1m. This change just changes the interval to the default of Prometheus. This change will not override monitors which set an interval.