### PR TITLE
Manage Flux notification provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Added
+
+- [#985](https://github.com/XenitAB/terraform-modules/pull/985) Manage Flux notification provider.
+
 ### Changed
 
 - [#983](https://github.com/XenitAB/terraform-modules/pull/983) Update Flux to 0.25.3.

--- a/modules/kubernetes/fluxcd-v2-azdo/templates/tenant.yaml
+++ b/modules/kubernetes/fluxcd-v2-azdo/templates/tenant.yaml
@@ -52,6 +52,17 @@ spec:
     name: ${name}
   prune: true
   validation: client
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta1
+kind: Provider
+metadata:
+  name: ${name}
+  namespace: ${name}
+spec:
+  type: azuredevops
+  address: ${repo}
+  secretRef:
+    name: flux
 %{ if create_crds == true }
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/kubernetes/fluxcd-v2-github/templates/tenant.yaml
+++ b/modules/kubernetes/fluxcd-v2-github/templates/tenant.yaml
@@ -52,6 +52,17 @@ spec:
     name: ${name}
   prune: true
   validation: client
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta1
+kind: Provider
+metadata:
+  name: ${name}
+  namespace: ${name}
+spec:
+  type: github
+  address: ${repo}
+  secretRef:
+    name: flux
 %{ if create_crds == true }
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
It seems more reasonable for the provider to be automatically created in the tenants namespace. The configuration is very similar to the GitRepository that is created so this removes some burden on end users.