### PR TITLE
Update external-dns and metrics-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - [#892](https://github.com/XenitAB/terraform-modules/pull/892) Change the default Prometheus scrape interval to every minute.
+- [#896](https://github.com/XenitAB/terraform-modules/pull/896) Update external-dns and metrics-server.
 
 ## 2022.12.3
 

--- a/modules/kubernetes/external-dns/main.tf
+++ b/modules/kubernetes/external-dns/main.tf
@@ -34,7 +34,7 @@ resource "helm_release" "external_dns" {
   chart       = "external-dns"
   name        = "external-dns"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "6.1.6"
+  version     = "6.12.2"
   max_history = 3
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {
     provider     = var.dns_provider,

--- a/modules/kubernetes/prometheus/main.tf
+++ b/modules/kubernetes/prometheus/main.tf
@@ -61,7 +61,7 @@ resource "helm_release" "metrics_server" {
   chart       = "metrics-server"
   name        = "metrics-server"
   namespace   = "kube-system"
-  version     = "6.0.4"
+  version     = "6.2.4"
   max_history = 3
   values      = [templatefile("${path.module}/templates/values-metrics-server.yaml.tpl", {})]
 }


### PR DESCRIPTION
Previous versions does not seem to be available any more