### PR TITLE
fix: add required name label to ingress-nginx namespace

### DIFF
--- a/modules/kubernetes/ingress-nginx/main.tf
+++ b/modules/kubernetes/ingress-nginx/main.tf
@@ -24,6 +24,7 @@ resource "kubernetes_namespace" "ingress_nginx" {
     name = "ingress-nginx"
     labels = {
       "xkf.xenit.io/kind" = "platform"
+      "name"              = "ingress-nginx"
     }
   }
 }


### PR DESCRIPTION
This PR adds the `name` label that is required on the `ingress-nginx `namespace in order for network policicies to work properly.