### PR TITLE
Add node labels and taints as tags to ASG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#903](https://github.com/XenitAB/terraform-modules/pull/903) Update Node TTL to v0.0.4.
 - [#905](https://github.com/XenitAB/terraform-modules/pull/905) Update Prometheus to v2.41.0.
 
+### Fix
+
+- [#907](https://github.com/XenitAB/terraform-modules/pull/907) Add node labels and taints as tags to ASG.
+
 ## 2022.12.3
 
 ### Fix

--- a/modules/aws/eks/README.md
+++ b/modules/aws/eks/README.md
@@ -34,6 +34,8 @@
 
 | Name | Type |
 |------|------|
+| [aws_autoscaling_group_tag.label](https://registry.terraform.io/providers/hashicorp/aws/4.31.0/docs/resources/autoscaling_group_tag) | resource |
+| [aws_autoscaling_group_tag.taint](https://registry.terraform.io/providers/hashicorp/aws/4.31.0/docs/resources/autoscaling_group_tag) | resource |
 | [aws_eks_addon.core_dns](https://registry.terraform.io/providers/hashicorp/aws/4.31.0/docs/resources/eks_addon) | resource |
 | [aws_eks_addon.ebs_csi_driver](https://registry.terraform.io/providers/hashicorp/aws/4.31.0/docs/resources/eks_addon) | resource |
 | [aws_eks_addon.kube_proxy](https://registry.terraform.io/providers/hashicorp/aws/4.31.0/docs/resources/eks_addon) | resource |

--- a/modules/aws/eks/templates/userdata.sh.tpl
+++ b/modules/aws/eks/templates/userdata.sh.tpl
@@ -8,6 +8,6 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 set -ex
 B64_CLUSTER_CA=${b64_cluster_ca}
 API_SERVER_URL=${api_server_url}
-/etc/eks/bootstrap.sh ${cluster_name} --kubelet-extra-args '--node-labels=eks.amazonaws.com/capacityType=ON_DEMAND,eks.amazonaws.com/nodegroup=${node_group}' --b64-cluster-ca $B64_CLUSTER_CA --apiserver-endpoint $API_SERVER_URL --use-max-pods false
+/etc/eks/bootstrap.sh ${cluster_name} --kubelet-extra-args '%{if node_labels != ""}--node-labels=${node_labels}%{endif}%{if node_taints != ""} --register-with-taints=${node_taints}%{endif}' --b64-cluster-ca $B64_CLUSTER_CA --apiserver-endpoint $API_SERVER_URL --use-max-pods false
 
 --==MYBOUNDARY==--


### PR DESCRIPTION
This change adds node taint and labels as tags to their ASG. Sadly this is required because EKS does not manage this for you.