### PR TITLE
Disable AKS file driver and snapshot controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - [#909](https://github.com/XenitAB/terraform-modules/pull/909) Update Azure provider.
+- [#910](https://github.com/XenitAB/terraform-modules/pull/910) Disable AKS file driver and snapshot controller.
 
 ### Fix
 

--- a/modules/azure/aks/aks.tf
+++ b/modules/azure/aks/aks.tf
@@ -60,6 +60,11 @@ resource "azurerm_kubernetes_cluster" "this" {
     }
   }
 
+  storage_profile {
+    file_driver_enabled         = false
+    snapshot_controller_enabled = false
+  }
+
   default_node_pool {
     name           = "default"
     vnet_subnet_id = data.azurerm_subnet.this.id


### PR DESCRIPTION
This just disables storage features that we do not use. These features create daemonsets that waste resources, even if it is not that much. We don not mount Azure Files with the file CSI driver, and we do not make snapshots of CSI disks inside of the cluster.