### PR TITLE
fix: ignore metadata changes for flux namespace

### DIFF
--- a/modules/kubernetes/fluxcd/main.tf
+++ b/modules/kubernetes/fluxcd/main.tf
@@ -58,6 +58,12 @@ resource "kubernetes_namespace" "flux_system" {
   metadata {
     name = "flux-system"
   }
+
+  lifecycle {
+    ignore_changes = [
+      metadata
+    ]
+  }
 }
 
 resource "flux_bootstrap_git" "this" {


### PR DESCRIPTION
This PR adds lifecycle management to ignores changes to metadata of the flux namespace to prevent constant updates of the namespace which will be reverted automatically by flux.