### PR TITLE
Fix Kubernetes version validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+
+- [#995](https://github.com/XenitAB/terraform-modules/pull/995) Fix Kubernetes version validation.
+
 ## 2023.06.3
 
 ### Changed

--- a/modules/aws/eks/variables.tf
+++ b/modules/aws/eks/variables.tf
@@ -56,9 +56,9 @@ variable "eks_config" {
 
   validation {
     condition = alltrue([
-      for np in concat(var.eks_config.node_pools, [{ version : var.eks_config.version }]) : can(regex("^1.(22|23|24)", np.version))
+      for np in concat(var.eks_config.node_pools, [{ version : var.eks_config.version }]) : can(regex("^1.(24|25)", np.version))
     ])
-    error_message = "The Kubernetes version has not been validated yet, supported versions are 1.22, 1.23, 1.24."
+    error_message = "The Kubernetes version has not been validated yet, supported versions are 1.24, 1.25."
   }
 
   validation {

--- a/modules/azure/aks/variables.tf
+++ b/modules/azure/aks/variables.tf
@@ -58,9 +58,9 @@ variable "aks_config" {
 
   validation {
     condition = alltrue([
-      for np in concat(var.aks_config.node_pools, [{ version : var.aks_config.version }]) : can(regex("^1.(23|24|25)", np.version))
+      for np in concat(var.aks_config.node_pools, [{ version : var.aks_config.version }]) : can(regex("^1.(24|25)", np.version))
     ])
-    error_message = "The Kubernetes version has not been validated yet, supported versions are 1.23, 1.24, 1.25."
+    error_message = "The Kubernetes version has not been validated yet, supported versions are 1.24, 1.25."
   }
 
   validation {

--- a/validation/aws/eks/main.tf
+++ b/validation/aws/eks/main.tf
@@ -23,12 +23,12 @@ module "eks" {
 
   eks_authorized_ips = ["0.0.0.0/0"]
   eks_config = {
-    version    = "1.23"
+    version    = "1.25"
     cidr_block = "10.0.16.0/20"
     node_pools = [
       {
         name           = "standard"
-        version        = "1.23.5-20220309"
+        version        = "1.25.5-20220309"
         min_size       = 1
         max_size       = 3
         instance_types = ["t3.large"]
@@ -37,7 +37,7 @@ module "eks" {
       },
       {
         name           = "batch"
-        version        = "1.23.5-20220309"
+        version        = "1.25.5-20220309"
         min_size       = 1
         max_size       = 3
         instance_types = ["t3.large"]


### PR DESCRIPTION
EKS version validation was not updated. This change fixes this and locks support to only Kubernetes 1.24 and 1.25.