### PR TITLE
Add azad kube proxy password in core key vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Changed
 
+- [#1049](https://github.com/XenitAB/terraform-modules/pull/1049) Add azad kube proxy password to core key vault.
 - [#1041](https://github.com/XenitAB/terraform-modules/pull/1041) Fix ingress-healthz YAML for linkerd.
 - [#1040](https://github.com/XenitAB/terraform-modules/pull/1040) Exclude ingress-healthz namespace from gatekeeper.
 - [#1044](https://github.com/XenitAB/terraform-modules/pull/1044) Update Spegel to v0.0.14.

--- a/modules/azure/aks-regional/README.md
+++ b/modules/azure/aks-regional/README.md
@@ -37,6 +37,7 @@ This module is used to create resources that are used by AKS clusters.
 | [azurerm_eventhub_namespace_authorization_rule.listen](https://registry.terraform.io/providers/hashicorp/azurerm/3.71.0/docs/resources/eventhub_namespace_authorization_rule) | resource |
 | [azurerm_key_vault_access_policy.datadog](https://registry.terraform.io/providers/hashicorp/azurerm/3.71.0/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/3.71.0/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_secret.azad_kube_proxy](https://registry.terraform.io/providers/hashicorp/azurerm/3.71.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.eventhub_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/3.71.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.ssh_key](https://registry.terraform.io/providers/hashicorp/azurerm/3.71.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_public_ip_prefix.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.71.0/docs/resources/public_ip_prefix) | resource |

--- a/modules/azure/aks-regional/azad-kube-proxy.tf
+++ b/modules/azure/aks-regional/azad-kube-proxy.tf
@@ -10,3 +10,9 @@ module "azad_kube_proxy" {
   display_name = local.azad_kube_proxy_name
   cluster_name = local.azad_kube_proxy_name
 }
+
+resource "azurerm_key_vault_secret" "azad_kube_proxy" {
+  name         = "azad-kube-proxy-${var.environment}-${var.location_short}-${var.name}"
+  key_vault_id = data.azurerm_key_vault.core.id
+  value        = module.azad_kube_proxy.data.client_secret
+}

--- a/modules/azure/aks-regional/azad-kube-proxy.tf
+++ b/modules/azure/aks-regional/azad-kube-proxy.tf
@@ -15,4 +15,5 @@ resource "azurerm_key_vault_secret" "azad_kube_proxy" {
   name         = "azad-kube-proxy-${var.environment}-${var.location_short}-${var.name}"
   key_vault_id = data.azurerm_key_vault.core.id
   value        = module.azad_kube_proxy.data.client_secret
+  content_type = "string"
 }

--- a/modules/azure/aks-regional/azad-kube-proxy.tf
+++ b/modules/azure/aks-regional/azad-kube-proxy.tf
@@ -11,6 +11,7 @@ module "azad_kube_proxy" {
   cluster_name = local.azad_kube_proxy_name
 }
 
+#tfsec:ignore:AZU023
 resource "azurerm_key_vault_secret" "azad_kube_proxy" {
   name         = "azad-kube-proxy-${var.environment}-${var.location_short}-${var.name}"
   key_vault_id = data.azurerm_key_vault.core.id


### PR DESCRIPTION
Add azad kube proxy password to the core key vault. This will enable the separation of the kubernetes/aks_core module from the rest of aks, thereby minimizing blast radius and simplifying maintenance of aks.