### PR TITLE
ci: run check when PR is labeled

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -3,6 +3,11 @@ on:
   pull_request:
     branches:
       - 'main'
+    types:
+      - labeled
+      - opened
+      - reopened
+      - synchronize
 jobs:
   conventional-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR runs the check action when a PR is labeled. This to make sure the required checks are run when updating the CHANGELOG