### PR TITLE
[Breaking] Upgrade grafana-agent to 0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#944](https://github.com/XenitAB/terraform-modules/pull/944) Upgrade grafana-agent to 0.6.0.
+
 ## 2023.02.3
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- [#944](https://github.com/XenitAB/terraform-modules/pull/944) Upgrade grafana-agent to 0.6.0.
+- [#944](https://github.com/XenitAB/terraform-modules/pull/944) Upgrade grafana-agent to 0.2.12.
 
 ## 2023.02.3
 

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -383,7 +383,7 @@ module "grafana_agent_crd" {
 
   chart_repository = "https://grafana.github.io/helm-charts"
   chart_name       = "grafana-agent-operator"
-  chart_version    = "0.6.0"
+  chart_version    = "0.2.12"
 }
 
 module "grafana_agent" {

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -383,7 +383,7 @@ module "grafana_agent_crd" {
 
   chart_repository = "https://grafana.github.io/helm-charts"
   chart_name       = "grafana-agent-operator"
-  chart_version    = "0.1.5"
+  chart_version    = "0.6.0"
 }
 
 module "grafana_agent" {

--- a/modules/kubernetes/grafana-agent/main.tf
+++ b/modules/kubernetes/grafana-agent/main.tf
@@ -126,7 +126,7 @@ resource "helm_release" "grafana_agent_operator" {
   chart       = "grafana-agent-operator"
   name        = "grafana-agent-operator"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "0.1.5"
+  version     = "0.6.0"
   max_history = 3
   skip_crds   = true
   values      = [local.operator_values]

--- a/modules/kubernetes/grafana-agent/main.tf
+++ b/modules/kubernetes/grafana-agent/main.tf
@@ -126,7 +126,7 @@ resource "helm_release" "grafana_agent_operator" {
   chart       = "grafana-agent-operator"
   name        = "grafana-agent-operator"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "0.6.0"
+  version     = "0.2.12"
   max_history = 3
   skip_crds   = true
   values      = [local.operator_values]


### PR DESCRIPTION
The deployment of the operator updates a few selectors....

```
│ Error: cannot patch "grafana-agent-operator" with kind Deployment: Deployment.apps "grafana-agent-operator" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/instance":"grafana-agent-operator", "app.kubernetes.io/name":"grafana-agent-operator"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
```

You manually need to deplete the deployment before applying the change.

```
k delete deployments.apps grafana-agent-operator -n grafana-agent
```