### PR TITLE
fix: allow prometheus-node-exporter to use host network/port

### DIFF
--- a/modules/kubernetes/azure-policy/main.tf
+++ b/modules/kubernetes/azure-policy/main.tf
@@ -927,7 +927,7 @@ resource "azurerm_policy_set_definition" "xks" {
         "value": "deny"
       },
       "excludedNamespaces": {
-        "value": "[concat(parameters('excludedNamespaces'),createArray(${local.system_namespaces}),createArray('aad-pod-identity','csi-secrets-store-provider-azure','spegel'))]"
+        "value": "[concat(parameters('excludedNamespaces'),createArray(${local.system_namespaces}),createArray('aad-pod-identity','csi-secrets-store-provider-azure','prometheus','spegel'))]"
       },
       "excludedImages": {
         "value": "[parameters('excludedImages')]"


### PR DESCRIPTION
This PR adds an exemption for prometheus-node-exporter to bypass the Azure policy that denies use of host network and/or ports