### PR TITLE
fix: Revert Exclude ambassador namespace"

### DIFF
--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -1,7 +1,6 @@
 locals {
   exclude_namespaces = [
     "aad-pod-identity",
-    "ambassador",
     "azad-kube-proxy",
     "azdo-proxy",
     "azure-metrics",


### PR DESCRIPTION
Reverts XenitAB/terraform-modules#1185