### PR TITLE
Add azad kube proxy password to core key vault

### DIFF
--- a/modules/azure/aks-regional/azad-kube-proxy.tf
+++ b/modules/azure/aks-regional/azad-kube-proxy.tf
@@ -10,3 +10,9 @@ module "azad_kube_proxy" {
   display_name = local.azad_kube_proxy_name
   cluster_name = local.azad_kube_proxy_name
 }
+
+resource "azurerm_key_vault_secret" "azad_kube_proxy" {
+  name         = "azad-kube-proxy-${var.environment}-${var.location_short}-${var.name}"
+  key_vault_id = module.azad_kube_proxy.data.client_secret
+  value        = azuread_application_password.this.value
+}

--- a/modules/azure/aks-regional/azad-kube-proxy.tf
+++ b/modules/azure/aks-regional/azad-kube-proxy.tf
@@ -13,6 +13,6 @@ module "azad_kube_proxy" {
 
 resource "azurerm_key_vault_secret" "azad_kube_proxy" {
   name         = "azad-kube-proxy-${var.environment}-${var.location_short}-${var.name}"
-  key_vault_id = module.azad_kube_proxy.data.client_secret
-  value        = azuread_application_password.this.value
+  key_vault_id = data.azurerm_key_vault.core.id
+  value        = module.azad_kube_proxy.data.client_secret
 }

--- a/modules/azure/aks/aks.tf
+++ b/modules/azure/aks/aks.tf
@@ -146,119 +146,78 @@ resource "azurerm_monitor_diagnostic_setting" "log_storage_account_audit" {
   log {
     category = "kube-scheduler"
     enabled  = false
-
-    retention_policy {
-      enabled = false
-      days    = 0
-    }
   }
 
   log {
     category = "kube-controller-manager"
     enabled  = false
-
-    retention_policy {
-      enabled = false
-      days    = 0
-    }
   }
 
   log {
     category = "cloud-controller-manager"
     enabled  = false
-
-    retention_policy {
-      enabled = false
-      days    = 0
-    }
   }
 
   log {
     category = "csi-azurefile-controller"
     enabled  = false
-
-    retention_policy {
-      enabled = false
-      days    = 0
-    }
   }
 
   log {
     category = "csi-snapshot-controller"
     enabled  = false
-
-    retention_policy {
-      enabled = false
-      days    = 0
-    }
   }
 
   log {
     category = "csi-azuredisk-controller"
     enabled  = false
-
-    retention_policy {
-      enabled = false
-      days    = 0
-    }
   }
 
   log {
     category = "guard"
     enabled  = false
-
-    retention_policy {
-      enabled = false
-      days    = 0
-    }
   }
 
   log {
     category = "cluster-autoscaler"
     enabled  = false
-
-    retention_policy {
-      enabled = false
-      days    = 0
-    }
   }
 
   log {
     category = "kube-audit"
     enabled  = false
-
-    retention_policy {
-      enabled = false
-      days    = 0
-    }
   }
 
   log {
     category = "kube-audit-admin"
     enabled  = true
-
-    retention_policy {
-      enabled = true
-      days    = var.aks_audit_log_retention
-    }
   }
 
   log {
     category = "kube-apiserver"
     enabled  = false
-    retention_policy {
-      enabled = false
-      days    = 0
-    }
   }
 
   metric {
     category = "AllMetrics"
     enabled  = false
+  }
+}
 
-    retention_policy {
-      days    = 0
-      enabled = false
+resource "azurerm_storage_management_policy" "log_storage_account_audit_policy" {
+  storage_account_id = data.azurerm_storage_account.log.id
+  
+  rule {
+    name    = "logs_kube_audit_admin"
+    enabled = true
+    filters {
+      prefix_match = ["insights-logs-kube-audit-admin"]
+      blob_types   = ["appendBlob"]
+    }
+    actions {
+      base_blob {
+        delete_after_days_since_modification_greater_than = var.aks_audit_log_retention
+      }
     }
   }
 }


### PR DESCRIPTION
With the azad kube proxy password in the key vault, the kubernetes/aks-core module can be separated from the rest of aks, significantly reducing blast radius and the size of the terraform state, thereby simplifying updates of the cluster.  