### PR TITLE
Migrate node-ttl to install with Flux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [#1001](https://github.com/XenitAB/terraform-modules/pull/1001) Migrate node-ttl to install with Flux.
+
 ## 2023.06.4
 
 ### Fixed

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -21,6 +21,7 @@ locals {
     "grafana-agent",
     "promtail",
     "prometheus",
+    "node-ttl",
     "spegel",
   ]
   cluster_id = "${var.location_short}-${var.environment}-${var.name}${local.aks_name_suffix}"
@@ -640,8 +641,6 @@ module "node_local_dns" {
 }
 
 module "node_ttl" {
-  depends_on = [module.opa_gatekeeper]
-
   for_each = {
     for s in ["node-ttl"] :
     s => s
@@ -650,6 +649,7 @@ module "node_ttl" {
 
   source = "../../kubernetes/node-ttl"
 
+  cluster_id                  = local.cluster_id
   status_config_map_namespace = "kube-system"
 }
 

--- a/modules/kubernetes/eks-core/modules.tf
+++ b/modules/kubernetes/eks-core/modules.tf
@@ -14,6 +14,7 @@ locals {
     "reloader",
     "velero",
     "promtail",
+    "node-ttl",
     "spegel"
   ]
   dns_zone = {
@@ -510,8 +511,6 @@ module "node_local_dns" {
 }
 
 module "node_ttl" {
-  depends_on = [module.opa_gatekeeper]
-
   for_each = {
     for s in ["node-ttl"] :
     s => s
@@ -520,6 +519,7 @@ module "node_ttl" {
 
   source = "../../kubernetes/node-ttl"
 
+  cluster_id                  = local.cluster_id
   status_config_map_namespace = "cluster-autoscaler"
 }
 

--- a/modules/kubernetes/node-ttl/README.md
+++ b/modules/kubernetes/node-ttl/README.md
@@ -7,15 +7,13 @@ This module is used to add [`node-ttl`](https://github.com/XenitAB/node-ttl) to 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.6.0 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.13.1 |
+| <a name="requirement_git"></a> [git](#requirement\_git) | 0.0.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.6.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.13.1 |
+| <a name="provider_git"></a> [git](#provider\_git) | 0.0.2 |
 
 ## Modules
 
@@ -25,13 +23,14 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/2.6.0/docs/resources/release) | resource |
-| [kubernetes_namespace.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/namespace) | resource |
+| [git_repository_file.kustomization](https://registry.terraform.io/providers/xenitab/git/0.0.2/docs/resources/repository_file) | resource |
+| [git_repository_file.node_ttl](https://registry.terraform.io/providers/xenitab/git/0.0.2/docs/resources/repository_file) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | Unique identifier of the cluster across regions and instances. | `string` | n/a | yes |
 | <a name="input_status_config_map_namespace"></a> [status\_config\_map\_namespace](#input\_status\_config\_map\_namespace) | Namespace where Cluster Autoscaler status ConfigMap is created | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/kubernetes/node-ttl/main.tf
+++ b/modules/kubernetes/node-ttl/main.tf
@@ -8,34 +8,23 @@ terraform {
   required_version = ">= 1.3.0"
 
   required_providers {
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "2.13.1"
-    }
-    helm = {
-      source  = "hashicorp/helm"
-      version = "2.6.0"
+    git = {
+      source  = "xenitab/git"
+      version = "0.0.2"
     }
   }
 }
 
-resource "kubernetes_namespace" "this" {
-  metadata {
-    name = "node-ttl"
-    labels = {
-      name                = "node-ttl"
-      "xkf.xenit.io/kind" = "platform"
-    }
-  }
+resource "git_repository_file" "kustomization" {
+  path = "clusters/${var.cluster_id}/node-ttl.yaml"
+  content = templatefile("${path.module}/templates/kustomization.yaml.tpl", {
+    cluster_id = var.cluster_id
+  })
 }
 
-resource "helm_release" "this" {
-  chart       = "oci://ghcr.io/xenitab/helm-charts/node-ttl"
-  name        = "node-ttl"
-  namespace   = kubernetes_namespace.this.metadata[0].name
-  version     = "v0.0.6"
-  max_history = 3
-  values = [templatefile("${path.module}/templates/values.yaml.tpl", {
+resource "git_repository_file" "node_ttl" {
+  path = "platform/${var.cluster_id}/node-ttl/node-ttl.yaml"
+  content = templatefile("${path.module}/templates/node-ttl.yaml.tpl", {
     status_config_map_namespace = var.status_config_map_namespace
-  })]
+  })
 }

--- a/modules/kubernetes/node-ttl/templates/kustomization.yaml.tpl
+++ b/modules/kubernetes/node-ttl/templates/kustomization.yaml.tpl
@@ -1,0 +1,17 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: node-ttl
+  namespace: flux-system
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: "./platform/${cluster_id}/node-ttl/"
+  prune: true
+  healthChecks:
+  - apiVersion: apps/v1
+    kind: Deployment
+    namespace: node-ttl
+    name: node-ttl

--- a/modules/kubernetes/node-ttl/templates/node-ttl.yaml.tpl
+++ b/modules/kubernetes/node-ttl/templates/node-ttl.yaml.tpl
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+ name: node-ttl
+ labels:
+   name              = "node-ttl"
+   xkf.xenit.io/kind = "platform"
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: node-ttl
+  namespace: node-ttl
+spec:
+  type: "oci"
+  interval: 1m0s
+  url: "oci://ghcr.io/xenitab/helm-charts/node-ttl"
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: node-ttl
+  namespace: node-ttl
+spec:
+  chart:
+    spec:
+      chart: node-ttl
+      sourceRef:
+        kind: HelmRepository
+        name: node-ttl
+      version: v0.0.6
+  interval: 1m0s
+  values:
+    resources:
+      requests:
+        cpu: 5m
+        memory: 20Mi
+      limits:
+        memory: 50Mi
+    nodeTtl:
+      statusConfigMapNamespace: ${status_config_map_namespace}

--- a/modules/kubernetes/node-ttl/templates/values.yaml.tpl
+++ b/modules/kubernetes/node-ttl/templates/values.yaml.tpl
@@ -1,8 +1,0 @@
-resources:
-  requests:
-    cpu: 5m
-    memory: 20Mi
-  limits:
-    memory: 50Mi
-nodeTtl:
-  statusConfigMapNamespace: ${status_config_map_namespace}

--- a/modules/kubernetes/node-ttl/variables.tf
+++ b/modules/kubernetes/node-ttl/variables.tf
@@ -1,3 +1,8 @@
+variable "cluster_id" {
+  description = "Unique identifier of the cluster across regions and instances."
+  type        = string
+}
+
 variable "status_config_map_namespace" {
   description = "Namespace where Cluster Autoscaler status ConfigMap is created"
   type        = string

--- a/validation/kubernetes/node-ttl/main.tf
+++ b/validation/kubernetes/node-ttl/main.tf
@@ -6,5 +6,6 @@ provider "helm" {}
 
 module "node_ttl" {
   source                      = "../../../modules/kubernetes/node-ttl"
+  cluster_id                  = "foobar"
   status_config_map_namespace = "kube-system"
 }


### PR DESCRIPTION
This change starts the move from using the Helm provider to using Flux to install things into Kubernetes.