### PR TITLE
Add certificate permissions for resource group AAD group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+
+- [#934](https://github.com/XenitAB/terraform-modules/pull/934) Add certificate permissions for resource group AAD group.
+
 ### Changed
 
 - [#928](https://github.com/XenitAB/terraform-modules/pull/928) Enable Node TTL by default.

--- a/modules/azure/governance-regional/delegate-kv.tf
+++ b/modules/azure/governance-regional/delegate-kv.tf
@@ -36,11 +36,12 @@ resource "azurerm_key_vault_access_policy" "ap_rg_aad_group" {
     if rg.delegate_key_vault == true
   }
 
-  key_vault_id       = azurerm_key_vault.delegate_kv[each.key].id
-  tenant_id          = data.azurerm_client_config.current.tenant_id
-  object_id          = var.azuread_groups.rg_contributor[each.key].id
-  key_permissions    = local.key_vault_default_permissions.key_permissions
-  secret_permissions = local.key_vault_default_permissions.secret_permissions
+  key_vault_id            = azurerm_key_vault.delegate_kv[each.key].id
+  tenant_id               = data.azurerm_client_config.current.tenant_id
+  object_id               = var.azuread_groups.rg_contributor[each.key].id
+  key_permissions         = local.key_vault_default_permissions.key_permissions
+  secret_permissions      = local.key_vault_default_permissions.secret_permissions
+  certificate_permissions = local.key_vault_default_permissions.certificate_permissions
 }
 
 resource "azurerm_key_vault_access_policy" "ap_rg_sp" {


### PR DESCRIPTION
This is to fix access issues for some customers that has started to utilize certificates in Azure KeyVault