### PR TITLE
fix: wrong location name forces replacement of automation resources

### DIFF
--- a/modules/azure/aks/README.md
+++ b/modules/azure/aks/README.md
@@ -91,6 +91,7 @@ https://pumpingco.de/blog/modify-aks-default-node-pool-in-terraform-without-rede
 | <a name="input_defender_enabled"></a> [defender\_enabled](#input\_defender\_enabled) | If Defender for Containers should be enabled | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment name to use for the deploy | `string` | n/a | yes |
 | <a name="input_group_name_separator"></a> [group\_name\_separator](#input\_group\_name\_separator) | Separator for group names | `string` | `"-"` | no |
+| <a name="input_location"></a> [location](#input\_location) | The Azure region | `string` | `"West Europe"` | no |
 | <a name="input_location_short"></a> [location\_short](#input\_location\_short) | The Azure region short name | `string` | n/a | yes |
 | <a name="input_log_eventhub_authorization_rule_id"></a> [log\_eventhub\_authorization\_rule\_id](#input\_log\_eventhub\_authorization\_rule\_id) | The authoritzation rule id for event hub | `string` | n/a | yes |
 | <a name="input_log_eventhub_name"></a> [log\_eventhub\_name](#input\_log\_eventhub\_name) | The eventhub name for k8s logs | `string` | n/a | yes |

--- a/modules/azure/aks/automation/main.tf
+++ b/modules/azure/aks/automation/main.tf
@@ -17,7 +17,7 @@ resource "azuread_group" "automation_access" {
 
 resource "azurerm_user_assigned_identity" "aks_automation" {
   resource_group_name = data.azurerm_resource_group.this.name
-  location            = data.azurerm_resource_group.this.location
+  location            = var.location
   name                = "uai-${var.aks_name}-auto"
 }
 
@@ -35,7 +35,7 @@ resource "azurerm_role_assignment" "automation_access" {
 
 resource "azurerm_automation_account" "aks" {
   name                          = "auto-${var.aks_name}"
-  location                      = data.azurerm_resource_group.this.location
+  location                      = var.location
   resource_group_name           = data.azurerm_resource_group.this.name
   public_network_access_enabled = var.aks_automation_config.public_network_access_enabled
   sku_name                      = "Basic"
@@ -52,7 +52,7 @@ resource "azurerm_automation_account" "aks" {
 
 resource "azurerm_automation_runbook" "aks" {
   name                    = "AKS-StartStop"
-  location                = data.azurerm_resource_group.this.location
+  location                = var.location
   resource_group_name     = data.azurerm_resource_group.this.name
   automation_account_name = azurerm_automation_account.aks.name
   log_verbose             = "false"

--- a/modules/azure/aks/automation/variables.tf
+++ b/modules/azure/aks/automation/variables.tf
@@ -31,6 +31,11 @@ variable "environment" {
   type        = string
 }
 
+variable "location" {
+  description = "The Azure region"
+  type        = string
+}
+
 variable "location_short" {
   description = "The Azure region short name"
   type        = string

--- a/modules/azure/aks/modules.tf
+++ b/modules/azure/aks/modules.tf
@@ -16,6 +16,7 @@ module "automation" {
   alerts_enabled             = var.alerts_enabled
   alerts_resource_group_name = data.azurerm_resource_group.log.name
   alert_name                 = "audit log${var.environment}${var.location_short}${var.name}${var.unique_suffix} storage account missing data"
+  location                   = var.location
   location_short             = var.location_short
   notification_email         = var.notification_email
   resource_group_name        = data.azurerm_resource_group.this.name

--- a/modules/azure/aks/variables.tf
+++ b/modules/azure/aks/variables.tf
@@ -52,6 +52,12 @@ variable "aks_joblogs_retention_days" {
   default     = 7
 }
 
+variable "location" {
+  description = "The Azure region"
+  type        = string
+  default     = "West Europe"
+}
+
 variable "location_short" {
   description = "The Azure region short name"
   type        = string


### PR DESCRIPTION
This PR adds a fix for not being able to pull the Azure region (location) name from a resource group datasource, since it returns the value `westeurope`, and not the required `West Europe`. This caused automation accounts and related resources to be re-created.