### PR TITLE
Set EKS max unavailible percentage to same value as AKS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fix
 
 - [#856](https://github.com/XenitAB/terraform-modules/pull/856) Update falco to v0.33.0 and falco-exporter to v0.8.0.
+- [#914](https://github.com/XenitAB/terraform-modules/pull/914) Set EKS max unavailible percentage to same value as AKS.
 
 ## 2023.01.2
 

--- a/modules/aws/eks/eks.tf
+++ b/modules/aws/eks/eks.tf
@@ -247,6 +247,10 @@ resource "aws_eks_node_group" "this" {
 
   subnet_ids = [for s in data.aws_subnet.node : s.id]
 
+  update_config {
+    max_unavailable_percentage = "33%"
+  }
+
   launch_template {
     id      = aws_launch_template.eks_node_group[each.key].id
     version = aws_launch_template.eks_node_group[each.key].latest_version


### PR DESCRIPTION
This will speed up node pool deletions by allowing parallel changes to nodes.