### PR TITLE
Opa gatekeeper pdb constraint

### DIFF
--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -30,7 +30,7 @@ module "opa_gatekeeper_crd" {
 
   chart_repository = "https://open-policy-agent.github.io/gatekeeper/charts"
   chart_name       = "gatekeeper"
-  chart_version    = "3.7.1"
+  chart_version    = "3.11.0"
 }
 
 module "opa_gatekeeper" {

--- a/modules/kubernetes/opa-gatekeeper/locals.tf
+++ b/modules/kubernetes/opa-gatekeeper/locals.tf
@@ -206,7 +206,7 @@ locals {
       name               = "k8spoddisruptionbudget"
       enforcement_action = ""
       match = {
-        kinds      = []
+      kinds        = ["Deployment", "StatefulSet", "PodDisruptionBudget"]
         namespaces = []
       }
       parameters = {}

--- a/modules/kubernetes/opa-gatekeeper/locals.tf
+++ b/modules/kubernetes/opa-gatekeeper/locals.tf
@@ -201,5 +201,15 @@ locals {
       }
       parameters = {}
     },
+    {
+      kind               = "K8sPodDisruptionBudget"
+      name               = "k8spoddisruptionbudget"
+      enforcement_action = ""
+      match = {
+        kinds      = []
+        namespaces = []
+      }
+      parameters = {}
+    },
   ]
 }

--- a/modules/kubernetes/opa-gatekeeper/main.tf
+++ b/modules/kubernetes/opa-gatekeeper/main.tf
@@ -138,7 +138,7 @@ resource "helm_release" "gatekeeper_templates" {
   chart       = "gatekeeper-library-templates"
   name        = "gatekeeper-library-templates"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "v0.20.1"
+  version     = "v0.21.0"
   max_history = 3
   values      = [local.values]
 }
@@ -150,7 +150,7 @@ resource "helm_release" "gatekeeper_constraints" {
   chart       = "gatekeeper-library-constraints"
   name        = "gatekeeper-library-constraints"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "v0.20.1"
+  version     = "v0.21.0"
   max_history = 3
   values      = [local.values]
 }

--- a/modules/kubernetes/opa-gatekeeper/main.tf
+++ b/modules/kubernetes/opa-gatekeeper/main.tf
@@ -123,7 +123,7 @@ resource "helm_release" "gatekeeper" {
   chart       = "gatekeeper"
   name        = "gatekeeper"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "3.9.0"
+  version     = "3.11.0"
   max_history = 3
   skip_crds   = true
   values = [templatefile("${path.module}/templates/gatekeeper-values.yaml.tpl", {

--- a/modules/kubernetes/opa-gatekeeper/templates/gatekeeper-values.yaml.tpl
+++ b/modules/kubernetes/opa-gatekeeper/templates/gatekeeper-values.yaml.tpl
@@ -27,6 +27,7 @@ psp:
 upgradeCRDs:
   enabled: false
 mutatingWebhookReinvocationPolicy: IfNeeded
+validatingWebhookFailurePolicy: Fail
 
 mutatingWebhookCustomRules:
   - apiGroups:


### PR DESCRIPTION
Use the new PDB rule to make sure that a user can't define a PDB minAvliable bigger then an HPA/deployment number.