### PR TITLE
chore: bump azuread provider to v2.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## Changed
+
+- [#1108](https://github.com/XenitAB/terraform-modules/pull/1108) chore: bump azuread provider to v2.50.0
+
 ## 2024.05.1
 
 ## Added

--- a/modules/azure-ad/azad-kube-proxy/README.md
+++ b/modules/azure-ad/azad-kube-proxy/README.md
@@ -7,14 +7,14 @@ This module is used to configure the Azure AD Application used by [`azad-kube-pr
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.47.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.50.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.5.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.47.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.50.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules
@@ -25,15 +25,15 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azuread_app_role_assignment.ms_graph_directory_read_all](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/app_role_assignment) | resource |
-| [azuread_application.this](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/application) | resource |
-| [azuread_application_password.this](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/application_password) | resource |
-| [azuread_application_pre_authorized.azure_cli](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/application_pre_authorized) | resource |
-| [azuread_service_principal.ms_graph](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/service_principal) | resource |
-| [azuread_service_principal.this](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/service_principal) | resource |
+| [azuread_app_role_assignment.ms_graph_directory_read_all](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/app_role_assignment) | resource |
+| [azuread_application.this](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/application) | resource |
+| [azuread_application_password.this](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/application_password) | resource |
+| [azuread_application_pre_authorized.azure_cli](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/application_pre_authorized) | resource |
+| [azuread_service_principal.ms_graph](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/service_principal) | resource |
+| [azuread_service_principal.this](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/service_principal) | resource |
 | [random_uuid.oauth2_permission_scope_user_impersonation](https://registry.terraform.io/providers/hashicorp/random/3.5.1/docs/resources/uuid) | resource |
-| [azuread_application_published_app_ids.well_known](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/application_published_app_ids) | data source |
-| [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/client_config) | data source |
+| [azuread_application_published_app_ids.well_known](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/application_published_app_ids) | data source |
+| [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/client_config) | data source |
 
 ## Inputs
 

--- a/modules/azure-ad/azad-kube-proxy/main.tf
+++ b/modules/azure-ad/azad-kube-proxy/main.tf
@@ -9,7 +9,7 @@ terraform {
 
   required_providers {
     azuread = {
-      version = "2.47.0"
+      version = "2.50.0"
       source  = "hashicorp/azuread"
     }
     random = {

--- a/modules/azure/aks-global/README.md
+++ b/modules/azure/aks-global/README.md
@@ -3,14 +3,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.47.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.50.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.99.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.47.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.50.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.99.0 |
 
 ## Modules
@@ -30,9 +30,9 @@ No modules.
 | [azurerm_role_assignment.acr_push](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.acr_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
-| [azuread_group.acr_pull](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/group) | data source |
-| [azuread_group.acr_push](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/group) | data source |
-| [azuread_group.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/group) | data source |
+| [azuread_group.acr_pull](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
+| [azuread_group.acr_push](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
+| [azuread_group.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
 
 ## Inputs
 

--- a/modules/azure/aks-global/main.tf
+++ b/modules/azure/aks-global/main.tf
@@ -6,7 +6,7 @@ terraform {
       source  = "hashicorp/azurerm"
     }
     azuread = {
-      version = "2.47.0"
+      version = "2.50.0"
       source  = "hashicorp/azuread"
     }
   }

--- a/modules/azure/aks-regional/README.md
+++ b/modules/azure/aks-regional/README.md
@@ -7,7 +7,7 @@ This module is used to create resources that are used by AKS clusters.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.47.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.50.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.99.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.5.1 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | 4.0.4 |
@@ -16,7 +16,7 @@ This module is used to create resources that are used by AKS clusters.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.47.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.50.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.99.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.4 |
 
@@ -30,7 +30,7 @@ This module is used to create resources that are used by AKS clusters.
 
 | Name | Type |
 |------|------|
-| [azuread_group_member.aad_pod_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
+| [azuread_group_member.aad_pod_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
 | [azurerm_eventhub.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/eventhub) | resource |
 | [azurerm_eventhub_namespace.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/eventhub_namespace) | resource |
 | [azurerm_eventhub_namespace_authorization_rule.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/eventhub_namespace_authorization_rule) | resource |
@@ -46,7 +46,7 @@ This module is used to create resources that are used by AKS clusters.
 | [azurerm_user_assigned_identity.aad_pod_identity](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/user_assigned_identity) | resource |
 | [azurerm_user_assigned_identity.xenit](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/user_assigned_identity) | resource |
 | [tls_private_key.ssh_key](https://registry.terraform.io/providers/hashicorp/tls/4.0.4/docs/resources/private_key) | resource |
-| [azuread_group.resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/group) | data source |
+| [azuread_group.resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/client_config) | data source |
 | [azurerm_key_vault.core](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/key_vault) | data source |
 | [azurerm_resource_group.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/resource_group) | data source |

--- a/modules/azure/aks-regional/main.tf
+++ b/modules/azure/aks-regional/main.tf
@@ -13,7 +13,7 @@ terraform {
       source  = "hashicorp/azurerm"
     }
     azuread = {
-      version = "2.47.0"
+      version = "2.50.0"
       source  = "hashicorp/azuread"
     }
     random = {

--- a/modules/azure/aks/README.md
+++ b/modules/azure/aks/README.md
@@ -14,7 +14,7 @@ https://pumpingco.de/blog/modify-aks-default-node-pool-in-terraform-without-rede
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.47.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.50.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.99.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.5.1 |
 
@@ -22,7 +22,7 @@ https://pumpingco.de/blog/modify-aks-default-node-pool-in-terraform-without-rede
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.47.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.50.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.99.0 |
 
 ## Modules
@@ -33,9 +33,9 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azuread_group_member.aks_cluster_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
-| [azuread_group_member.aks_managed_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
-| [azuread_group_member.tenant](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
+| [azuread_group_member.aks_cluster_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
+| [azuread_group_member.aks_managed_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
+| [azuread_group_member.tenant](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
 | [azurerm_federated_identity_credential.tenant](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/federated_identity_credential) | resource |
 | [azurerm_kubernetes_cluster.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/kubernetes_cluster) | resource |
 | [azurerm_kubernetes_cluster_node_pool.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/kubernetes_cluster_node_pool) | resource |
@@ -57,7 +57,7 @@ No modules.
 | [azurerm_security_center_subscription_pricing.containers](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/security_center_subscription_pricing) | resource |
 | [azurerm_storage_management_policy.log_storage_account_audit_policy](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/storage_management_policy) | resource |
 | [azurerm_user_assigned_identity.tenant](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/user_assigned_identity) | resource |
-| [azuread_group.tenant_resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/group) | data source |
+| [azuread_group.tenant_resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
 | [azurerm_resource_group.aks](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.log](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/resource_group) | data source |

--- a/modules/azure/aks/main.tf
+++ b/modules/azure/aks/main.tf
@@ -21,7 +21,7 @@ terraform {
       source  = "hashicorp/azurerm"
     }
     azuread = {
-      version = "2.47.0"
+      version = "2.50.0"
       source  = "hashicorp/azuread"
     }
     random = {

--- a/modules/azure/core/README.md
+++ b/modules/azure/core/README.md
@@ -9,7 +9,7 @@ Easiest is to define this RG in the governance module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.47.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.50.0 |
 | <a name="requirement_azurecaf"></a> [azurecaf](#requirement\_azurecaf) | 2.0.0-preview3 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.99.0 |
 
@@ -17,7 +17,7 @@ Easiest is to define this RG in the governance module.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.47.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.50.0 |
 | <a name="provider_azurecaf"></a> [azurecaf](#provider\_azurecaf) | 2.0.0-preview3 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.99.0 |
 
@@ -47,7 +47,7 @@ Easiest is to define this RG in the governance module.
 | [azurerm_subnet_route_table_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet_route_table_association) | resource |
 | [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/virtual_network) | resource |
 | [azurerm_virtual_network_peering.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/virtual_network_peering) | resource |
-| [azuread_group.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/group) | data source |
+| [azuread_group.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
 | [azurecaf_name.azuread_group_service_endpoint_join](https://registry.terraform.io/providers/aztfmod/azurecaf/2.0.0-preview3/docs/data-sources/name) | data source |
 | [azurecaf_name.azurerm_monitor_action_group_this](https://registry.terraform.io/providers/aztfmod/azurecaf/2.0.0-preview3/docs/data-sources/name) | data source |
 | [azurecaf_name.azurerm_network_security_group_this](https://registry.terraform.io/providers/aztfmod/azurecaf/2.0.0-preview3/docs/data-sources/name) | data source |

--- a/modules/azure/core/main.tf
+++ b/modules/azure/core/main.tf
@@ -15,7 +15,7 @@ terraform {
       source  = "hashicorp/azurerm"
     }
     azuread = {
-      version = "2.47.0"
+      version = "2.50.0"
       source  = "hashicorp/azuread"
     }
     azurecaf = {

--- a/modules/azure/governance-global/README.md
+++ b/modules/azure/governance-global/README.md
@@ -7,7 +7,7 @@ This module is used for governance on a global level and not using any specific 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.47.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.50.0 |
 | <a name="requirement_azurecaf"></a> [azurecaf](#requirement\_azurecaf) | 2.0.0-preview3 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.99.0 |
 | <a name="requirement_pal"></a> [pal](#requirement\_pal) | 0.2.5 |
@@ -17,7 +17,7 @@ This module is used for governance on a global level and not using any specific 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.47.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.50.0 |
 | <a name="provider_azurecaf"></a> [azurecaf](#provider\_azurecaf) | 2.0.0-preview3 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.99.0 |
 | <a name="provider_pal"></a> [pal](#provider\_pal) | 0.2.5 |
@@ -32,50 +32,50 @@ This module is used for governance on a global level and not using any specific 
 
 | Name | Type |
 |------|------|
-| [azuread_application.aad_app](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/application) | resource |
-| [azuread_application.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/application) | resource |
-| [azuread_application.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/application) | resource |
-| [azuread_application_password.aad_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/application_password) | resource |
-| [azuread_application_password.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/application_password) | resource |
-| [azuread_group.acr_pull](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group) | resource |
-| [azuread_group.acr_push](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group) | resource |
-| [azuread_group.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group) | resource |
-| [azuread_group.rg_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group) | resource |
-| [azuread_group.rg_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group) | resource |
-| [azuread_group.rg_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group) | resource |
-| [azuread_group.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group) | resource |
-| [azuread_group.sub_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group) | resource |
-| [azuread_group.sub_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group) | resource |
-| [azuread_group.sub_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group) | resource |
-| [azuread_group_member.acr_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
-| [azuread_group_member.acr_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
-| [azuread_group_member.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
-| [azuread_group_member.acr_reader_rg_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
-| [azuread_group_member.acr_reader_rg_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
-| [azuread_group_member.acr_reader_rg_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
-| [azuread_group_member.acr_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
-| [azuread_group_member.service_endpoint_join_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
-| [azuread_group_member.service_endpoint_join_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
-| [azuread_group_member.service_endpoint_join_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
-| [azuread_group_member.sp_all_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
-| [azuread_group_member.sub_all_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
-| [azuread_group_member.sub_all_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
-| [azuread_group_member.sub_all_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
-| [azuread_service_principal.aad_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/service_principal) | resource |
-| [azuread_service_principal.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/service_principal) | resource |
-| [azuread_service_principal.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/service_principal) | resource |
+| [azuread_application.aad_app](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/application) | resource |
+| [azuread_application.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/application) | resource |
+| [azuread_application.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/application) | resource |
+| [azuread_application_password.aad_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/application_password) | resource |
+| [azuread_application_password.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/application_password) | resource |
+| [azuread_group.acr_pull](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
+| [azuread_group.acr_push](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
+| [azuread_group.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
+| [azuread_group.rg_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
+| [azuread_group.rg_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
+| [azuread_group.rg_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
+| [azuread_group.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
+| [azuread_group.sub_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
+| [azuread_group.sub_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
+| [azuread_group.sub_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
+| [azuread_group_member.acr_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
+| [azuread_group_member.acr_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
+| [azuread_group_member.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
+| [azuread_group_member.acr_reader_rg_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
+| [azuread_group_member.acr_reader_rg_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
+| [azuread_group_member.acr_reader_rg_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
+| [azuread_group_member.acr_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
+| [azuread_group_member.service_endpoint_join_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
+| [azuread_group_member.service_endpoint_join_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
+| [azuread_group_member.service_endpoint_join_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
+| [azuread_group_member.sp_all_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
+| [azuread_group_member.sub_all_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
+| [azuread_group_member.sub_all_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
+| [azuread_group_member.sub_all_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
+| [azuread_service_principal.aad_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/service_principal) | resource |
+| [azuread_service_principal.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/service_principal) | resource |
+| [azuread_service_principal.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/service_principal) | resource |
 | [azurerm_role_assignment.sub_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.sub_owner](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.sub_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
 | [pal_management_partner.aad_sp](https://registry.terraform.io/providers/xenitab/pal/0.2.5/docs/resources/management_partner) | resource |
 | [pal_management_partner.owner_spn](https://registry.terraform.io/providers/xenitab/pal/0.2.5/docs/resources/management_partner) | resource |
-| [azuread_application.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/application) | data source |
-| [azuread_group.all_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/group) | data source |
-| [azuread_group.all_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/group) | data source |
-| [azuread_group.all_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/group) | data source |
-| [azuread_service_principal.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/service_principal) | data source |
-| [azuread_service_principal.sp_all_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/service_principal) | data source |
+| [azuread_application.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/application) | data source |
+| [azuread_group.all_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
+| [azuread_group.all_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
+| [azuread_group.all_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
+| [azuread_service_principal.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/service_principal) | data source |
+| [azuread_service_principal.sp_all_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/service_principal) | data source |
 | [azurecaf_name.azuread_application_aad_app](https://registry.terraform.io/providers/aztfmod/azurecaf/2.0.0-preview3/docs/data-sources/name) | data source |
 | [azurecaf_name.azuread_application_delegate_kv_aad](https://registry.terraform.io/providers/aztfmod/azurecaf/2.0.0-preview3/docs/data-sources/name) | data source |
 | [azurecaf_name.azuread_application_sub_reader_sp](https://registry.terraform.io/providers/aztfmod/azurecaf/2.0.0-preview3/docs/data-sources/name) | data source |

--- a/modules/azure/governance-global/main.tf
+++ b/modules/azure/governance-global/main.tf
@@ -13,7 +13,7 @@ terraform {
       source  = "hashicorp/azurerm"
     }
     azuread = {
-      version = "2.47.0"
+      version = "2.50.0"
       source  = "hashicorp/azuread"
     }
     random = {

--- a/modules/azure/governance-regional/README.md
+++ b/modules/azure/governance-regional/README.md
@@ -7,7 +7,7 @@ This module is used for governance on a regional level and not using any specifi
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.47.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.50.0 |
 | <a name="requirement_azurecaf"></a> [azurecaf](#requirement\_azurecaf) | 2.0.0-preview3 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.99.0 |
 | <a name="requirement_pal"></a> [pal](#requirement\_pal) | 0.2.5 |
@@ -17,7 +17,7 @@ This module is used for governance on a regional level and not using any specifi
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.47.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.50.0 |
 | <a name="provider_azurecaf"></a> [azurecaf](#provider\_azurecaf) | 2.0.0-preview3 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.99.0 |
 
@@ -31,8 +31,8 @@ This module is used for governance on a regional level and not using any specifi
 
 | Name | Type |
 |------|------|
-| [azuread_application_password.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/application_password) | resource |
-| [azuread_application_password.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/application_password) | resource |
+| [azuread_application_password.delegate_kv_aad](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/application_password) | resource |
+| [azuread_application_password.sub_reader_sp](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/application_password) | resource |
 | [azurerm_key_vault.delegate_kv](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/key_vault) | resource |
 | [azurerm_key_vault_access_policy.ap_kvreader_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.ap_owner_spn](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/key_vault_access_policy) | resource |
@@ -49,7 +49,7 @@ This module is used for governance on a regional level and not using any specifi
 | [azurerm_role_assignment.rg_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.rg_owner](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.rg_reader](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/role_assignment) | resource |
-| [azuread_service_principal.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/service_principal) | data source |
+| [azuread_service_principal.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/service_principal) | data source |
 | [azurecaf_name.azurerm_key_vault_delegate_kv](https://registry.terraform.io/providers/aztfmod/azurecaf/2.0.0-preview3/docs/data-sources/name) | data source |
 | [azurecaf_name.azurerm_resource_group_rg](https://registry.terraform.io/providers/aztfmod/azurecaf/2.0.0-preview3/docs/data-sources/name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/client_config) | data source |

--- a/modules/azure/governance-regional/main.tf
+++ b/modules/azure/governance-regional/main.tf
@@ -13,7 +13,7 @@ terraform {
       source  = "hashicorp/azurerm"
     }
     azuread = {
-      version = "2.47.0"
+      version = "2.50.0"
       source  = "hashicorp/azuread"
     }
     random = {

--- a/modules/azure/hub/README.md
+++ b/modules/azure/hub/README.md
@@ -11,14 +11,14 @@ Use together with the `core` module to create a peered network where SPOF (singl
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.47.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.50.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.99.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.47.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.50.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.99.0 |
 
 ## Modules
@@ -40,7 +40,7 @@ No modules.
 | [azurerm_subnet_network_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/subnet_network_security_group_association) | resource |
 | [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/virtual_network) | resource |
 | [azurerm_virtual_network_peering.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/resources/virtual_network_peering) | resource |
-| [azuread_group.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/group) | data source |
+| [azuread_group.service_endpoint_join](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/resource_group) | data source |
 
 ## Inputs

--- a/modules/azure/hub/main.tf
+++ b/modules/azure/hub/main.tf
@@ -17,7 +17,7 @@ terraform {
       source  = "hashicorp/azurerm"
     }
     azuread = {
-      version = "2.47.0"
+      version = "2.50.0"
       source  = "hashicorp/azuread"
     }
   }

--- a/modules/azure/xkf-governance-global-data/README.md
+++ b/modules/azure/xkf-governance-global-data/README.md
@@ -3,14 +3,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.47.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.50.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.99.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.47.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.50.0 |
 
 ## Modules
 
@@ -20,11 +20,11 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azuread_group.aks_managed_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/group) | data source |
-| [azuread_group.cluster_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/group) | data source |
-| [azuread_group.cluster_view](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/group) | data source |
-| [azuread_group.edit](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/group) | data source |
-| [azuread_group.view](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/group) | data source |
+| [azuread_group.aks_managed_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
+| [azuread_group.cluster_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
+| [azuread_group.cluster_view](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
+| [azuread_group.edit](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
+| [azuread_group.view](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
 
 ## Inputs
 

--- a/modules/azure/xkf-governance-global-data/main.tf
+++ b/modules/azure/xkf-governance-global-data/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.1.7"
   required_providers {
     azuread = {
-      version = "2.47.0"
+      version = "2.50.0"
       source  = "hashicorp/azuread"
     }
     azurerm = {

--- a/modules/azure/xkf-governance-global/README.md
+++ b/modules/azure/xkf-governance-global/README.md
@@ -3,14 +3,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.7 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.47.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.50.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.99.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.47.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.50.0 |
 
 ## Modules
 
@@ -20,14 +20,14 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azuread_group.aks_managed_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group) | resource |
-| [azuread_group.cluster_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group) | resource |
-| [azuread_group.cluster_view](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group) | resource |
-| [azuread_group.edit](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group) | resource |
-| [azuread_group.view](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group) | resource |
-| [azuread_group_member.resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
-| [azuread_group_member.resource_group_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
-| [azuread_group_member.resource_group_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/resources/group_member) | resource |
+| [azuread_group.aks_managed_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
+| [azuread_group.cluster_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
+| [azuread_group.cluster_view](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
+| [azuread_group.edit](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
+| [azuread_group.view](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
+| [azuread_group_member.resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
+| [azuread_group_member.resource_group_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
+| [azuread_group_member.resource_group_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group_member) | resource |
 
 ## Inputs
 

--- a/modules/azure/xkf-governance-global/main.tf
+++ b/modules/azure/xkf-governance-global/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.1.7"
   required_providers {
     azuread = {
-      version = "2.47.0"
+      version = "2.50.0"
       source  = "hashicorp/azuread"
     }
     azurerm = {

--- a/modules/kubernetes/aks-core/README.md
+++ b/modules/kubernetes/aks-core/README.md
@@ -7,7 +7,7 @@ This module is used to create AKS clusters.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.47.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.50.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.99.0 |
 | <a name="requirement_flux"></a> [flux](#requirement\_flux) | 0.25.3 |
 | <a name="requirement_github"></a> [github](#requirement\_github) | 5.34.0 |
@@ -20,7 +20,7 @@ This module is used to create AKS clusters.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.47.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.50.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.99.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.11.0 |
 | <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | 1.14.0 |
@@ -103,7 +103,7 @@ This module is used to create AKS clusters.
 | [kubernetes_storage_class.azurefile_zrs_standard](https://registry.terraform.io/providers/hashicorp/kubernetes/2.23.0/docs/resources/storage_class) | resource |
 | [kubernetes_storage_class.zrs_premium](https://registry.terraform.io/providers/hashicorp/kubernetes/2.23.0/docs/resources/storage_class) | resource |
 | [kubernetes_storage_class.zrs_standard](https://registry.terraform.io/providers/hashicorp/kubernetes/2.23.0/docs/resources/storage_class) | resource |
-| [azuread_group.aks_managed_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.47.0/docs/data-sources/group) | data source |
+| [azuread_group.aks_managed_identity](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/client_config) | data source |
 | [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/container_registry) | data source |
 | [azurerm_dns_zone.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.99.0/docs/data-sources/dns_zone) | data source |

--- a/modules/kubernetes/aks-core/main.tf
+++ b/modules/kubernetes/aks-core/main.tf
@@ -13,7 +13,7 @@ terraform {
       source  = "hashicorp/azurerm"
     }
     azuread = {
-      version = "2.47.0"
+      version = "2.50.0"
       source  = "hashicorp/azuread"
     }
     random = {


### PR DESCRIPTION
This PR bumps the version of the azuread provider to v2.50.0