### PR TITLE
refactor: associate AKS default NSG with vnet subnet 

### DIFF
--- a/modules/azure/aks/README.md
+++ b/modules/azure/aks/README.md
@@ -59,12 +59,15 @@ https://pumpingco.de/blog/modify-aks-default-node-pool-in-terraform-without-rede
 | [azurerm_security_center_auto_provisioning.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/security_center_auto_provisioning) | resource |
 | [azurerm_security_center_subscription_pricing.containers](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/security_center_subscription_pricing) | resource |
 | [azurerm_storage_management_policy.log_storage_account_audit_policy](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/storage_management_policy) | resource |
+| [azurerm_subnet_network_security_group_association.subnet_nsg_association](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/subnet_network_security_group_association) | resource |
 | [azurerm_user_assigned_identity.aks](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/user_assigned_identity) | resource |
 | [azurerm_user_assigned_identity.tenant](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/user_assigned_identity) | resource |
 | [azuread_group.tenant_resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
+| [azurerm_kubernetes_cluster.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/kubernetes_cluster) | data source |
 | [azurerm_resource_group.aks](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.log](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/resource_group) | data source |
+| [azurerm_resources.nsg](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/resources) | data source |
 | [azurerm_storage_account.log](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/storage_account) | data source |
 | [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/subnet) | data source |
 

--- a/modules/azure/aks/aks.tf
+++ b/modules/azure/aks/aks.tf
@@ -352,5 +352,5 @@ resource "azurerm_subnet_network_security_group_association" "subnet_nsg_associa
   }
 
   subnet_id                 = each.value.vnet_subnet_id
-  network_security_group_id = data.azurerm_resources.nsg.id
+  network_security_group_id = data.azurerm_resources.nsg.resources[0].id
 }

--- a/modules/azure/aks/aks.tf
+++ b/modules/azure/aks/aks.tf
@@ -334,3 +334,23 @@ resource "azurerm_role_assignment" "aks_managed_identity_noderg_virtual_machine_
   role_definition_name = "Virtual Machine Contributor"
   principal_id         = var.aad_groups.aks_managed_identity.id
 }
+
+data "azurerm_kubernetes_cluster" "this" {
+  name                = azurerm_kubernetes_cluster.this.name
+  resource_group_name = azurerm_kubernetes_cluster.this.resource_group_name
+}
+
+data "azurerm_resources" "nsg" {
+  resource_group_name = data.azurerm_kubernetes_cluster.this.node_resource_group
+  type                = "Microsoft.Network/networkSecurityGroups"
+}
+
+resource "azurerm_subnet_network_security_group_association" "subnet_nsg_association" {
+  for_each = {
+    for pool_profile in data.azurerm_kubernetes_cluster.this.agent_pool_profile :
+    pool_profile.name => pool_profile
+  }
+
+  subnet_id                 = each.value.vnet_subnet_id
+  network_security_group_id = data.azurerm_resources.nsg.id
+}


### PR DESCRIPTION
This PR associates the default NSG with the vnet subnet.