### PR TITLE
Update Goldilocks and VPA and move to using registry.k8s.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#957](https://github.com/XenitAB/terraform-modules/pull/957) Update Spegel to v0.0.5 and set resources.
 - [#959](https://github.com/XenitAB/terraform-modules/pull/959) Update node-local-dns to 1.22.20 and move to using registry.k8s.io.
 - [#962](https://github.com/XenitAB/terraform-modules/pull/962) Update Cluster Autoscaler Helm chart to move to using registry.k8s.io.
+- [#960](https://github.com/XenitAB/terraform-modules/pull/960) Update Goldilocks and VPA and move to using registry.k8s.io.
 
 ## 2023.03.1
 

--- a/modules/kubernetes/vpa/main.tf
+++ b/modules/kubernetes/vpa/main.tf
@@ -38,7 +38,7 @@ resource "helm_release" "vpa" {
   chart       = "vpa"
   name        = "vpa"
   namespace   = kubernetes_namespace.vpa.metadata[0].name
-  version     = "0.5.0"
+  version     = "1.6.1"
   max_history = 3
   skip_crds   = true
   values      = [templatefile("${path.module}/templates/vpa-values.yaml.tpl", {})]
@@ -49,7 +49,7 @@ resource "helm_release" "goldilocks" {
   chart       = "goldilocks"
   name        = "goldilocks"
   namespace   = kubernetes_namespace.vpa.metadata[0].name
-  version     = "5.1.0"
+  version     = "6.5.1"
   max_history = 3
   values      = [templatefile("${path.module}/templates/goldilocks-values.yaml.tpl", {})]
 }

--- a/modules/kubernetes/vpa/templates/vpa-values.yaml.tpl
+++ b/modules/kubernetes/vpa/templates/vpa-values.yaml.tpl
@@ -17,3 +17,9 @@ updater:
 
 admissionController:
   enabled: false
+
+recommender:
+  image:
+    repository: registry.k8s.io/autoscaling/vpa-recommender
+    pullPolicy: IfNotPresent
+    tag: "0.12.0"


### PR DESCRIPTION
This change updates VPA to fix compatibility with Kubernetes 1.25 and move to using registry.k8s.io.