### PR TITLE
Try 1.0.0-rc.8 Datadog-Operator

### DIFF
--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -352,7 +352,7 @@ module "datadog_crd" {
 
   chart_repository = "https://helm.datadoghq.com"
   chart_name       = "datadog-operator"
-  chart_version    = "0.8.0"
+  chart_version    = "0.8.4"
 }
 
 module "datadog" {

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -352,7 +352,7 @@ module "datadog_crd" {
 
   chart_repository = "https://helm.datadoghq.com"
   chart_name       = "datadog-operator"
-  chart_version    = "0.8.4"
+  chart_version    = "0.9.2"
 }
 
 module "datadog" {

--- a/modules/kubernetes/datadog/charts/datadog-extras/Chart.yaml
+++ b/modules/kubernetes/datadog/charts/datadog-extras/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/datadog/charts/datadog-extras/Chart.yaml
+++ b/modules/kubernetes/datadog/charts/datadog-extras/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/modules/kubernetes/datadog/charts/datadog-extras/templates/datadogagent.yaml
+++ b/modules/kubernetes/datadog/charts/datadog-extras/templates/datadogagent.yaml
@@ -1,4 +1,4 @@
-apiVersion: datadoghq.com/v1alpha1
+apiVersion: datadoghq.com/v2alpha1
 kind: DatadogAgent
 metadata:
   name: datadog

--- a/modules/kubernetes/datadog/charts/datadog-extras/templates/datadogagent.yaml
+++ b/modules/kubernetes/datadog/charts/datadog-extras/templates/datadogagent.yaml
@@ -1,4 +1,4 @@
-apiVersion: datadoghq.com/v2alpha1
+apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
 metadata:
   name: datadog

--- a/modules/kubernetes/datadog/main.tf
+++ b/modules/kubernetes/datadog/main.tf
@@ -55,7 +55,6 @@ resource "helm_release" "datadog_operator" {
   chart       = "datadog-operator"
   name        = "datadog-operator"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "0.8.0"
   max_history = 3
   values      = [local.values_datadog_operator]
 }

--- a/modules/kubernetes/datadog/main.tf
+++ b/modules/kubernetes/datadog/main.tf
@@ -55,6 +55,7 @@ resource "helm_release" "datadog_operator" {
   chart       = "datadog-operator"
   name        = "datadog-operator"
   namespace   = kubernetes_namespace.this.metadata[0].name
+  version     = "0.8.4"
   max_history = 3
   values      = [local.values_datadog_operator]
 }

--- a/modules/kubernetes/datadog/main.tf
+++ b/modules/kubernetes/datadog/main.tf
@@ -55,7 +55,7 @@ resource "helm_release" "datadog_operator" {
   chart       = "datadog-operator"
   name        = "datadog-operator"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "1.0.0-rc.8"
+  version     = local.values_datadog_operator.image.tag
   max_history = 3
   values      = [local.values_datadog_operator]
 }

--- a/modules/kubernetes/datadog/main.tf
+++ b/modules/kubernetes/datadog/main.tf
@@ -55,7 +55,7 @@ resource "helm_release" "datadog_operator" {
   chart       = "datadog-operator"
   name        = "datadog-operator"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "0.8.4"
+  version     = "1.0.0-rc.8"
   max_history = 3
   values      = [local.values_datadog_operator]
 }

--- a/modules/kubernetes/datadog/main.tf
+++ b/modules/kubernetes/datadog/main.tf
@@ -55,7 +55,7 @@ resource "helm_release" "datadog_operator" {
   chart       = "datadog-operator"
   name        = "datadog-operator"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "0.8.4"
+  version     = "0.9.2"
   max_history = 3
   values      = [local.values_datadog_operator]
 }

--- a/modules/kubernetes/datadog/main.tf
+++ b/modules/kubernetes/datadog/main.tf
@@ -55,7 +55,7 @@ resource "helm_release" "datadog_operator" {
   chart       = "datadog-operator"
   name        = "datadog-operator"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "1.0.0-rc.8"
+  version     = "0.8.0"
   max_history = 3
   values      = [local.values_datadog_operator]
 }

--- a/modules/kubernetes/datadog/main.tf
+++ b/modules/kubernetes/datadog/main.tf
@@ -55,7 +55,7 @@ resource "helm_release" "datadog_operator" {
   chart       = "datadog-operator"
   name        = "datadog-operator"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = local.values_datadog_operator.image.tag
+  version     = "0.8.4"
   max_history = 3
   values      = [local.values_datadog_operator]
 }

--- a/modules/kubernetes/datadog/main.tf
+++ b/modules/kubernetes/datadog/main.tf
@@ -55,7 +55,7 @@ resource "helm_release" "datadog_operator" {
   chart       = "datadog-operator"
   name        = "datadog-operator"
   namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "0.8.0"
+  version     = "1.0.0-rc.8"
   max_history = 3
   values      = [local.values_datadog_operator]
 }

--- a/modules/kubernetes/datadog/templates/datadog-operator-values.yaml.tpl
+++ b/modules/kubernetes/datadog/templates/datadog-operator-values.yaml.tpl
@@ -3,6 +3,10 @@ apiKey: ${api_key}
 image:
   tag: 1.0.0-rc.8
 installCRDs: false
+datadog-crds:
+  migration:
+    datadogAgents:
+      version: "v2alpha1"
 datadogMonitor:
   enabled: true
 resources:

--- a/modules/kubernetes/datadog/templates/datadog-operator-values.yaml.tpl
+++ b/modules/kubernetes/datadog/templates/datadog-operator-values.yaml.tpl
@@ -3,10 +3,6 @@ apiKey: ${api_key}
 image:
   tag: 1.0.0-rc.8
 installCRDs: false
-datadog-crds:
-  migration:
-    datadogAgents:
-      version: "v2alpha1"
 datadogMonitor:
   enabled: true
 resources:

--- a/modules/kubernetes/datadog/templates/datadog-operator-values.yaml.tpl
+++ b/modules/kubernetes/datadog/templates/datadog-operator-values.yaml.tpl
@@ -1,6 +1,12 @@
 appKey: ${app_key}
 apiKey: ${api_key}
+image:
+  tag: 1.0.0-rc.8
 installCRDs: false
+datadog-crds:
+  migration:
+    datadogAgents:
+      version: "v2alpha1"
 datadogMonitor:
   enabled: true
 resources:

--- a/modules/kubernetes/datadog/templates/values.yaml.tpl
+++ b/modules/kubernetes/datadog/templates/values.yaml.tpl
@@ -3,7 +3,3 @@ clusterName: ${location}-${environment}
 containerInclude: ${container_filter_include}
 apmIgnoreResources: ${apm_ignore_resources}
 environment: ${environment}
-datadog-crds:
-  migration:
-    datadogAgents:
-      version: "v2alpha1"

--- a/modules/kubernetes/datadog/templates/values.yaml.tpl
+++ b/modules/kubernetes/datadog/templates/values.yaml.tpl
@@ -3,3 +3,7 @@ clusterName: ${location}-${environment}
 containerInclude: ${container_filter_include}
 apmIgnoreResources: ${apm_ignore_resources}
 environment: ${environment}
+datadog-crds:
+  migration:
+    datadogAgents:
+      version: "v2alpha1"

--- a/modules/kubernetes/datadog/templates/values.yaml.tpl
+++ b/modules/kubernetes/datadog/templates/values.yaml.tpl
@@ -1,5 +1,6 @@
 site: ${datadog_site}
 clusterName: ${location}-${environment}
 containerInclude: ${container_filter_include}
+
 apmIgnoreResources: ${apm_ignore_resources}
 environment: ${environment}

--- a/modules/kubernetes/datadog/templates/values.yaml.tpl
+++ b/modules/kubernetes/datadog/templates/values.yaml.tpl
@@ -1,6 +1,6 @@
 site: ${datadog_site}
 clusterName: ${location}-${environment}
-containerInclude: ${container_filter_include}
 
+containerInclude: ${container_filter_include}
 apmIgnoreResources: ${apm_ignore_resources}
 environment: ${environment}

--- a/modules/kubernetes/datadog/templates/values.yaml.tpl
+++ b/modules/kubernetes/datadog/templates/values.yaml.tpl
@@ -1,6 +1,5 @@
 site: ${datadog_site}
 clusterName: ${location}-${environment}
-
 containerInclude: ${container_filter_include}
 apmIgnoreResources: ${apm_ignore_resources}
 environment: ${environment}


### PR DESCRIPTION
This could be the workaround we have been looking for to run with 1.25.
It appears that datadog-operator doesnt have any intentions to release a chart with the release of 1.0.0. So this has to be the "new" way of running the operator?

Saw the information about CRD apiversions here:
https://github.com/DataDog/datadog-operator/issues/619#issuecomment-1440121556
Not entirely sure if i did that correctly in our use-case.