### PR TITLE
document the RG needed to use the core module

### DIFF
--- a/modules/azure/core/README.md
+++ b/modules/azure/core/README.md
@@ -1,6 +1,8 @@
 # Core
 
 This module is used to create core resources like virtual network for the subscription.
+This module assumes that you have a RG called `rg-<env>-<location_short>-log`.
+Easiest is to define this RG in the governance module.
 
 ## Requirements
 

--- a/modules/azure/core/main.tf
+++ b/modules/azure/core/main.tf
@@ -2,6 +2,8 @@
   * # Core
   *
   * This module is used to create core resources like virtual network for the subscription.
+  * This module assumes that you have a RG called `rg-<env>-<location_short>-log`.
+  * Easiest is to define this RG in the governance module.
   */
 
 terraform {


### PR DESCRIPTION
We assume that the log rg exists in the core module. This creation of this RG should be done in the governance module. fix #930