### PR TITLE
feat: add support for Nginx Gateway Fabric

### DIFF
--- a/modules/kubernetes/README.md
+++ b/modules/kubernetes/README.md
@@ -29,6 +29,7 @@ This directory contains all the Kubernetes Terraform modules.
 - [`ingress-healthz`](ingress-healthz/README.md)
 - [`ingress-nginx`](ingress-nginx/README.md)
 - [`linkerd`](linkerd/README.md)
+- [`nginx-gateway-fabric`](nginx-gateway-fabric/README.md)
 - [`node-local-dns`](node-local-dns/README.md)
 - [`node-ttl`](node-ttl/README.md)
 - [`prometheus`](prometheus/README.md)

--- a/modules/kubernetes/aks-core/README.md
+++ b/modules/kubernetes/aks-core/README.md
@@ -51,6 +51,7 @@ This module is used to create AKS clusters.
 | <a name="module_ingress_nginx"></a> [ingress\_nginx](#module\_ingress\_nginx) | ../../kubernetes/ingress-nginx | n/a |
 | <a name="module_linkerd"></a> [linkerd](#module\_linkerd) | ../../kubernetes/linkerd | n/a |
 | <a name="module_linkerd_crd"></a> [linkerd\_crd](#module\_linkerd\_crd) | ../../kubernetes/helm-crd-oci | n/a |
+| <a name="module_nginx_gateway_fabric"></a> [nginx\_gateway\_fabric](#module\_nginx\_gateway\_fabric) | ../../kubernetes/nginx-gateway-fabric | n/a |
 | <a name="module_node_local_dns"></a> [node\_local\_dns](#module\_node\_local\_dns) | ../../kubernetes/node-local-dns | n/a |
 | <a name="module_node_ttl"></a> [node\_ttl](#module\_node\_ttl) | ../../kubernetes/node-ttl | n/a |
 | <a name="module_prometheus"></a> [prometheus](#module\_prometheus) | ../../kubernetes/prometheus | n/a |
@@ -173,6 +174,8 @@ This module is used to create AKS clusters.
 | <a name="input_mirrord_enabled"></a> [mirrord\_enabled](#input\_mirrord\_enabled) | Should mirrord be enabled | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | The commonName to use for the deploy | `string` | n/a | yes |
 | <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | The namespaces that should be created in Kubernetes. | <pre>list(<br/>    object({<br/>      name   = string<br/>      labels = map(string)<br/>      flux = optional(object({<br/>        provider            = string<br/>        project             = optional(string)<br/>        repository          = string<br/>        include_tenant_name = optional(bool, false)<br/>        create_crds         = optional(bool, false)<br/>      }))<br/>    })<br/>  )</pre> | n/a | yes |
+| <a name="input_nginx_gateway_config"></a> [nginx\_gateway\_config](#input\_nginx\_gateway\_config) | Gateway Fabric configuration | <pre>object({<br/>    logging_level     = optional(string, "info")<br/>    replica_count     = optional(number, 2)<br/>    telemetry_enabled = optional(bool, true)<br/>    telemetry_config = optional(object({<br/>      endpoint    = optional(string, "")<br/>      interval    = optional(string, "")<br/>      batch_size  = optional(number, 0)<br/>      batch_count = optional(number, 0)<br/>    }), {})<br/>  })</pre> | `{}` | no |
+| <a name="input_nginx_gateway_enabled"></a> [nginx\_gateway\_enabled](#input\_nginx\_gateway\_enabled) | Should NGINX Gateway Fabric be enabled | `bool` | `false` | no |
 | <a name="input_node_local_dns_enabled"></a> [node\_local\_dns\_enabled](#input\_node\_local\_dns\_enabled) | Should VPA be enabled | `bool` | `true` | no |
 | <a name="input_node_ttl_enabled"></a> [node\_ttl\_enabled](#input\_node\_ttl\_enabled) | Should Node TTL be enabled | `bool` | `true` | no |
 | <a name="input_oidc_issuer_url"></a> [oidc\_issuer\_url](#input\_oidc\_issuer\_url) | Kubernetes OIDC issuer URL for workload identity. | `string` | n/a | yes |

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -449,6 +449,22 @@ module "ingress_nginx" {
   cluster_id              = local.cluster_id
 }
 
+module "nginx_gateway_fabric" {
+  depends_on = [module.gateway_api]
+
+  for_each = {
+    for s in ["nginx-gateway"] :
+    s => s
+    if var.nginx_gateway_enabled
+  }
+
+  source = "../../kubernetes/nginx-gateway-fabric"
+
+  cluster_id     = local.cluster_id
+  gateway_config = var.nginx_gateway_config
+  nginx_config   = var.ingress_nginx_config.customization
+}
+
 module "linkerd" {
   depends_on = [module.cert_manager_crd, module.linkerd_crd]
 

--- a/modules/kubernetes/aks-core/variables.tf
+++ b/modules/kubernetes/aks-core/variables.tf
@@ -733,3 +733,25 @@ variable "gateway_api_config" {
     error_message = "Invalid API channel: ${var.gateway_api_config.api_channel}. Allowed vallues: ['standard', 'experimental']"
   }
 }
+
+variable "nginx_gateway_enabled" {
+  description = "Should NGINX Gateway Fabric be enabled"
+  type        = bool
+  default     = false
+}
+
+variable "nginx_gateway_config" {
+  description = "Gateway Fabric configuration"
+  type = object({
+    logging_level     = optional(string, "info")
+    replica_count     = optional(number, 2)
+    telemetry_enabled = optional(bool, true)
+    telemetry_config = optional(object({
+      endpoint    = optional(string, "")
+      interval    = optional(string, "")
+      batch_size  = optional(number, 0)
+      batch_count = optional(number, 0)
+    }), {})
+  })
+  default = {}
+}

--- a/modules/kubernetes/nginx-gateway-fabric/README.md
+++ b/modules/kubernetes/nginx-gateway-fabric/README.md
@@ -1,0 +1,41 @@
+# Nginx Gateway Fabric
+
+This module is used to add [`nginx-gateway-fabric`](https://docs.nginx.com/nginx-gateway-fabric/) to Kubernetes clusters.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.0 |
+| <a name="requirement_git"></a> [git](#requirement\_git) | 0.0.3 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_git"></a> [git](#provider\_git) | 0.0.3 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [git_repository_file.ingress_nginx](https://registry.terraform.io/providers/xenitab/git/0.0.3/docs/resources/repository_file) | resource |
+| [git_repository_file.kustomization](https://registry.terraform.io/providers/xenitab/git/0.0.3/docs/resources/repository_file) | resource |
+| [kubernetes_namespace.nginx_gateway](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | Unique identifier of the cluster across regions and instances. | `string` | n/a | yes |
+| <a name="input_gateway_config"></a> [gateway\_config](#input\_gateway\_config) | Gateway Fabric configuration | <pre>object({<br/>    logging_level     = optional(string, "info")<br/>    replica_count     = optional(number, 2)<br/>    telemetry_enabled = optional(bool, true)<br/>    telemetry_config = optional(object({<br/>      endpoint    = optional(string, "")<br/>      interval    = optional(string, "")<br/>      batch_size  = optional(number, 0)<br/>      batch_count = optional(number, 0)<br/>    }), {})<br/>  })</pre> | n/a | yes |
+| <a name="input_nginx_config"></a> [nginx\_config](#input\_nginx\_config) | Global nginx configuration that will be applied to GatewayClass. | <pre>object({<br/>    allow_snippet_annotations = optional(bool, false)<br/>    http_snippet              = optional(string, "")<br/>    extra_config              = optional(map(string), {})<br/>    extra_headers             = optional(map(string), {})<br/>  })</pre> | n/a | yes |
+
+## Outputs
+
+No outputs.

--- a/modules/kubernetes/nginx-gateway-fabric/README.md
+++ b/modules/kubernetes/nginx-gateway-fabric/README.md
@@ -6,15 +6,16 @@ This module is used to add [`nginx-gateway-fabric`](https://docs.nginx.com/nginx
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_git"></a> [git](#requirement\_git) | 0.0.3 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.23.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_git"></a> [git](#provider\_git) | 0.0.3 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | n/a |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.23.0 |
 
 ## Modules
 
@@ -26,7 +27,7 @@ No modules.
 |------|------|
 | [git_repository_file.ingress_nginx](https://registry.terraform.io/providers/xenitab/git/0.0.3/docs/resources/repository_file) | resource |
 | [git_repository_file.kustomization](https://registry.terraform.io/providers/xenitab/git/0.0.3/docs/resources/repository_file) | resource |
-| [kubernetes_namespace.nginx_gateway](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+| [kubernetes_namespace.nginx_gateway](https://registry.terraform.io/providers/hashicorp/kubernetes/2.23.0/docs/resources/namespace) | resource |
 
 ## Inputs
 

--- a/modules/kubernetes/nginx-gateway-fabric/main.tf
+++ b/modules/kubernetes/nginx-gateway-fabric/main.tf
@@ -5,9 +5,13 @@
   */
 
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.23.0"
+    }
     git = {
       source  = "xenitab/git"
       version = "0.0.3"

--- a/modules/kubernetes/nginx-gateway-fabric/main.tf
+++ b/modules/kubernetes/nginx-gateway-fabric/main.tf
@@ -1,0 +1,46 @@
+/**
+  * # Nginx Gateway Fabric
+  *
+  * This module is used to add [`nginx-gateway-fabric`](https://docs.nginx.com/nginx-gateway-fabric/) to Kubernetes clusters.
+  */
+
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    git = {
+      source  = "xenitab/git"
+      version = "0.0.3"
+    }
+  }
+}
+
+resource "kubernetes_namespace" "nginx_gateway" {
+  metadata {
+    name = "nginx-gateway"
+    labels = {
+      "xkf.xenit.io/kind" = "platform"
+    }
+  }
+}
+
+resource "git_repository_file" "kustomization" {
+  path = "clusters/${var.cluster_id}/nginx-gateway-fabric.yaml"
+  content = templatefile("${path.module}/templates/kustomization.yaml.tpl", {
+    cluster_id = var.cluster_id
+  })
+}
+
+resource "git_repository_file" "ingress_nginx" {
+  path = "platform/${var.cluster_id}/nginx-gateway-fabric/gateway-fabric.yaml"
+  content = templatefile("${path.module}/templates/gateway-fabric.yaml.tpl", {
+    logging_level             = var.gateway_config.logging_level
+    replica_count             = var.gateway_config.replica_count
+    telemetry_enabled         = var.gateway_config.telemetry_enabled
+    telemetry_config          = var.gateway_config.telemetry_config
+    allow_snippet_annotations = var.nginx_config.allow_snippet_annotations
+    http_snippet              = var.nginx_config.http_snippet
+    extra_config              = var.nginx_config.extra_config
+    extra_headers             = var.nginx_config.extra_headers
+  })
+}

--- a/modules/kubernetes/nginx-gateway-fabric/templates/gateway-fabric.yaml.tpl
+++ b/modules/kubernetes/nginx-gateway-fabric/templates/gateway-fabric.yaml.tpl
@@ -1,0 +1,64 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: nginx-gateway-fabric
+  namespace: nginx-gateway
+spec:
+  interval: 1m0s
+  type: oci
+  url: "oci://ghcr.io/nginxinc/charts"
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: nginx-gateway-fabric
+  namespace: nginx-gateway
+spec:
+  chart:
+    spec:
+      chart: nginx-gateway-fabric
+      sourceRef:
+        kind: HelmRepository
+        name: nginx-gateway-fabric
+      version: 1.4.0
+  interval: 1m0s
+  values:
+    nginxGateway:
+      config:
+        logging:
+          level: ${logging_level}
+      configAnnotations:
+        cert-manager.io/cluster-issuer: letsencrypt
+      gatewayClassName: nginx
+      gwAPIExperimentalFeatures:
+        enable: true
+      productTelemetry:
+        enable: false
+      replicaCount: ${replica_count}
+      snippetsFilters:
+        enable: true
+    nginx:
+      ipFamily: dual
+      rewriteClientIP: XForwardedFor
+      %{~ if telemetry_enabled ~}
+      telemetry:
+        exporter:
+          endpoint: ${telemetry_config.endpoint}
+          interval: ${telemetry_config.interval}
+          batchSize: ${telemetry_config.batch_size}
+          batchCount: ${telemetry_config.batch_count}
+      %{~ endif ~}
+      logging:
+        errorLevel: ${logging_level}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/instance
+                      operator: In
+                      values:
+                        - ingress-nginx
+                topologyKey: topology.kubernetes.io/zone
+              weight: 100

--- a/modules/kubernetes/nginx-gateway-fabric/templates/kustomization.yaml.tpl
+++ b/modules/kubernetes/nginx-gateway-fabric/templates/kustomization.yaml.tpl
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: nginx-gateway
+  namespace: flux-system
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: "./platform/${cluster_id}/nginx-gateway-fabric/"
+  prune: true
+  wait: true
+  #healthChecks:
+  #- apiVersion: apps/v1
+  #  kind: Deployment
+  #  namespace: ingress-nginx
+  #  name: ingress-nginx-controller

--- a/modules/kubernetes/nginx-gateway-fabric/variables.tf
+++ b/modules/kubernetes/nginx-gateway-fabric/variables.tf
@@ -1,0 +1,29 @@
+variable "cluster_id" {
+  description = "Unique identifier of the cluster across regions and instances."
+  type        = string
+}
+
+variable "gateway_config" {
+  description = "Gateway Fabric configuration"
+  type = object({
+    logging_level     = optional(string, "info")
+    replica_count     = optional(number, 2)
+    telemetry_enabled = optional(bool, true)
+    telemetry_config = optional(object({
+      endpoint    = optional(string, "")
+      interval    = optional(string, "")
+      batch_size  = optional(number, 0)
+      batch_count = optional(number, 0)
+    }), {})
+  })
+}
+
+variable "nginx_config" {
+  description = "Global nginx configuration that will be applied to GatewayClass."
+  type = object({
+    allow_snippet_annotations = optional(bool, false)
+    http_snippet              = optional(string, "")
+    extra_config              = optional(map(string), {})
+    extra_headers             = optional(map(string), {})
+  })
+}

--- a/validation/kubernetes/nginx-gateway-fabric/main.tf
+++ b/validation/kubernetes/nginx-gateway-fabric/main.tf
@@ -1,0 +1,12 @@
+terraform {}
+
+provider "kubernetes" {}
+
+provider "helm" {}
+
+module "nginx_gateway_fabric" {
+  source         = "../../../modules/kubernetes/nginx-gateway-fabric"
+  cluster_id     = "bar"
+  gateway_config = {}
+  nginx_config   = {}
+}


### PR DESCRIPTION
This PR adds basic support for deploying `Nginx Gateway Fabric `to the cluster. The current version of the Gateway Fabric has very limited support for GatewayClass and Gateway configuration. As such, users who have previously used the Nginx Ingress Controller and are used to be able to perform advanced Nginx configuration will not be able to do this currently. However, there is a [proposal](https://github.com/nginxinc/nginx-gateway-fabric/blob/main/docs/proposals/nginx-extensions.md) in place that will add provider specific configuration in the future, and we will update the new module accordingly as they become available.