### PR TITLE
Update Spegel to v0.0.4 and fix misspelled Spegel namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#939](https://github.com/XenitAB/terraform-modules/pull/939) Update Spegel to v0.0.4 and fix misspelled Spegel namespace.
+
 ## 2023.02.2
 
 ### Added

--- a/modules/kubernetes/spegel/main.tf
+++ b/modules/kubernetes/spegel/main.tf
@@ -21,7 +21,7 @@ terraform {
 
 resource "kubernetes_namespace" "this" {
   metadata {
-    name = "sepgel"
+    name = "spegel"
     labels = {
       name                = "spegel"
       "xkf.xenit.io/kind" = "platform"
@@ -33,6 +33,6 @@ resource "helm_release" "this" {
   chart       = "oci://ghcr.io/xenitab/helm-charts/spegel"
   name        = "spegel"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "v0.0.3"
+  version     = "v0.0.4"
   max_history = 3
 }


### PR DESCRIPTION
There was an issue with topology keys that needed to be fixed, and the namespace name was misspelled.