### PR TITLE
Update AzureRM provider to 3.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#970](https://github.com/XenitAB/terraform-modules/pull/970) Update Azurerm provider to 3.51.0.
+
 ### Added
 
 - [#958](https://github.com/XenitAB/terraform-modules/pull/958) Make azure/governance and azure/core use the [aztfmod/azurecaf](https://registry.terraform.io/providers/aztfmod/azurecaf/latest/docs) provider for names.

--- a/modules/azure/aks-global/README.md
+++ b/modules/azure/aks-global/README.md
@@ -4,14 +4,14 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.38.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.51.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.28.1 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.38.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.51.0 |
 
 ## Modules
 
@@ -21,14 +21,14 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/container_registry) | resource |
-| [azurerm_dns_zone.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/dns_zone) | resource |
-| [azurerm_management_lock.rg](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/management_lock) | resource |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/resource_group) | resource |
-| [azurerm_role_assignment.acr_pull](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.acr_push](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.acr_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
+| [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/container_registry) | resource |
+| [azurerm_dns_zone.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/dns_zone) | resource |
+| [azurerm_management_lock.rg](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/management_lock) | resource |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/resource_group) | resource |
+| [azurerm_role_assignment.acr_pull](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.acr_push](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.acr_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
 | [azuread_group.acr_pull](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/group) | data source |
 | [azuread_group.acr_push](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/group) | data source |
 | [azuread_group.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/group) | data source |

--- a/modules/azure/aks-global/main.tf
+++ b/modules/azure/aks-global/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.1.7"
   required_providers {
     azurerm = {
-      version = "3.38.0"
+      version = "3.51.0"
       source  = "hashicorp/azurerm"
     }
     azuread = {

--- a/modules/azure/aks-regional/README.md
+++ b/modules/azure/aks-regional/README.md
@@ -8,7 +8,7 @@ This module is used to create resources that are used by AKS clusters.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.38.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.51.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.4.3 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | 4.0.3 |
 
@@ -17,7 +17,7 @@ This module is used to create resources that are used by AKS clusters.
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.28.1 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.38.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.51.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.3 |
 
 ## Modules
@@ -31,41 +31,41 @@ This module is used to create resources that are used by AKS clusters.
 | Name | Type |
 |------|------|
 | [azuread_group_member.aad_pod_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/resources/group_member) | resource |
-| [azurerm_eventhub.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/eventhub) | resource |
-| [azurerm_eventhub_namespace.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/eventhub_namespace) | resource |
-| [azurerm_eventhub_namespace_authorization_rule.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/eventhub_namespace_authorization_rule) | resource |
-| [azurerm_eventhub_namespace_authorization_rule.listen](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/eventhub_namespace_authorization_rule) | resource |
-| [azurerm_key_vault_access_policy.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_secret.eventhub_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/key_vault_secret) | resource |
-| [azurerm_key_vault_secret.ssh_key](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/key_vault_secret) | resource |
-| [azurerm_public_ip_prefix.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/public_ip_prefix) | resource |
-| [azurerm_role_assignment.aad_pod_identity](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.external_dns_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.external_dns_msi](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.external_dns_rg_read](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.external_storage_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.trivy_acr](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.trivy_managed](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.velero_msi](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.velero_rg_read](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_storage_account.velero](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/storage_account) | resource |
-| [azurerm_storage_container.velero](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/storage_container) | resource |
-| [azurerm_user_assigned_identity.aad_pod_identity](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/user_assigned_identity) | resource |
-| [azurerm_user_assigned_identity.azure_metrics](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/user_assigned_identity) | resource |
-| [azurerm_user_assigned_identity.external_dns](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/user_assigned_identity) | resource |
-| [azurerm_user_assigned_identity.trivy](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/user_assigned_identity) | resource |
-| [azurerm_user_assigned_identity.velero](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/user_assigned_identity) | resource |
-| [azurerm_user_assigned_identity.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/user_assigned_identity) | resource |
+| [azurerm_eventhub.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/eventhub) | resource |
+| [azurerm_eventhub_namespace.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/eventhub_namespace) | resource |
+| [azurerm_eventhub_namespace_authorization_rule.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/eventhub_namespace_authorization_rule) | resource |
+| [azurerm_eventhub_namespace_authorization_rule.listen](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/eventhub_namespace_authorization_rule) | resource |
+| [azurerm_key_vault_access_policy.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_secret.eventhub_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.ssh_key](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_public_ip_prefix.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/public_ip_prefix) | resource |
+| [azurerm_role_assignment.aad_pod_identity](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.external_dns_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.external_dns_msi](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.external_dns_rg_read](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.external_storage_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.trivy_acr](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.trivy_managed](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.velero_msi](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.velero_rg_read](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_storage_account.velero](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/storage_account) | resource |
+| [azurerm_storage_container.velero](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/storage_container) | resource |
+| [azurerm_user_assigned_identity.aad_pod_identity](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/user_assigned_identity) | resource |
+| [azurerm_user_assigned_identity.azure_metrics](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/user_assigned_identity) | resource |
+| [azurerm_user_assigned_identity.external_dns](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/user_assigned_identity) | resource |
+| [azurerm_user_assigned_identity.trivy](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/user_assigned_identity) | resource |
+| [azurerm_user_assigned_identity.velero](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/user_assigned_identity) | resource |
+| [azurerm_user_assigned_identity.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/user_assigned_identity) | resource |
 | [tls_private_key.ssh_key](https://registry.terraform.io/providers/hashicorp/tls/4.0.3/docs/resources/private_key) | resource |
 | [azuread_group.resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/group) | data source |
-| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/client_config) | data source |
-| [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/container_registry) | data source |
-| [azurerm_dns_zone.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/dns_zone) | data source |
-| [azurerm_key_vault.core](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/key_vault) | data source |
-| [azurerm_resource_group.global](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/resource_group) | data source |
-| [azurerm_resource_group.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/resource_group) | data source |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/resource_group) | data source |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/client_config) | data source |
+| [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/container_registry) | data source |
+| [azurerm_dns_zone.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/dns_zone) | data source |
+| [azurerm_key_vault.core](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/key_vault) | data source |
+| [azurerm_resource_group.global](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 

--- a/modules/azure/aks-regional/main.tf
+++ b/modules/azure/aks-regional/main.tf
@@ -9,7 +9,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      version = "3.38.0"
+      version = "3.51.0"
       source  = "hashicorp/azurerm"
     }
     azuread = {

--- a/modules/azure/aks/README.md
+++ b/modules/azure/aks/README.md
@@ -15,7 +15,7 @@ https://pumpingco.de/blog/modify-aks-default-node-pool-in-terraform-without-rede
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.38.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.51.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.4.3 |
 
 ## Providers
@@ -23,7 +23,7 @@ https://pumpingco.de/blog/modify-aks-default-node-pool-in-terraform-without-rede
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.28.1 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.38.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.51.0 |
 
 ## Modules
 
@@ -34,25 +34,25 @@ No modules.
 | Name | Type |
 |------|------|
 | [azuread_group_member.aks_managed_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/resources/group_member) | resource |
-| [azurerm_kubernetes_cluster.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/kubernetes_cluster) | resource |
-| [azurerm_kubernetes_cluster_node_pool.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/kubernetes_cluster_node_pool) | resource |
-| [azurerm_monitor_diagnostic_setting.log_eventhub_audit](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/monitor_diagnostic_setting) | resource |
-| [azurerm_monitor_diagnostic_setting.log_storage_account_audit](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/monitor_diagnostic_setting) | resource |
-| [azurerm_role_assignment.aks_managed_identity_noderg_managed_identity_operator](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.aks_managed_identity_noderg_virtual_machine_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.azure_metrics](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.azure_metrics_aks_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.azure_metrics_lb_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.cluster_admin](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.cluster_view](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.edit](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.view](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/client_config) | data source |
-| [azurerm_resource_group.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/resource_group) | data source |
-| [azurerm_resource_group.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/resource_group) | data source |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/resource_group) | data source |
-| [azurerm_storage_account.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/storage_account) | data source |
-| [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/subnet) | data source |
+| [azurerm_kubernetes_cluster.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/kubernetes_cluster) | resource |
+| [azurerm_kubernetes_cluster_node_pool.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/kubernetes_cluster_node_pool) | resource |
+| [azurerm_monitor_diagnostic_setting.log_eventhub_audit](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/monitor_diagnostic_setting) | resource |
+| [azurerm_monitor_diagnostic_setting.log_storage_account_audit](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/monitor_diagnostic_setting) | resource |
+| [azurerm_role_assignment.aks_managed_identity_noderg_managed_identity_operator](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.aks_managed_identity_noderg_virtual_machine_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.azure_metrics](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.azure_metrics_aks_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.azure_metrics_lb_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.cluster_admin](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.cluster_view](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.edit](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.view](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/client_config) | data source |
+| [azurerm_resource_group.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/resource_group) | data source |
+| [azurerm_storage_account.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/storage_account) | data source |
+| [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/subnet) | data source |
 
 ## Inputs
 

--- a/modules/azure/aks/main.tf
+++ b/modules/azure/aks/main.tf
@@ -17,7 +17,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      version = "3.38.0"
+      version = "3.51.0"
       source  = "hashicorp/azurerm"
     }
     azuread = {

--- a/modules/azure/azure-pipelines-agent-vmss/README.md
+++ b/modules/azure/azure-pipelines-agent-vmss/README.md
@@ -11,14 +11,14 @@ Follow this guide to setup the agent pool (manually): https://docs.microsoft.com
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.38.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.51.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | 4.0.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.38.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.51.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.3 |
 
 ## Modules
@@ -29,11 +29,11 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_key_vault_secret.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/key_vault_secret) | resource |
-| [azurerm_linux_virtual_machine_scale_set.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/linux_virtual_machine_scale_set) | resource |
+| [azurerm_key_vault_secret.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_linux_virtual_machine_scale_set.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/linux_virtual_machine_scale_set) | resource |
 | [tls_private_key.this](https://registry.terraform.io/providers/hashicorp/tls/4.0.3/docs/resources/private_key) | resource |
-| [azurerm_key_vault.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/key_vault) | data source |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/resource_group) | data source |
+| [azurerm_key_vault.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/key_vault) | data source |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 

--- a/modules/azure/azure-pipelines-agent-vmss/main.tf
+++ b/modules/azure/azure-pipelines-agent-vmss/main.tf
@@ -13,7 +13,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      version = "3.38.0"
+      version = "3.51.0"
       source  = "hashicorp/azurerm"
     }
     tls = {

--- a/modules/azure/core/README.md
+++ b/modules/azure/core/README.md
@@ -11,7 +11,7 @@ Easiest is to define this RG in the governance module.
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
 | <a name="requirement_azurecaf"></a> [azurecaf](#requirement\_azurecaf) | 2.0.0-preview3 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.38.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.51.0 |
 
 ## Providers
 
@@ -19,7 +19,7 @@ Easiest is to define this RG in the governance module.
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.28.1 |
 | <a name="provider_azurecaf"></a> [azurecaf](#provider\_azurecaf) | 2.0.0-preview3 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.38.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.51.0 |
 
 ## Modules
 
@@ -31,22 +31,22 @@ Easiest is to define this RG in the governance module.
 
 | Name | Type |
 |------|------|
-| [azurerm_monitor_action_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/monitor_action_group) | resource |
-| [azurerm_monitor_metric_alert.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/monitor_metric_alert) | resource |
-| [azurerm_network_security_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/network_security_group) | resource |
-| [azurerm_role_assignment.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_definition.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_definition) | resource |
-| [azurerm_route.not_virtual_appliance](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/route) | resource |
-| [azurerm_route.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/route) | resource |
-| [azurerm_route_table.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/route_table) | resource |
-| [azurerm_storage_account.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/storage_account) | resource |
-| [azurerm_storage_account.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/storage_account) | resource |
-| [azurerm_subnet.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/subnet) | resource |
-| [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/subnet) | resource |
-| [azurerm_subnet_network_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/subnet_network_security_group_association) | resource |
-| [azurerm_subnet_route_table_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/subnet_route_table_association) | resource |
-| [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/virtual_network) | resource |
-| [azurerm_virtual_network_peering.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/virtual_network_peering) | resource |
+| [azurerm_monitor_action_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/monitor_action_group) | resource |
+| [azurerm_monitor_metric_alert.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/monitor_metric_alert) | resource |
+| [azurerm_network_security_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/network_security_group) | resource |
+| [azurerm_role_assignment.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_definition.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_definition) | resource |
+| [azurerm_route.not_virtual_appliance](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/route) | resource |
+| [azurerm_route.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/route) | resource |
+| [azurerm_route_table.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/route_table) | resource |
+| [azurerm_storage_account.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/storage_account) | resource |
+| [azurerm_storage_account.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/storage_account) | resource |
+| [azurerm_subnet.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/subnet) | resource |
+| [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/subnet) | resource |
+| [azurerm_subnet_network_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/subnet_network_security_group_association) | resource |
+| [azurerm_subnet_route_table_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/subnet_route_table_association) | resource |
+| [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/virtual_network) | resource |
+| [azurerm_virtual_network_peering.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/virtual_network_peering) | resource |
 | [azuread_group.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/group) | data source |
 | [azurecaf_name.azuread_group_service_endpoint_join](https://registry.terraform.io/providers/aztfmod/azurecaf/2.0.0-preview3/docs/data-sources/name) | data source |
 | [azurecaf_name.azurerm_monitor_action_group_this](https://registry.terraform.io/providers/aztfmod/azurecaf/2.0.0-preview3/docs/data-sources/name) | data source |
@@ -60,8 +60,8 @@ Easiest is to define this RG in the governance module.
 | [azurecaf_name.azurerm_virtual_network_this](https://registry.terraform.io/providers/aztfmod/azurecaf/2.0.0-preview3/docs/data-sources/name) | data source |
 | [azurecaf_name.local_peerings_name](https://registry.terraform.io/providers/aztfmod/azurecaf/2.0.0-preview3/docs/data-sources/name) | data source |
 | [azurecaf_name.local_subnets_subnet_full_name](https://registry.terraform.io/providers/aztfmod/azurecaf/2.0.0-preview3/docs/data-sources/name) | data source |
-| [azurerm_resource_group.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/resource_group) | data source |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 

--- a/modules/azure/core/main.tf
+++ b/modules/azure/core/main.tf
@@ -11,7 +11,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      version = "3.38.0"
+      version = "3.51.0"
       source  = "hashicorp/azurerm"
     }
     azuread = {

--- a/modules/azure/github-runner/README.md
+++ b/modules/azure/github-runner/README.md
@@ -13,14 +13,14 @@ Setup an image using Packer according [github-runner](https://github.com/XenitAB
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.38.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.51.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | 4.0.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.38.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.51.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.3 |
 
 ## Modules
@@ -31,15 +31,15 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_key_vault_access_policy.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_secret.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/key_vault_secret) | resource |
-| [azurerm_linux_virtual_machine_scale_set.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/linux_virtual_machine_scale_set) | resource |
+| [azurerm_key_vault_access_policy.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_secret.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_linux_virtual_machine_scale_set.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/linux_virtual_machine_scale_set) | resource |
 | [tls_private_key.this](https://registry.terraform.io/providers/hashicorp/tls/4.0.3/docs/resources/private_key) | resource |
-| [azurerm_key_vault.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/key_vault) | data source |
-| [azurerm_key_vault_secret.github_secrets](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/key_vault_secret) | data source |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/resource_group) | data source |
-| [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/subnet) | data source |
-| [azurerm_subscription.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/subscription) | data source |
+| [azurerm_key_vault.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/key_vault) | data source |
+| [azurerm_key_vault_secret.github_secrets](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/resource_group) | data source |
+| [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/subnet) | data source |
+| [azurerm_subscription.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/subscription) | data source |
 
 ## Inputs
 

--- a/modules/azure/github-runner/main.tf
+++ b/modules/azure/github-runner/main.tf
@@ -15,7 +15,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      version = "3.38.0"
+      version = "3.51.0"
       source  = "hashicorp/azurerm"
     }
     tls = {

--- a/modules/azure/governance-global/README.md
+++ b/modules/azure/governance-global/README.md
@@ -9,7 +9,7 @@ This module is used for governance on a global level and not using any specific 
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
 | <a name="requirement_azurecaf"></a> [azurecaf](#requirement\_azurecaf) | 2.0.0-preview3 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.38.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.51.0 |
 | <a name="requirement_pal"></a> [pal](#requirement\_pal) | 0.2.5 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.4.3 |
 
@@ -19,7 +19,7 @@ This module is used for governance on a global level and not using any specific 
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.28.1 |
 | <a name="provider_azurecaf"></a> [azurecaf](#provider\_azurecaf) | 2.0.0-preview3 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.38.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.51.0 |
 | <a name="provider_pal"></a> [pal](#provider\_pal) | 0.2.5 |
 
 ## Modules
@@ -63,10 +63,10 @@ This module is used for governance on a global level and not using any specific 
 | [azuread_service_principal.aad_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/resources/service_principal) | resource |
 | [azuread_service_principal.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/resources/service_principal) | resource |
 | [azuread_service_principal.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/resources/service_principal) | resource |
-| [azurerm_role_assignment.sub_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.sub_owner](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.sub_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.sub_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.sub_owner](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.sub_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
 | [pal_management_partner.aad_sp](https://registry.terraform.io/providers/xenitab/pal/0.2.5/docs/resources/management_partner) | resource |
 | [pal_management_partner.owner_spn](https://registry.terraform.io/providers/xenitab/pal/0.2.5/docs/resources/management_partner) | resource |
 | [azuread_application.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/application) | data source |
@@ -90,7 +90,7 @@ This module is used for governance on a global level and not using any specific 
 | [azurecaf_name.azuread_group_sub_contributor](https://registry.terraform.io/providers/aztfmod/azurecaf/2.0.0-preview3/docs/data-sources/name) | data source |
 | [azurecaf_name.azuread_group_sub_owner](https://registry.terraform.io/providers/aztfmod/azurecaf/2.0.0-preview3/docs/data-sources/name) | data source |
 | [azurecaf_name.azuread_group_sub_reader](https://registry.terraform.io/providers/aztfmod/azurecaf/2.0.0-preview3/docs/data-sources/name) | data source |
-| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/subscription) | data source |
+| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/subscription) | data source |
 
 ## Inputs
 

--- a/modules/azure/governance-global/main.tf
+++ b/modules/azure/governance-global/main.tf
@@ -9,7 +9,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      version = "3.38.0"
+      version = "3.51.0"
       source  = "hashicorp/azurerm"
     }
     azuread = {

--- a/modules/azure/governance-regional/README.md
+++ b/modules/azure/governance-regional/README.md
@@ -9,7 +9,7 @@ This module is used for governance on a regional level and not using any specifi
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
 | <a name="requirement_azurecaf"></a> [azurecaf](#requirement\_azurecaf) | 2.0.0-preview3 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.38.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.51.0 |
 | <a name="requirement_pal"></a> [pal](#requirement\_pal) | 0.2.5 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.4.3 |
 
@@ -19,7 +19,7 @@ This module is used for governance on a regional level and not using any specifi
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.28.1 |
 | <a name="provider_azurecaf"></a> [azurecaf](#provider\_azurecaf) | 2.0.0-preview3 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.38.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.51.0 |
 
 ## Modules
 
@@ -33,27 +33,27 @@ This module is used for governance on a regional level and not using any specifi
 |------|------|
 | [azuread_application_password.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/resources/application_password) | resource |
 | [azuread_application_password.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/resources/application_password) | resource |
-| [azurerm_key_vault.delegate_kv](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/key_vault) | resource |
-| [azurerm_key_vault_access_policy.ap_kvreader_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_access_policy.ap_owner_spn](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_access_policy.ap_rg_aad_group](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_access_policy.ap_rg_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_access_policy.ap_sub_aad_group_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_access_policy.ap_sub_aad_group_owner](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_secret.aad_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/key_vault_secret) | resource |
-| [azurerm_key_vault_secret.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/key_vault_secret) | resource |
-| [azurerm_key_vault_secret.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/key_vault_secret) | resource |
-| [azurerm_management_lock.rg](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/management_lock) | resource |
-| [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/resource_group) | resource |
-| [azurerm_role_assignment.aad_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.rg_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.rg_owner](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.rg_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
+| [azurerm_key_vault.delegate_kv](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/key_vault) | resource |
+| [azurerm_key_vault_access_policy.ap_kvreader_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.ap_owner_spn](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.ap_rg_aad_group](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.ap_rg_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.ap_sub_aad_group_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.ap_sub_aad_group_owner](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_secret.aad_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_management_lock.rg](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/management_lock) | resource |
+| [azurerm_resource_group.rg](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/resource_group) | resource |
+| [azurerm_role_assignment.aad_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.rg_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.rg_owner](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.rg_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
 | [azuread_service_principal.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/service_principal) | data source |
 | [azurecaf_name.azurerm_key_vault_delegate_kv](https://registry.terraform.io/providers/aztfmod/azurecaf/2.0.0-preview3/docs/data-sources/name) | data source |
 | [azurecaf_name.azurerm_resource_group_rg](https://registry.terraform.io/providers/aztfmod/azurecaf/2.0.0-preview3/docs/data-sources/name) | data source |
-| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/client_config) | data source |
-| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/subscription) | data source |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/client_config) | data source |
+| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/subscription) | data source |
 
 ## Inputs
 

--- a/modules/azure/governance-regional/main.tf
+++ b/modules/azure/governance-regional/main.tf
@@ -9,7 +9,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      version = "3.38.0"
+      version = "3.51.0"
       source  = "hashicorp/azurerm"
     }
     azuread = {

--- a/modules/azure/hub/README.md
+++ b/modules/azure/hub/README.md
@@ -12,14 +12,14 @@ Use together with the `core` module to create a peered network where SPOF (singl
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.38.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.51.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.28.1 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.38.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.51.0 |
 
 ## Modules
 
@@ -29,19 +29,19 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_nat_gateway.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/nat_gateway) | resource |
-| [azurerm_nat_gateway_public_ip_prefix_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/nat_gateway_public_ip_prefix_association) | resource |
-| [azurerm_network_security_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/network_security_group) | resource |
-| [azurerm_public_ip_prefix.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/public_ip_prefix) | resource |
-| [azurerm_role_assignment.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_definition.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/role_definition) | resource |
-| [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/subnet) | resource |
-| [azurerm_subnet_nat_gateway_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/subnet_nat_gateway_association) | resource |
-| [azurerm_subnet_network_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/subnet_network_security_group_association) | resource |
-| [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/virtual_network) | resource |
-| [azurerm_virtual_network_peering.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/resources/virtual_network_peering) | resource |
+| [azurerm_nat_gateway.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/nat_gateway) | resource |
+| [azurerm_nat_gateway_public_ip_prefix_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/nat_gateway_public_ip_prefix_association) | resource |
+| [azurerm_network_security_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/network_security_group) | resource |
+| [azurerm_public_ip_prefix.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/public_ip_prefix) | resource |
+| [azurerm_role_assignment.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_definition.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/role_definition) | resource |
+| [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/subnet) | resource |
+| [azurerm_subnet_nat_gateway_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/subnet_nat_gateway_association) | resource |
+| [azurerm_subnet_network_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/subnet_network_security_group_association) | resource |
+| [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/virtual_network) | resource |
+| [azurerm_virtual_network_peering.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/resources/virtual_network_peering) | resource |
 | [azuread_group.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azuread/2.28.1/docs/data-sources/group) | data source |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 

--- a/modules/azure/hub/main.tf
+++ b/modules/azure/hub/main.tf
@@ -13,7 +13,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      version = "3.38.0"
+      version = "3.51.0"
       source  = "hashicorp/azurerm"
     }
     azuread = {

--- a/modules/azure/xkf-governance-global-data/README.md
+++ b/modules/azure/xkf-governance-global-data/README.md
@@ -4,7 +4,7 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.38.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.51.0 |
 
 ## Providers
 

--- a/modules/azure/xkf-governance-global-data/main.tf
+++ b/modules/azure/xkf-governance-global-data/main.tf
@@ -6,7 +6,7 @@ terraform {
       source  = "hashicorp/azuread"
     }
     azurerm = {
-      version = "3.38.0"
+      version = "3.51.0"
       source  = "hashicorp/azurerm"
     }
   }

--- a/modules/azure/xkf-governance-global/README.md
+++ b/modules/azure/xkf-governance-global/README.md
@@ -4,7 +4,7 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.38.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.51.0 |
 
 ## Providers
 

--- a/modules/azure/xkf-governance-global/main.tf
+++ b/modules/azure/xkf-governance-global/main.tf
@@ -6,7 +6,7 @@ terraform {
       source  = "hashicorp/azuread"
     }
     azurerm = {
-      version = "3.38.0"
+      version = "3.51.0"
       source  = "hashicorp/azurerm"
     }
   }

--- a/modules/kubernetes/aks-core/README.md
+++ b/modules/kubernetes/aks-core/README.md
@@ -8,7 +8,7 @@ This module is used to create AKS clusters.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.28.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.38.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.51.0 |
 | <a name="requirement_flux"></a> [flux](#requirement\_flux) | 0.17.0 |
 | <a name="requirement_github"></a> [github](#requirement\_github) | 4.21.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.6.0 |
@@ -20,7 +20,7 @@ This module is used to create AKS clusters.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.38.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.51.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.6.0 |
 | <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | 1.14.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.13.1 |
@@ -97,9 +97,9 @@ This module is used to create AKS clusters.
 | [kubernetes_role_binding.vpa](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/role_binding) | resource |
 | [kubernetes_storage_class.zrs_premium](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/storage_class) | resource |
 | [kubernetes_storage_class.zrs_standard](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/storage_class) | resource |
-| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/client_config) | data source |
-| [azurerm_resource_group.global](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/resource_group) | data source |
-| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/resource_group) | data source |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/client_config) | data source |
+| [azurerm_resource_group.global](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.51.0/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 

--- a/modules/kubernetes/aks-core/main.tf
+++ b/modules/kubernetes/aks-core/main.tf
@@ -9,7 +9,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      version = "3.38.0"
+      version = "3.51.0"
       source  = "hashicorp/azurerm"
     }
     azuread = {


### PR DESCRIPTION
This updates Azurerm to 3.51.0 and enables us to fix the SKUnaming for AKS since the API deprecations

Doesnt fix  #967, but enables us to fix it

Tested and doesnt have any breaking changes in any modules