### PR TITLE
Switch to Standard sku_tier due to deprecations in the AzureAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- [#973](https://github.com/XenitAB/terraform-modules/pull/973) Switch to Standard sku_tier due to deprecations in the AzureAPI.
 - [#970](https://github.com/XenitAB/terraform-modules/pull/970) Update Azurerm provider to 3.51.0.
 
 ### Added

--- a/modules/azure/aks/aks.tf
+++ b/modules/azure/aks/aks.tf
@@ -25,7 +25,7 @@ resource "azurerm_kubernetes_cluster" "this" {
   resource_group_name             = data.azurerm_resource_group.this.name
   dns_prefix                      = "aks-${var.environment}-${var.location_short}-${var.name}${local.aks_name_suffix}"
   kubernetes_version              = var.aks_config.version
-  sku_tier                        = var.aks_config.production_grade ? "Paid" : "Free"
+  sku_tier                        = var.aks_config.production_grade ? "Standard" : "Free"
   api_server_authorized_ip_ranges = var.aks_authorized_ips
   run_command_enabled             = false
 


### PR DESCRIPTION
Azure API Version 2023-02-01 and later now require sku_tier to be set to Standard instead of Paid.

Fixes #967 