### PR TITLE
chore: bump peter-evans/create-pull-request to v6

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -25,7 +25,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           OUTPUT: CHANGELOG.md
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           token:  "${{ secrets.GITHUB_TOKEN }}"
           committer: GitHub <noreply@github.com>


### PR DESCRIPTION
This PR bumps the version of peter-evans/create-pull-request to v6 to address this [issue](https://github.com/peter-evans/create-pull-request/issues/2790)