### PR TITLE
Revert "Remove instance label from API Server metrics (#899)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#892](https://github.com/XenitAB/terraform-modules/pull/892) Change the default Prometheus scrape interval to every minute.
 - [#896](https://github.com/XenitAB/terraform-modules/pull/896) Update external-dns and metrics-server.
-- [#899](https://github.com/XenitAB/terraform-modules/pull/899) Remove instance label from API Server metrics
 - [#900](https://github.com/XenitAB/terraform-modules/pull/900) Trigger upgrade pipeline in xkf-templates at release
 
 ## 2022.12.3

--- a/modules/kubernetes/prometheus/templates/values.yaml.tpl
+++ b/modules/kubernetes/prometheus/templates/values.yaml.tpl
@@ -26,8 +26,6 @@ kubeApiServer:
       - action: keep
         regex: "kubernetes_build_info|apiserver_admission_.*"
         sourceLabels: [__name__]
-      - action: labeldrop
-        regex: instance
 
 # Specific for AKS kube-proxy label
 kubeProxy:


### PR DESCRIPTION
This reverts commit a19fe555ce20545aabdcbf55ab35d9d8aa7edbae.