### PR TITLE
fix: use kubernets datasource to retrieve aks identity

### DIFF
--- a/modules/kubernetes/aks-core/README.md
+++ b/modules/kubernetes/aks-core/README.md
@@ -118,7 +118,6 @@ This module is used to create AKS clusters.
 | [azurerm_kubernetes_cluster.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/kubernetes_cluster) | data source |
 | [azurerm_resource_group.global](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/resource_group) | data source |
-| [azurerm_user_assigned_identity.aks](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/user_assigned_identity) | data source |
 | [azurerm_user_assigned_identity.tenant](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/user_assigned_identity) | data source |
 | [kubernetes_resources.bootstrap_token](https://registry.terraform.io/providers/hashicorp/kubernetes/2.23.0/docs/data-sources/resources) | data source |
 

--- a/modules/kubernetes/aks-core/main.tf
+++ b/modules/kubernetes/aks-core/main.tf
@@ -49,11 +49,6 @@ data "azurerm_resource_group" "global" {
   name = "rg-${var.environment}-${var.global_location_short}-global"
 }
 
-data "azurerm_user_assigned_identity" "aks" {
-  name                = "uai-aks-${var.environment}-${var.location_short}-${var.name}${local.aks_name_suffix}"
-  resource_group_name = data.azurerm_resource_group.this.name
-}
-
 data "azuread_group" "aks_managed_identity" {
   display_name = "${var.group_name_prefix}${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}aksmsi"
 }
@@ -89,7 +84,7 @@ data "azurerm_dns_zone" "this" {
 }
 
 data "azurerm_kubernetes_cluster" "this" {
-  name                = "aks-${var.environment}-${var.location_short}-${var.name}${var.aks_name_suffix}"
+  name                = "aks-${var.environment}-${var.location_short}-${var.name}${local.aks_name_suffix}"
   resource_group_name = data.azurerm_resource_group.this.name
 }
 

--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -509,7 +509,7 @@ module "popeye" {
 
   source = "../../kubernetes/popeye"
 
-  aks_managed_identity_id = data.azurerm_user_assigned_identity.aks.principal_id
+  aks_managed_identity_id = var.cilium_enabled ? data.azurerm_kubernetes_cluster.this.identity[0].identity_ids[0] : data.azurerm_kubernetes_cluster.this.identity[0].principal_id
   cluster_id              = local.cluster_id
   location                = data.azurerm_key_vault.core.location
   oidc_issuer_url         = var.oidc_issuer_url


### PR DESCRIPTION
This PR fixes two issues:

1. Use a `kubernetes_cluster` data source in `aks-core` module to retrieve the aks identity instead of using a data source for the identity based on the name of the identity
2. Take aks unique suffix into consideration properly when using a `kubernetes_cluster` data source in `aks-core` module