### PR TITLE
fix: missing namespace labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Changed
 
+- [#1095](https://github.com/XenitAB/terraform-modules/pull/1095) fix: missing namespace labels
 - [#1082](https://github.com/XenitAB/terraform-modules/pull/1082) feat!: bump and migrate azure-metrics to workload identity and install with flux
 - [#1091](https://github.com/XenitAB/terraform-modules/pull/1091) fix(make): make lint work again
 - [#1090](https://github.com/XenitAB/terraform-modules/pull/1090) Fix aad-pod-identity kustomization healthcheck.

--- a/modules/kubernetes/aad-pod-identity/templates/aad-pod-identity.yaml.tpl
+++ b/modules/kubernetes/aad-pod-identity/templates/aad-pod-identity.yaml.tpl
@@ -3,8 +3,8 @@ kind: Namespace
 metadata:
  name: aad-pod-identity
  labels:
-   name              = "aad-pod-identity"
-   xkf.xenit.io/kind = "platform"
+   name: aad-pod-identity
+   xkf.xenit.io/kind: platform
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/modules/kubernetes/azad-kube-proxy/templates/azad-kube-proxy.yaml.tpl
+++ b/modules/kubernetes/azad-kube-proxy/templates/azad-kube-proxy.yaml.tpl
@@ -3,8 +3,8 @@ kind: Namespace
 metadata:
  name: azad-kube-proxy
  labels:
-   name              = "azad-kube-proxy"
-   xkf.xenit.io/kind = "platform"
+   name: azad-kube-proxy
+   xkf.xenit.io/kind: platform
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/modules/kubernetes/cert-manager/templates/cert-manager.yaml.tpl
+++ b/modules/kubernetes/cert-manager/templates/cert-manager.yaml.tpl
@@ -3,8 +3,8 @@ kind: Namespace
 metadata:
  name: cert-manager
  labels:
-   name              = "cert-manager"
-   xkf.xenit.io/kind = "platform"
+   name: cert-manager
+   xkf.xenit.io/kind: platform
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/modules/kubernetes/control-plane-logs/templates/vector.yaml.tpl
+++ b/modules/kubernetes/control-plane-logs/templates/vector.yaml.tpl
@@ -3,8 +3,8 @@ kind: Namespace
 metadata:
  name: controle-plane-logs
  labels:
-   name              = "vector"
-   xkf.xenit.io/kind = "platform"
+   name: controle-plane-logs
+   xkf.xenit.io/kind: platform
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/modules/kubernetes/falco/templates/falco.yaml.tpl
+++ b/modules/kubernetes/falco/templates/falco.yaml.tpl
@@ -3,8 +3,8 @@ kind: Namespace
 metadata:
  name: falco
  labels:
-   name              = "falco"
-   xkf.xenit.io/kind = "platform"
+   name: falco
+   xkf.xenit.io/kind: platform
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/modules/kubernetes/ingress-healthz/templates/ingress-healthz.yaml.tpl
+++ b/modules/kubernetes/ingress-healthz/templates/ingress-healthz.yaml.tpl
@@ -3,8 +3,8 @@ kind: Namespace
 metadata:
  name: ingress-healthz
  labels:
-   name              = "ingress-healthz"
-   xkf.xenit.io/kind = "platform"
+   name: ingress-healthz
+   xkf.xenit.io/kind: platform
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/modules/kubernetes/ingress-nginx/templates/namespace.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/namespace.yaml.tpl
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
  name: ingress-nginx
  labels:
-   name              = "ingress-nginx"
-   xkf.xenit.io/kind = "platform"
+   name: ingress-nginx
+   xkf.xenit.io/kind: platform

--- a/modules/kubernetes/node-ttl/templates/node-ttl.yaml.tpl
+++ b/modules/kubernetes/node-ttl/templates/node-ttl.yaml.tpl
@@ -3,8 +3,8 @@ kind: Namespace
 metadata:
  name: node-ttl
  labels:
-   name              = "node-ttl"
-   xkf.xenit.io/kind = "platform"
+   name: node-ttl
+   xkf.xenit.io/kind: platform
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/modules/kubernetes/promtail/templates/promtail.yaml.tpl
+++ b/modules/kubernetes/promtail/templates/promtail.yaml.tpl
@@ -3,8 +3,8 @@ kind: Namespace
 metadata:
  name: promtail
  labels:
-   name              = "promtail"
-   xkf.xenit.io/kind = "platform"
+   name: promtail
+   xkf.xenit.io/kind: platform
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/modules/kubernetes/reloader/templates/reloader.yaml.tpl
+++ b/modules/kubernetes/reloader/templates/reloader.yaml.tpl
@@ -3,8 +3,8 @@ kind: Namespace
 metadata:
  name: reloader
  labels:
-   name              = "reloader"
-   xkf.xenit.io/kind = "platform"
+   name: reloader
+   xkf.xenit.io/kind: platform
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/modules/kubernetes/spegel/templates/spegel.yaml.tpl
+++ b/modules/kubernetes/spegel/templates/spegel.yaml.tpl
@@ -3,8 +3,8 @@ kind: Namespace
 metadata:
  name: spegel
  labels:
-   name              = "spegel"
-   xkf.xenit.io/kind = "platform"
+   name: spegel
+   xkf.xenit.io/kind: platform
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/modules/kubernetes/trivy/templates/trivy.yaml.tpl
+++ b/modules/kubernetes/trivy/templates/trivy.yaml.tpl
@@ -3,8 +3,8 @@ kind: Namespace
 metadata:
  name: trivy
  labels:
-   name              = "trivy"
-   xkf.xenit.io/kind = "platform"
+   name: trivy
+   xkf.xenit.io/kind: platform
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/modules/kubernetes/velero/templates/velero.yaml.tpl
+++ b/modules/kubernetes/velero/templates/velero.yaml.tpl
@@ -3,8 +3,8 @@ kind: Namespace
 metadata:
  name: velero
  labels:
-   name              = "velero"
-   xkf.xenit.io/kind = "platform"
+   name: velero
+   xkf.xenit.io/kind: platform
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/modules/kubernetes/vpa/templates/vpa.yaml.tpl
+++ b/modules/kubernetes/vpa/templates/vpa.yaml.tpl
@@ -3,8 +3,8 @@ kind: Namespace
 metadata:
  name: vpa
  labels:
-   name              = "vpa"
-   xkf.xenit.io/kind = "platform"
+   name: vpa
+   xkf.xenit.io/kind: platform
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository


### PR DESCRIPTION
This PR fixes syntax errors in Kubernetes manifest files that create namespaces for the kubernetes modules.