### PR TITLE
Update CSI secret store and move to using registry.k8s.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#959](https://github.com/XenitAB/terraform-modules/pull/959) Update node-local-dns to 1.22.20 and move to using registry.k8s.io.
 - [#962](https://github.com/XenitAB/terraform-modules/pull/962) Update Cluster Autoscaler Helm chart to move to using registry.k8s.io.
 - [#960](https://github.com/XenitAB/terraform-modules/pull/960) Update Goldilocks and VPA and move to using registry.k8s.io.
+- [#961](https://github.com/XenitAB/terraform-modules/pull/961) Update CSI secret store and move to using registry.k8s.io.
 
 ## 2023.03.1
 

--- a/modules/kubernetes/csi-secrets-store-provider-aws/charts/csi-secrets-store-provider-aws/values.yaml
+++ b/modules/kubernetes/csi-secrets-store-provider-aws/charts/csi-secrets-store-provider-aws/values.yaml
@@ -5,8 +5,7 @@
 image:
   repository: public.ecr.aws/aws-secrets-manager/secrets-store-csi-driver-provider-aws
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.0.r2-6-gee95299-2022.04.14.21.07"
+  tag: 1.0.r2-46-gf2a8f35-2023.03.21.21.55
 
 imagePullSecrets: []
 nameOverride: ""

--- a/modules/kubernetes/csi-secrets-store-provider-aws/main.tf
+++ b/modules/kubernetes/csi-secrets-store-provider-aws/main.tf
@@ -33,7 +33,7 @@ resource "helm_release" "csi_secrets_store_driver" {
   repository  = "https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts"
   chart       = "secrets-store-csi-driver"
   name        = "secrets-store-csi-driver"
-  version     = "1.1.2"
+  version     = "1.3.2"
   namespace   = kubernetes_namespace.this.metadata[0].name
   max_history = 3
   skip_crds   = true
@@ -64,6 +64,8 @@ resource "helm_release" "csi_secrets_store_driver" {
   }
 }
 
+# TODO: Switch to using new Helm Chart.
+# https://github.com/aws/secrets-store-csi-driver-provider-aws/tree/main/charts/secrets-store-csi-driver-provider-aws
 resource "helm_release" "csi_secrets_store_provider_aws" {
   depends_on = [helm_release.csi_secrets_store_driver]
 

--- a/modules/kubernetes/csi-secrets-store-provider-azure/main.tf
+++ b/modules/kubernetes/csi-secrets-store-provider-azure/main.tf
@@ -31,7 +31,7 @@ resource "kubernetes_namespace" "this" {
 
 resource "helm_release" "csi_secrets_store_provider_azure" {
   repository  = "https://azure.github.io/secrets-store-csi-driver-provider-azure/charts"
-  version     = "1.0.1"
+  version     = "1.4.0"
   chart       = "csi-secrets-store-provider-azure"
   name        = "csi-secrets-store-provider-azure"
   namespace   = kubernetes_namespace.this.metadata[0].name


### PR DESCRIPTION
This change updates the CSI secrets store version for both AWS and Azure and move to using registry.k8s.io.