### PR TITLE
feat: prevent destruction of tenant namespaces

### DIFF
--- a/modules/kubernetes/aks-core/namespace.tf
+++ b/modules/kubernetes/aks-core/namespace.tf
@@ -11,6 +11,10 @@ resource "kubernetes_namespace" "tenant" {
     )
     name = each.value.name
   }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "kubernetes_service_account_v1" "tenant" {


### PR DESCRIPTION
This PR adds  a lifecycle management tag to tenant namespace resources that will prevent the namespace from being destroyed. From now on, destorying tenant namespaces can only be made outside of Terraform/Open Tofu. 