### PR TITLE
refactor: use Microsoft provider for Azure DevOps

### DIFF
--- a/modules/kubernetes/fluxcd-v2-azdo/README.md
+++ b/modules/kubernetes/fluxcd-v2-azdo/README.md
@@ -18,7 +18,7 @@ the bootstrap configuration.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | 0.5.0 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | >=1.3.0 |
 | <a name="requirement_flux"></a> [flux](#requirement\_flux) | 0.25.3 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.11.0 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | 1.14.0 |
@@ -28,7 +28,7 @@ the bootstrap configuration.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuredevops"></a> [azuredevops](#provider\_azuredevops) | 0.5.0 |
+| <a name="provider_azuredevops"></a> [azuredevops](#provider\_azuredevops) | >=1.3.0 |
 | <a name="provider_flux"></a> [flux](#provider\_flux) | 0.25.3 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.11.0 |
 | <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | 1.14.0 |
@@ -42,17 +42,17 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azuredevops_git_repository_file.cluster_tenants](https://registry.terraform.io/providers/xenitab/azuredevops/0.5.0/docs/resources/git_repository_file) | resource |
-| [azuredevops_git_repository_file.install](https://registry.terraform.io/providers/xenitab/azuredevops/0.5.0/docs/resources/git_repository_file) | resource |
-| [azuredevops_git_repository_file.kustomize](https://registry.terraform.io/providers/xenitab/azuredevops/0.5.0/docs/resources/git_repository_file) | resource |
-| [azuredevops_git_repository_file.sync](https://registry.terraform.io/providers/xenitab/azuredevops/0.5.0/docs/resources/git_repository_file) | resource |
-| [azuredevops_git_repository_file.tenant](https://registry.terraform.io/providers/xenitab/azuredevops/0.5.0/docs/resources/git_repository_file) | resource |
+| [azuredevops_git_repository_file.cluster_tenants](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/git_repository_file) | resource |
+| [azuredevops_git_repository_file.install](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/git_repository_file) | resource |
+| [azuredevops_git_repository_file.kustomize](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/git_repository_file) | resource |
+| [azuredevops_git_repository_file.sync](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/git_repository_file) | resource |
+| [azuredevops_git_repository_file.tenant](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/git_repository_file) | resource |
 | [helm_release.git_auth_proxy](https://registry.terraform.io/providers/hashicorp/helm/2.11.0/docs/resources/release) | resource |
 | [kubectl_manifest.install](https://registry.terraform.io/providers/gavinbunney/kubectl/1.14.0/docs/resources/manifest) | resource |
 | [kubectl_manifest.sync](https://registry.terraform.io/providers/gavinbunney/kubectl/1.14.0/docs/resources/manifest) | resource |
 | [kubernetes_namespace.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.23.0/docs/resources/namespace) | resource |
-| [azuredevops_git_repository.cluster](https://registry.terraform.io/providers/xenitab/azuredevops/0.5.0/docs/data-sources/git_repository) | data source |
-| [azuredevops_project.this](https://registry.terraform.io/providers/xenitab/azuredevops/0.5.0/docs/data-sources/project) | data source |
+| [azuredevops_git_repository.cluster](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/data-sources/git_repository) | data source |
+| [azuredevops_project.this](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/data-sources/project) | data source |
 | [flux_install.this](https://registry.terraform.io/providers/fluxcd/flux/0.25.3/docs/data-sources/install) | data source |
 | [flux_sync.this](https://registry.terraform.io/providers/fluxcd/flux/0.25.3/docs/data-sources/sync) | data source |
 | [kubectl_file_documents.install](https://registry.terraform.io/providers/gavinbunney/kubectl/1.14.0/docs/data-sources/file_documents) | data source |

--- a/modules/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/main.tf
@@ -28,7 +28,7 @@ terraform {
       version = "0.25.3"
     }
     azuredevops = {
-      source  = "mirosoft/azuredevops"
+      source  = "microsoft/azuredevops"
       version = ">=1.3.0"
     }
     kubernetes = {

--- a/modules/kubernetes/fluxcd-v2-azdo/main.tf
+++ b/modules/kubernetes/fluxcd-v2-azdo/main.tf
@@ -28,8 +28,8 @@ terraform {
       version = "0.25.3"
     }
     azuredevops = {
-      source  = "xenitab/azuredevops"
-      version = "0.5.0"
+      source  = "mirosoft/azuredevops"
+      version = ">=1.3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
This PR replaces the Xenit fork of microsoft/azuredevops provider with the forked provider.