### PR TITLE
fix(make): make lint work again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ override.tf.json
 
 .terraform.lock.hcl
 .terraform.lock.hcl*
+
+# tflint plugins
+tflint/*

--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,11 @@ lint:
 	echo lint: Start
 	MODULE_GROUPS=$$(find modules -mindepth 1 -maxdepth 1 -type d)
 	for MODULE_GROUP in $${MODULE_GROUPS}; do
-		tflint --init -c $${MODULE_GROUP}/.tflint.hcl
+		tflint --init -c .tflint.hcl --chdir $${MODULE_GROUP}
 		MODULES=$$(find $${MODULE_GROUP} -mindepth 1 -maxdepth 1 -type d)
 		for MODULE in $$MODULES; do
 			echo lint: $${MODULE}
-			tflint -c $${MODULE_GROUP}/.tflint.hcl $${MODULE}
+			tflint -c ../.tflint.hcl --chdir $${MODULE}
 		done
 	done
 	echo lint: Success

--- a/modules/azure/.tflint.hcl
+++ b/modules/azure/.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "azurerm" {
   enabled = true
-  version = "0.18.0"
+  version = "0.26.0"
   source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
 }
 

--- a/modules/kubernetes/.tflint.hcl
+++ b/modules/kubernetes/.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "azurerm" {
   enabled = true
-  version = "0.18.0"
+  version = "0.26.0"
   source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
 }
 


### PR DESCRIPTION
This PR upgrades the azurerm tflint plugin to latest version 0.26 and fixes the make script to work again.