### PR TITLE
Fix: Velero storage account name format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Changed
 
+- [#1105](https://github.com/XenitAB/terraform-modules/pull/1105) Fix: Velero storage account name format
 - [#1101](https://github.com/XenitAB/terraform-modules/pull/1101) feat: migrate remaining platform components to workload identity
 - [#1098](https://github.com/XenitAB/terraform-modules/pull/1084) feat: migrate grafana-agent to install with flux
 - [#1102](https://github.com/XenitAB/terraform-modules/pull/1102) fix: deployment name in ingress-nginx healthcheck.

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -567,6 +567,7 @@ module "velero" {
   resource_group_name = data.azurerm_resource_group.this.name
   subscription_id     = data.azurerm_client_config.current.subscription_id
   unique_suffix       = var.unique_suffix
+  environment         = var.environment
 }
 
 module "vpa" {

--- a/modules/kubernetes/velero/README.md
+++ b/modules/kubernetes/velero/README.md
@@ -44,6 +44,7 @@ No modules.
 | <a name="input_aks_managed_identity"></a> [aks\_managed\_identity](#input\_aks\_managed\_identity) | AKS Azure AD managed identity | `string` | n/a | yes |
 | <a name="input_azure_config"></a> [azure\_config](#input\_azure\_config) | Azure specific configuration | <pre>object({<br>    storage_account_name      = string,<br>    storage_account_container = string<br>  })</pre> | <pre>{<br>  "storage_account_container": "",<br>  "storage_account_name": ""<br>}</pre> | no |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | Unique identifier of the cluster across regions and instances. | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | The environment name to use for the deploy | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The Azure region name. | `string` | n/a | yes |
 | <a name="input_oidc_issuer_url"></a> [oidc\_issuer\_url](#input\_oidc\_issuer\_url) | Kubernetes OIDC issuer URL for workload identity. | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The Azure resource group name | `string` | n/a | yes |

--- a/modules/kubernetes/velero/main.tf
+++ b/modules/kubernetes/velero/main.tf
@@ -31,8 +31,10 @@ resource "git_repository_file" "velero" {
   content = templatefile("${path.module}/templates/velero.yaml.tpl", {
     azure_config        = var.azure_config,
     client_id           = azurerm_user_assigned_identity.velero.client_id,
+    environment         = var.environment,
     resource_group_name = var.resource_group_name,
     subscription_id     = var.subscription_id,
+    unique_suffix       = var.unique_suffix,
   })
 }
 

--- a/modules/kubernetes/velero/storage.tf
+++ b/modules/kubernetes/velero/storage.tf
@@ -1,6 +1,6 @@
 #tfsec:ignore:azure-storage-queue-services-logging-enabled
 resource "azurerm_storage_account" "velero" {
-  name                            = "strg${var.cluster_id}velero${var.unique_suffix}"
+  name                            = var.azure_config.storage_account_name == "" ? "strg${var.environment}velero${var.unique_suffix}" : var.azure_config.storage_account_name
   resource_group_name             = var.resource_group_name
   location                        = var.location
   account_tier                    = "Standard"
@@ -12,6 +12,6 @@ resource "azurerm_storage_account" "velero" {
 
 resource "azurerm_storage_container" "velero" {
   storage_account_name  = azurerm_storage_account.velero.name
-  name                  = "backup"
+  name                  = var.azure_config.storage_account_container == "" ? "backup" : var.azure_config.storage_account_container
   container_access_type = "private"
 }

--- a/modules/kubernetes/velero/templates/velero.yaml.tpl
+++ b/modules/kubernetes/velero/templates/velero.yaml.tpl
@@ -36,24 +36,32 @@ spec:
       logFormat: "json"
       backupStorageLocation:
         name: "default"
+        %{ if azure_config.storage_account_container != "" }
         bucket: "${azure_config.storage_account_container}"
+        %{ endif }
+        %{ else }
+        bucket: "strg${environment}velero${unique_suffix}"
+        %{ endif }
         config:
           resourceGroup: "${resource_group_name}"
-          storageAccount: "${azure_config.storage_account_name}"
+          %{ if azure_config.storage_account_name != "" }
+          storageAccount: "${azure_config.storage_account_name"
+          %{ endif }
+          %{ else }
+          storageAccount: "strg${environment}velero${unique_suffix}"
+          %{ endif }
     snapshotsEnable: false
-    # Yes this is needed even if it duplicates data
-    # https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure#option-2-use-aad-pod-identity
     credentials:
     secretContents:
         cloud: |
-        AZURE_SUBSCRIPTION_ID=${subscription_id}
-        AZURE_RESOURCE_GROUP=${resource_group_name}
-        AZURE_CLOUD_NAME=AzurePublicCloud
+          AZURE_SUBSCRIPTION_ID=${subscription_id}
+          AZURE_RESOURCE_GROUP=${resource_group_name}
+          AZURE_CLOUD_NAME=AzurePublicCloud
     initContainers:
-    - name: "velero-plugin-for-microsoft-azure"
+      - name: "velero-plugin-for-microsoft-azure"
         image: "velero/velero-plugin-for-microsoft-azure:v1.1.1"
         volumeMounts:
-        - mountPath: "/target"
+          - mountPath: "/target"
             name: "plugins"
     podLabels:
       azure.workload.identity/use: "true"

--- a/modules/kubernetes/velero/templates/velero.yaml.tpl
+++ b/modules/kubernetes/velero/templates/velero.yaml.tpl
@@ -45,7 +45,7 @@ spec:
         config:
           resourceGroup: "${resource_group_name}"
           %{ if azure_config.storage_account_name != "" }
-          storageAccount: "${azure_config.storage_account_name"
+          storageAccount: "${azure_config.storage_account_name}"
           %{ endif }
           %{ else }
           storageAccount: "strg${environment}velero${unique_suffix}"

--- a/modules/kubernetes/velero/templates/velero.yaml.tpl
+++ b/modules/kubernetes/velero/templates/velero.yaml.tpl
@@ -38,7 +38,6 @@ spec:
         name: "default"
         %{ if azure_config.storage_account_container != "" }
         bucket: "${azure_config.storage_account_container}"
-        %{ endif }
         %{ else }
         bucket: "strg${environment}velero${unique_suffix}"
         %{ endif }
@@ -46,7 +45,6 @@ spec:
           resourceGroup: "${resource_group_name}"
           %{ if azure_config.storage_account_name != "" }
           storageAccount: "${azure_config.storage_account_name}"
-          %{ endif }
           %{ else }
           storageAccount: "strg${environment}velero${unique_suffix}"
           %{ endif }

--- a/modules/kubernetes/velero/variables.tf
+++ b/modules/kubernetes/velero/variables.tf
@@ -45,3 +45,8 @@ variable "unique_suffix" {
   type        = string
   default     = ""
 }
+
+variable "environment" {
+  description = "The environment name to use for the deploy"
+  type        = string
+}

--- a/validation/kubernetes/velero/main.tf
+++ b/validation/kubernetes/velero/main.tf
@@ -13,6 +13,7 @@ module "velero" {
     storage_account_container = "name"
   }
   cluster_id          = "we-dev-aks1"
+  environment         = "dev"
   location            = "we"
   oidc_issuer_url     = "url"
   resource_group_name = "rg-name"


### PR DESCRIPTION
This fixes issue with `-` in the name for velero storage account, also makes the name of the SA and SA container configurable if one wants/needs to do that.