### PR TITLE
fix: grafana alloy using wrong location short name

### DIFF
--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -378,7 +378,7 @@ module "grafana_alloy" {
   aks_name            = var.name
   cluster_id          = local.cluster_id
   environment         = var.environment
-  location_short      = data.azurerm_resource_group.this.location
+  location_short      = var.location_short
   oidc_issuer_url     = var.oidc_issuer_url
   resource_group_name = data.azurerm_resource_group.this.name
 }


### PR DESCRIPTION
This PR fixes an error where the location short name was wrong, which prohibited the installation of the grafana alloy module.