### PR TITLE
Remove instance label from API Server metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#892](https://github.com/XenitAB/terraform-modules/pull/892) Change the default Prometheus scrape interval to every minute.
 - [#896](https://github.com/XenitAB/terraform-modules/pull/896) Update external-dns and metrics-server.
+- [#899](https://github.com/XenitAB/terraform-modules/pull/899) Remove instance label from API Server metrics
 
 ## 2022.12.3
 

--- a/modules/kubernetes/prometheus/templates/values.yaml.tpl
+++ b/modules/kubernetes/prometheus/templates/values.yaml.tpl
@@ -26,6 +26,8 @@ kubeApiServer:
       - action: keep
         regex: "kubernetes_build_info|apiserver_admission_.*"
         sourceLabels: [__name__]
+      - action: labeldrop
+        regex: instance
 
 # Specific for AKS kube-proxy label
 kubeProxy:


### PR DESCRIPTION
The instance label contain two different values on AWS and hence duplicates the number of time series