### PR TITLE
Fix Client ID set to tenant service account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## Fixed
 
 - [#1075](https://github.com/XenitAB/terraform-modules/pull/1075) Fix name collision in identities when AKS does not have unique suffix.
+- [#1079](https://github.com/XenitAB/terraform-modules/pull/1079) Fix Client ID set to tenant service account.
 
 ## 2023.10.2
 

--- a/modules/kubernetes/aks-core/main.tf
+++ b/modules/kubernetes/aks-core/main.tf
@@ -65,7 +65,7 @@ data "azurerm_container_registry" "acr" {
 data "azurerm_user_assigned_identity" "tenant" {
   for_each = { for ns in var.namespaces : ns.name => ns }
 
-  name                = "uai-${var.environment}-${var.location_short}-${var.name}${local.aks_name_suffix}-${each.key}"
+  name                = "uai-${var.environment}-${var.location_short}-${var.name}${local.aks_name_suffix}-${each.key}-wi"
   resource_group_name = data.azurerm_resource_group.this.name
 }
 


### PR DESCRIPTION
When changing the UAI name in #1075 I missed updating the datasource in aks-core.