### PR TITLE
Add x509-certificate-exporter to prometheus ns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+
+- [#894](https://github.com/XenitAB/terraform-modules/pull/894) Add x509-certificate-exporter helm chart.
+
 ### Changed
 
 - [#892](https://github.com/XenitAB/terraform-modules/pull/892) Change the default Prometheus scrape interval to every minute.

--- a/modules/kubernetes/prometheus/README.md
+++ b/modules/kubernetes/prometheus/README.md
@@ -29,6 +29,7 @@ No modules.
 | [helm_release.metrics_server](https://registry.terraform.io/providers/hashicorp/helm/2.6.0/docs/resources/release) | resource |
 | [helm_release.prometheus](https://registry.terraform.io/providers/hashicorp/helm/2.6.0/docs/resources/release) | resource |
 | [helm_release.prometheus_extras](https://registry.terraform.io/providers/hashicorp/helm/2.6.0/docs/resources/release) | resource |
+| [helm_release.x509_certificate_exporter](https://registry.terraform.io/providers/hashicorp/helm/2.6.0/docs/resources/release) | resource |
 | [kubernetes_namespace.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/namespace) | resource |
 
 ## Inputs

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.45
+version: 0.1.46
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.46
+version: 0.1.47
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/templates/monitors.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/templates/monitors.yaml
@@ -461,7 +461,7 @@ spec:
       scrapeTimeout: 30s
       metricRelabelings:
         - action: labeldrop
-          regex: serial_number|issuer_CN|secret_key|secret_namespace|
+          regex: serial_number|issuer_CN|secret_key|secret_namespace|service|pod|instance|container
   namespaceSelector:
     matchNames:
     - prometheus

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/templates/monitors.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/templates/monitors.yaml
@@ -445,4 +445,24 @@ spec:
       app.kubernetes.io/instance: promtail
       app.kubernetes.io/name: promtail
 {{- end }}
-
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    xkf.xenit.io/monitoring: platform
+  name: x509-certificate-exporter
+  namespace: prometheus
+spec:
+  endpoints:
+    - port: metrics
+      interval: 60s
+      path: /metrics
+      scrapeTimeout: 30s
+  namespaceSelector:
+    matchNames:
+    - prometheus
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: x509-certificate-exporter
+      app.kubernetes.io/name: x509-certificate-exporter

--- a/modules/kubernetes/prometheus/charts/prometheus-extras/templates/monitors.yaml
+++ b/modules/kubernetes/prometheus/charts/prometheus-extras/templates/monitors.yaml
@@ -459,6 +459,9 @@ spec:
       interval: 60s
       path: /metrics
       scrapeTimeout: 30s
+      metricRelabelings:
+        - action: labeldrop
+          regex: serial_number|issuer_CN|secret_key|secret_namespace|
   namespaceSelector:
     matchNames:
     - prometheus

--- a/modules/kubernetes/prometheus/main.tf
+++ b/modules/kubernetes/prometheus/main.tf
@@ -111,7 +111,7 @@ resource "helm_release" "prometheus_extras" {
 # https://github.com/enix/x509-certificate-exporter
 resource "helm_release" "x509_certificate_exporter" {
   repository  = "https://charts.enix.io"
-  chart       = "enix/x509-certificate-exporter"
+  chart       = "x509-certificate-exporter"
   name        = "x509-certificate-exporter"
   namespace   = kubernetes_namespace.this.metadata[0].name
   version     = "3.6.0"

--- a/modules/kubernetes/prometheus/main.tf
+++ b/modules/kubernetes/prometheus/main.tf
@@ -107,3 +107,16 @@ resource "helm_release" "prometheus_extras" {
     promtail_enabled                         = var.promtail_enabled
   })]
 }
+
+# https://github.com/enix/x509-certificate-exporter
+resource "helm_release" "x509_certificate_exporter" {
+  repository  = "https://charts.enix.io"
+  chart       = "enix/x509-certificate-exporter"
+  name        = "x509-certificate-exporter"
+  namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "3.6.0"
+  max_history = 3
+  values = [templatefile("${path.module}/templates/values-x509.yaml.tpl", {
+    prometheus_namespace = kubernetes_namespace.this.metadata[0].name,
+  })]
+}

--- a/modules/kubernetes/prometheus/templates/values-x509.yaml.tpl
+++ b/modules/kubernetes/prometheus/templates/values-x509.yaml.tpl
@@ -8,4 +8,4 @@ prometheusRules:
 
 prometheusServiceMonitor:
   # -- Should a ServiceMonitor ressource be installed to scrape this exporter. For prometheus-operator (kube-prometheus) users.
-  create: true
+  create: false

--- a/modules/kubernetes/prometheus/templates/values-x509.yaml.tpl
+++ b/modules/kubernetes/prometheus/templates/values-x509.yaml.tpl
@@ -1,0 +1,11 @@
+secretsExporter:
+  includeNamespaces:
+    - ${prometheus_namespace}
+
+prometheusRules:
+  # -- Should a PrometheusRule ressource be installed to alert on certificate expiration. For prometheus-operator (kube-prometheus) users.
+  create: false
+
+prometheusServiceMonitor:
+  # -- Should a ServiceMonitor ressource be installed to scrape this exporter. For prometheus-operator (kube-prometheus) users.
+  create: true

--- a/modules/kubernetes/prometheus/templates/values-x509.yaml.tpl
+++ b/modules/kubernetes/prometheus/templates/values-x509.yaml.tpl
@@ -3,9 +3,9 @@ secretsExporter:
     - ${prometheus_namespace}
 
 prometheusRules:
-  # -- Should a PrometheusRule ressource be installed to alert on certificate expiration. For prometheus-operator (kube-prometheus) users.
+  # We don't manage prometheus rules per cluster.
   create: false
 
 prometheusServiceMonitor:
-  # -- Should a ServiceMonitor ressource be installed to scrape this exporter. For prometheus-operator (kube-prometheus) users.
+  # We use serviceMonitors from another helm chart.
   create: false


### PR DESCRIPTION
This to be able to monitor the mTLS cert that we use to send metrics to our central monitoring cluster.

This is how the metrics looks like:

```# HELP x509_cert_expired Indicates if the certificate is expired
# TYPE x509_cert_expired gauge
x509_cert_expired{issuer_CN="Intermediate CA",secret_key="tls.crt",secret_name="xenit-proxy-certificate",secret_namespace="prometheus",serial_number="53273528899929633352051475171416450529",subject_CN="unbox"} 0
x509_cert_expired{issuer_CN="Root CA",secret_key="tls.crt",secret_name="xenit-proxy-certificate",secret_namespace="prometheus",serial_number="60338911324707063396089478656720186399",subject_CN="Intermediate CA"} 0
# HELP x509_cert_not_after Indicates the certificate's not after timestamp
# TYPE x509_cert_not_after gauge
x509_cert_not_after{issuer_CN="Intermediate CA",secret_key="tls.crt",secret_name="xenit-proxy-certificate",secret_namespace="prometheus",serial_number="53273528899929633352051475171416450529",subject_CN="unbox"} 1.682115307e+09
x509_cert_not_after{issuer_CN="Root CA",secret_key="tls.crt",secret_name="xenit-proxy-certificate",secret_namespace="prometheus",serial_number="60338911324707063396089478656720186399",subject_CN="Intermediate CA"} 1.789806566e+09
# HELP x509_cert_not_before Indicates the certificate's not before timestamp
# TYPE x509_cert_not_before gauge
x509_cert_not_before{issuer_CN="Intermediate CA",secret_key="tls.crt",secret_name="xenit-proxy-certificate",secret_namespace="prometheus",serial_number="53273528899929633352051475171416450529",subject_CN="unbox"} 1.650579307e+09
x509_cert_not_before{issuer_CN="Root CA",secret_key="tls.crt",secret_name="xenit-proxy-certificate",secret_namespace="prometheus",serial_number="60338911324707063396089478656720186399",subject_CN="Intermediate CA"} 1.632126566e+09
# HELP x509_exporter_build_info A metric with a constant '1' value labeled with version, revision, build date, Go version, Go OS, and Go architecture
# TYPE x509_exporter_build_info gauge
x509_exporter_build_info{built="2022-10-27T14:48:05",goarch="amd64",goos="linux",goversion="go1.18.6",revision="0dd5e2318ae07e33778a72f53cd6e6ac8dbe0931",version="3.6.0"} 1
# HELP x509_read_errors Indicates the number of read failure(s)
# TYPE x509_read_errors gauge
x509_read_errors 0
```
