### PR TITLE
Remove delegate resource group from namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#1072](https://github.com/XenitAB/terraform-modules/pull/1072) Update Spegel to v0.0.20 and move to using chart from spegel-org.
 - [#1069](https://github.com/XenitAB/terraform-modules/pull/1069) Update external-dns to use workload identities for authentication.
 - [#1076](https://github.com/XenitAB/terraform-modules/pull/1076) Update Datadog to use workload identities.
+- [#1078](https://github.com/XenitAB/terraform-modules/pull/1078) Remove delegate resource group from namespaces.
 
 ## Fixed
 

--- a/modules/azure/aks-regional/README.md
+++ b/modules/azure/aks-regional/README.md
@@ -81,7 +81,7 @@ This module is used to create resources that are used by AKS clusters.
 | <a name="input_group_name_separator"></a> [group\_name\_separator](#input\_group\_name\_separator) | Separator for group names | `string` | `"-"` | no |
 | <a name="input_location_short"></a> [location\_short](#input\_location\_short) | The Azure region short name | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The name to use for the deploy | `string` | n/a | yes |
-| <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | The namespaces that should be created in Kubernetes | <pre>list(<br>    object({<br>      name                    = string<br>      delegate_resource_group = bool<br>    })<br>  )</pre> | n/a | yes |
+| <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | The namespaces that should be created in Kubernetes | <pre>list(<br>    object({<br>      name = string<br>    })<br>  )</pre> | n/a | yes |
 | <a name="input_public_ip_prefix_configuration"></a> [public\_ip\_prefix\_configuration](#input\_public\_ip\_prefix\_configuration) | Configuration for public IP prefix | <pre>object({<br>    count         = number<br>    prefix_length = number<br>  })</pre> | <pre>{<br>  "count": 2,<br>  "prefix_length": 30<br>}</pre> | no |
 | <a name="input_public_ip_prefix_name_override"></a> [public\_ip\_prefix\_name\_override](#input\_public\_ip\_prefix\_name\_override) | Override the default public ip prefix name - the last digit | `string` | `""` | no |
 | <a name="input_subscription_name"></a> [subscription\_name](#input\_subscription\_name) | The commonName for the subscription | `string` | n/a | yes |

--- a/modules/azure/aks-regional/aad-pod-identity.tf
+++ b/modules/azure/aks-regional/aad-pod-identity.tf
@@ -23,7 +23,6 @@ data "azuread_group" "resource_group_contributor" {
   for_each = {
     for ns in var.namespaces :
     ns.name => ns
-    if ns.delegate_resource_group == true
   }
   display_name = "${var.azure_ad_group_prefix}${var.group_name_separator}rg${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}${each.key}${var.group_name_separator}contributor"
 }
@@ -32,7 +31,6 @@ resource "azuread_group_member" "aad_pod_identity" {
   for_each = {
     for ns in var.namespaces :
     ns.name => ns
-    if ns.delegate_resource_group == true
   }
   group_object_id  = data.azuread_group.resource_group_contributor[each.key].id
   member_object_id = azurerm_user_assigned_identity.aad_pod_identity[each.key].principal_id

--- a/modules/azure/aks-regional/variables.tf
+++ b/modules/azure/aks-regional/variables.tf
@@ -27,8 +27,7 @@ variable "namespaces" {
   description = "The namespaces that should be created in Kubernetes"
   type = list(
     object({
-      name                    = string
-      delegate_resource_group = bool
+      name = string
     })
   )
 }

--- a/modules/azure/aks/README.md
+++ b/modules/azure/aks/README.md
@@ -109,7 +109,7 @@ No modules.
 | <a name="input_log_eventhub_authorization_rule_id"></a> [log\_eventhub\_authorization\_rule\_id](#input\_log\_eventhub\_authorization\_rule\_id) | The authoritzation rule id for event hub | `string` | n/a | yes |
 | <a name="input_log_eventhub_name"></a> [log\_eventhub\_name](#input\_log\_eventhub\_name) | The eventhub name for k8s logs | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The commonName to use for the deploy | `string` | n/a | yes |
-| <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | The namespaces that should be created in Kubernetes | <pre>list(<br>    object({<br>      name                    = string<br>      delegate_resource_group = bool<br>    })<br>  )</pre> | n/a | yes |
+| <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | The namespaces that should be created in Kubernetes | <pre>list(<br>    object({<br>      name = string<br>    })<br>  )</pre> | n/a | yes |
 | <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | SSH public key to add to servers | `string` | n/a | yes |
 | <a name="input_subscription_name"></a> [subscription\_name](#input\_subscription\_name) | The commonName for the subscription | `string` | n/a | yes |
 | <a name="input_unique_suffix"></a> [unique\_suffix](#input\_unique\_suffix) | Unique suffix that is used in globally unique resources names | `string` | n/a | yes |

--- a/modules/azure/aks/variables.tf
+++ b/modules/azure/aks/variables.tf
@@ -176,8 +176,7 @@ variable "namespaces" {
   description = "The namespaces that should be created in Kubernetes"
   type = list(
     object({
-      name                    = string
-      delegate_resource_group = bool
+      name = string
     })
   )
 }

--- a/modules/azure/aks/workload-identity.tf
+++ b/modules/azure/aks/workload-identity.tf
@@ -13,7 +13,6 @@ data "azuread_group" "tenant_resource_group_contributor" {
   for_each = {
     for ns in var.namespaces :
     ns.name => ns
-    if ns.delegate_resource_group == true
   }
 
   display_name = "${var.azure_ad_group_prefix}${var.group_name_separator}rg${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}${each.key}${var.group_name_separator}contributor"
@@ -23,7 +22,6 @@ resource "azuread_group_member" "tenant" {
   for_each = {
     for ns in var.namespaces :
     ns.name => ns
-    if ns.delegate_resource_group == true
   }
 
   group_object_id  = data.azuread_group.tenant_resource_group_contributor[each.key].id

--- a/modules/azure/xkf-governance-global-data/README.md
+++ b/modules/azure/xkf-governance-global-data/README.md
@@ -33,7 +33,7 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | The environemnt | `string` | n/a | yes |
 | <a name="input_group_name_prefix"></a> [group\_name\_prefix](#input\_group\_name\_prefix) | Prefix for Azure AD groups | `string` | n/a | yes |
 | <a name="input_group_name_separator"></a> [group\_name\_separator](#input\_group\_name\_separator) | Separator for group names | `string` | `"-"` | no |
-| <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | The Kubernetes namespaces to create Azure AD groups for | <pre>list(<br>    object({<br>      name                    = string<br>      delegate_resource_group = bool<br>    })<br>  )</pre> | n/a | yes |
+| <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | The Kubernetes namespaces to create Azure AD groups for | <pre>list(<br>    object({<br>      name = string<br>    })<br>  )</pre> | n/a | yes |
 | <a name="input_subscription_name"></a> [subscription\_name](#input\_subscription\_name) | The commonName for the subscription | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/azure/xkf-governance-global-data/variables.tf
+++ b/modules/azure/xkf-governance-global-data/variables.tf
@@ -12,8 +12,7 @@ variable "namespaces" {
   description = "The Kubernetes namespaces to create Azure AD groups for"
   type = list(
     object({
-      name                    = string
-      delegate_resource_group = bool
+      name = string
     })
   )
 }

--- a/modules/azure/xkf-governance-global/README.md
+++ b/modules/azure/xkf-governance-global/README.md
@@ -37,7 +37,7 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | The environemnt | `string` | n/a | yes |
 | <a name="input_group_name_prefix"></a> [group\_name\_prefix](#input\_group\_name\_prefix) | Prefix for Azure AD groups | `string` | n/a | yes |
 | <a name="input_group_name_separator"></a> [group\_name\_separator](#input\_group\_name\_separator) | Separator for group names | `string` | `"-"` | no |
-| <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | The Kubernetes namespaces to create Azure AD groups for | <pre>list(<br>    object({<br>      name                    = string<br>      delegate_resource_group = bool<br>    })<br>  )</pre> | n/a | yes |
+| <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | The Kubernetes namespaces to create Azure AD groups for | <pre>list(<br>    object({<br>      name = string<br>    })<br>  )</pre> | n/a | yes |
 | <a name="input_subscription_name"></a> [subscription\_name](#input\_subscription\_name) | The commonName for the subscription | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/azure/xkf-governance-global/delegate-xks-rg.tf
+++ b/modules/azure/xkf-governance-global/delegate-xks-rg.tf
@@ -1,9 +1,7 @@
-
 resource "azuread_group_member" "resource_group_owner" {
   for_each = {
     for ns in var.namespaces :
     ns.name => ns
-    if ns.delegate_resource_group == true
   }
   group_object_id  = azuread_group.edit[each.key].id
   member_object_id = var.azuread_groups.rg_owner[each.key].id
@@ -13,7 +11,6 @@ resource "azuread_group_member" "resource_group_contributor" {
   for_each = {
     for ns in var.namespaces :
     ns.name => ns
-    if ns.delegate_resource_group == true
   }
   group_object_id  = azuread_group.edit[each.key].id
   member_object_id = var.azuread_groups.rg_contributor[each.key].id
@@ -23,7 +20,6 @@ resource "azuread_group_member" "resource_group_reader" {
   for_each = {
     for ns in var.namespaces :
     ns.name => ns
-    if ns.delegate_resource_group == true
   }
   group_object_id  = azuread_group.view[each.key].id
   member_object_id = var.azuread_groups.rg_reader[each.key].id

--- a/modules/azure/xkf-governance-global/variables.tf
+++ b/modules/azure/xkf-governance-global/variables.tf
@@ -12,8 +12,7 @@ variable "namespaces" {
   description = "The Kubernetes namespaces to create Azure AD groups for"
   type = list(
     object({
-      name                    = string
-      delegate_resource_group = bool
+      name = string
     })
   )
 }

--- a/validation/azure/aks-regional/main.tf
+++ b/validation/azure/aks-regional/main.tf
@@ -22,8 +22,7 @@ module "aks_regional" {
   unique_suffix         = "1234"
   namespaces = [
     {
-      name                    = "team1"
-      delegate_resource_group = true
+      name = "team1"
       labels = {
         "test" = "test"
       }

--- a/validation/azure/aks/main.tf
+++ b/validation/azure/aks/main.tf
@@ -57,8 +57,7 @@ module "aks" {
   }
   namespaces = [
     {
-      name                    = "team1"
-      delegate_resource_group = true
+      name = "team1"
       labels = {
         "test" = "test"
       }

--- a/validation/azure/xkf-governance-global-data/main.tf
+++ b/validation/azure/xkf-governance-global-data/main.tf
@@ -10,8 +10,7 @@ module "xks_global" {
 
   namespaces = [
     {
-      name                    = "team1"
-      delegate_resource_group = true
+      name = "team1"
       labels = {
         "test" = "test"
       }

--- a/validation/azure/xkf-governance-global/main.tf
+++ b/validation/azure/xkf-governance-global/main.tf
@@ -10,8 +10,7 @@ module "xkf_global" {
 
   namespaces = [
     {
-      name                    = "team1"
-      delegate_resource_group = true
+      name = "team1"
       labels = {
         "test" = "test"
       }


### PR DESCRIPTION
I cannot find any use where delegate_resource_group is false. This just adds complexity to the namespace configuration so we should just completely remove it instead.