### PR TITLE
Fix Node TTL status ConfigMap namespace for AKS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#909](https://github.com/XenitAB/terraform-modules/pull/909) Update Azure provider.
 
+### Fix
+
+- [#911](https://github.com/XenitAB/terraform-modules/pull/911) Fix Node TTL status ConfigMap namespace for AKS.
+
 ## 2023.01.1
 
 ### Added

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -644,4 +644,6 @@ module "node_ttl" {
   }
 
   source = "../../kubernetes/node-ttl"
+
+  status_config_map_namespace = "kube-system"
 }

--- a/modules/kubernetes/eks-core/modules.tf
+++ b/modules/kubernetes/eks-core/modules.tf
@@ -520,4 +520,6 @@ module "node_ttl" {
   }
 
   source = "../../kubernetes/node-ttl"
+
+  status_config_map_namespace = "cluster-autoscaler"
 }

--- a/modules/kubernetes/node-ttl/README.md
+++ b/modules/kubernetes/node-ttl/README.md
@@ -30,7 +30,9 @@ No modules.
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_status_config_map_namespace"></a> [status\_config\_map\_namespace](#input\_status\_config\_map\_namespace) | Namespace where Cluster Autoscaler status ConfigMap is created | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/kubernetes/node-ttl/main.tf
+++ b/modules/kubernetes/node-ttl/main.tf
@@ -35,5 +35,7 @@ resource "helm_release" "this" {
   namespace   = kubernetes_namespace.this.metadata[0].name
   version     = "v0.0.4"
   max_history = 3
-  values      = [templatefile("${path.module}/templates/values.yaml.tpl", {})]
+  values = [templatefile("${path.module}/templates/values.yaml.tpl", {
+    status_config_map_namespace = var.status_config_map_namespace
+  })]
 }

--- a/modules/kubernetes/node-ttl/templates/values.yaml.tpl
+++ b/modules/kubernetes/node-ttl/templates/values.yaml.tpl
@@ -4,3 +4,5 @@ resources:
     memory: 20Mi
   limits:
     memory: 50Mi
+nodeTtl:
+  statusConfigMapNamespace: ${status_config_map_namespace}

--- a/modules/kubernetes/node-ttl/variables.tf
+++ b/modules/kubernetes/node-ttl/variables.tf
@@ -1,0 +1,4 @@
+variable "status_config_map_namespace" {
+  description = "Namespace where Cluster Autoscaler status ConfigMap is created"
+  type        = string
+}

--- a/validation/kubernetes/node-ttl/main.tf
+++ b/validation/kubernetes/node-ttl/main.tf
@@ -5,5 +5,6 @@ provider "kubernetes" {}
 provider "helm" {}
 
 module "node_ttl" {
-  source = "../../../modules/kubernetes/node-ttl"
+  source                      = "../../../modules/kubernetes/node-ttl"
+  status_config_map_namespace = "kube-system"
 }


### PR DESCRIPTION
AKS and EKS stores the status ConfigMap in different locations. This change adds a variable to allow each module to configure the namespace.