### PR TITLE
Add purge task to remove old images from ACR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#1025](https://github.com/XenitAB/terraform-modules/pull/1025) Enable Spegel mirroring for private ACR registry.
 
+### Added
+
+- [#1027](https://github.com/XenitAB/terraform-modules/pull/1027) Add purge task to remove old images from ACR.
+
 ## 2023.08.2
 
 ### Changed

--- a/modules/azure/aks-global/README.md
+++ b/modules/azure/aks-global/README.md
@@ -22,6 +22,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/3.71.0/docs/resources/container_registry) | resource |
+| [azurerm_container_registry_task.acr_purge_task](https://registry.terraform.io/providers/hashicorp/azurerm/3.71.0/docs/resources/container_registry_task) | resource |
 | [azurerm_dns_zone.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.71.0/docs/resources/dns_zone) | resource |
 | [azurerm_management_lock.rg](https://registry.terraform.io/providers/hashicorp/azurerm/3.71.0/docs/resources/management_lock) | resource |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.71.0/docs/resources/resource_group) | resource |


### PR DESCRIPTION
This task will purge images that are older than 365 days, with the exception that it will keep the 5 newest versions. This will  remove the risk of removing images that have not been updated for a year but are still being used.