### PR TITLE
feat: Add option in AKS-module to set NSG rules

### DIFF
--- a/modules/azure/aks/README.md
+++ b/modules/azure/aks/README.md
@@ -46,6 +46,7 @@ https://pumpingco.de/blog/modify-aks-default-node-pool-in-terraform-without-rede
 | [azurerm_monitor_diagnostic_setting.log_analytics_workspace_audit](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.log_eventhub_audit](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.log_storage_account_audit](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/monitor_diagnostic_setting) | resource |
+| [azurerm_network_security_rule.nsg](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/network_security_rule) | resource |
 | [azurerm_resource_policy_assignment.agentless_discovery](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/resource_policy_assignment) | resource |
 | [azurerm_resource_policy_assignment.kubernetes_sensor](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/resource_policy_assignment) | resource |
 | [azurerm_resource_policy_assignment.vulnerability_assessments](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/resource_policy_assignment) | resource |
@@ -59,15 +60,12 @@ https://pumpingco.de/blog/modify-aks-default-node-pool-in-terraform-without-rede
 | [azurerm_security_center_auto_provisioning.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/security_center_auto_provisioning) | resource |
 | [azurerm_security_center_subscription_pricing.containers](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/security_center_subscription_pricing) | resource |
 | [azurerm_storage_management_policy.log_storage_account_audit_policy](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/storage_management_policy) | resource |
-| [azurerm_subnet_network_security_group_association.subnet_nsg_association](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/subnet_network_security_group_association) | resource |
 | [azurerm_user_assigned_identity.aks](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/user_assigned_identity) | resource |
 | [azurerm_user_assigned_identity.tenant](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/user_assigned_identity) | resource |
 | [azuread_group.tenant_resource_group_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
-| [azurerm_kubernetes_cluster.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/kubernetes_cluster) | data source |
 | [azurerm_resource_group.aks](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.log](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/resource_group) | data source |
-| [azurerm_resources.nsg](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/resources) | data source |
 | [azurerm_storage_account.log](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/storage_account) | data source |
 | [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/subnet) | data source |
 
@@ -104,6 +102,8 @@ https://pumpingco.de/blog/modify-aks-default-node-pool-in-terraform-without-rede
 | <a name="input_name"></a> [name](#input\_name) | The commonName to use for the deploy | `string` | n/a | yes |
 | <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | The namespaces that should be created in Kubernetes | <pre>list(<br/>    object({<br/>      name = string<br/>    })<br/>  )</pre> | n/a | yes |
 | <a name="input_notification_email"></a> [notification\_email](#input\_notification\_email) | Where to send email alerts | `string` | `"DG-Team-DevOps@xenit.se"` | no |
+| <a name="input_nsg_rules"></a> [nsg\_rules](#input\_nsg\_rules) | Rules for trafic in the NSG associated to AKS | <pre>list(object({<br/>    name                       = string<br/>    priority                   = number<br/>    direction                  = string<br/>    access                     = string<br/>    protocol                   = string<br/>    source_port_range          = string<br/>    destination_port_range     = string<br/>    source_address_prefix      = string<br/>    destination_address_prefix = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_nsg_rules_enabled"></a> [nsg\_rules\_enabled](#input\_nsg\_rules\_enabled) | Is NSG being used? If so, apply rules | `bool` | `true` | no |
 | <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | SSH public key to add to servers | `string` | n/a | yes |
 | <a name="input_subscription_name"></a> [subscription\_name](#input\_subscription\_name) | The commonName for the subscription | `string` | n/a | yes |
 | <a name="input_unique_suffix"></a> [unique\_suffix](#input\_unique\_suffix) | Unique suffix that is used in globally unique resources names | `string` | n/a | yes |

--- a/modules/azure/aks/aks.tf
+++ b/modules/azure/aks/aks.tf
@@ -334,23 +334,3 @@ resource "azurerm_role_assignment" "aks_managed_identity_noderg_virtual_machine_
   role_definition_name = "Virtual Machine Contributor"
   principal_id         = var.aad_groups.aks_managed_identity.id
 }
-
-data "azurerm_kubernetes_cluster" "this" {
-  name                = azurerm_kubernetes_cluster.this.name
-  resource_group_name = azurerm_kubernetes_cluster.this.resource_group_name
-}
-
-data "azurerm_resources" "nsg" {
-  resource_group_name = data.azurerm_kubernetes_cluster.this.node_resource_group
-  type                = "Microsoft.Network/networkSecurityGroups"
-}
-
-resource "azurerm_subnet_network_security_group_association" "subnet_nsg_association" {
-  for_each = {
-    for pool_profile in data.azurerm_kubernetes_cluster.this.agent_pool_profile :
-    pool_profile.name => pool_profile
-  }
-
-  subnet_id                 = each.value.vnet_subnet_id
-  network_security_group_id = data.azurerm_resources.nsg.resources[0].id
-}

--- a/modules/azure/aks/nsg.tf
+++ b/modules/azure/aks/nsg.tf
@@ -1,7 +1,7 @@
 resource "azurerm_network_security_rule" "nsg" {
   for_each = {
     for rule in var.nsg_rules :
-    name => rule
+    rule.name => rule
     if var.nsg_rules_enabled
   }
 

--- a/modules/azure/aks/nsg.tf
+++ b/modules/azure/aks/nsg.tf
@@ -1,0 +1,19 @@
+resource "azurerm_network_security_rule" "nsg" {
+  for_each = {
+    for rule in var.nsg_rules :
+    rule.name => rule
+    if var.nsg_rules_enabled
+  }
+
+  name                        = each.value.rule.name
+  priority                    = each.value.rule.priority
+  direction                   = each.value.rule.direction
+  access                      = each.value.rule.access
+  protocol                    = each.value.rule.protocol
+  source_port_range           = each.value.rule.source_port_range
+  destination_port_range      = each.value.rule.destination_port_range
+  source_address_prefix       = each.value.rule.source_address_prefix
+  destination_address_prefix  = each.value.rule.destination_address_prefix
+  resource_group_name         = data.azurerm_resource_group.this.name
+  network_security_group_name = "nsg-${var.environment}-${var.location_short}-${var.core_name}-${var.name}${var.aks_name_suffix}"
+}

--- a/modules/azure/aks/nsg.tf
+++ b/modules/azure/aks/nsg.tf
@@ -1,19 +1,19 @@
 resource "azurerm_network_security_rule" "nsg" {
   for_each = {
     for rule in var.nsg_rules :
-    rule.name => rule
+    name => rule
     if var.nsg_rules_enabled
   }
 
-  name                        = each.value.rule.name
-  priority                    = each.value.rule.priority
-  direction                   = each.value.rule.direction
-  access                      = each.value.rule.access
-  protocol                    = each.value.rule.protocol
-  source_port_range           = each.value.rule.source_port_range
-  destination_port_range      = each.value.rule.destination_port_range
-  source_address_prefix       = each.value.rule.source_address_prefix
-  destination_address_prefix  = each.value.rule.destination_address_prefix
+  name                        = each.value.name
+  priority                    = each.value.priority
+  direction                   = each.value.direction
+  access                      = each.value.access
+  protocol                    = each.value.protocol
+  source_port_range           = each.value.source_port_range
+  destination_port_range      = each.value.destination_port_range
+  source_address_prefix       = each.value.source_address_prefix
+  destination_address_prefix  = each.value.destination_address_prefix
   resource_group_name         = data.azurerm_resource_group.this.name
   network_security_group_name = "nsg-${var.environment}-${var.location_short}-${var.core_name}-${var.name}${var.aks_name_suffix}"
 }

--- a/modules/azure/aks/variables.tf
+++ b/modules/azure/aks/variables.tf
@@ -339,14 +339,14 @@ variable "cilium_enabled" {
   type        = bool
   default     = false
 }
-variable "nsg_rules_enabled" {
-  type        = bool
+variable "nsg_rules_enabled"{
+  type = bool
   description = "Is NSG being used? If so, apply rules"
-  default     = true
+  default = true
 }
 variable "nsg_rules" {
   description = "Rules for trafic in the NSG associated to AKS"
-  type = object({
+  type = list(object({
     name                       = string
     priority                   = number
     direction                  = string
@@ -356,7 +356,7 @@ variable "nsg_rules" {
     destination_port_range     = string
     source_address_prefix      = string
     destination_address_prefix = string
-  })
+  }))
 
   default = {}
 }

--- a/modules/azure/aks/variables.tf
+++ b/modules/azure/aks/variables.tf
@@ -358,5 +358,5 @@ variable "nsg_rules" {
     destination_address_prefix = string
   }))
 
-  default = {}
+  default = []
 }

--- a/modules/azure/aks/variables.tf
+++ b/modules/azure/aks/variables.tf
@@ -339,10 +339,10 @@ variable "cilium_enabled" {
   type        = bool
   default     = false
 }
-variable "nsg_rules_enabled"{
-  type = bool
+variable "nsg_rules_enabled" {
+  type        = bool
   description = "Is NSG being used? If so, apply rules"
-  default = true
+  default     = true
 }
 variable "nsg_rules" {
   description = "Rules for trafic in the NSG associated to AKS"

--- a/modules/azure/aks/variables.tf
+++ b/modules/azure/aks/variables.tf
@@ -339,3 +339,34 @@ variable "cilium_enabled" {
   type        = bool
   default     = false
 }
+variable "nsg_rules_enabled" {
+  type        = bool
+  description = "Is NSG being used? If so, apply rules"
+  default     = true
+}
+variable "nsg_rules" {
+  description = "Rules for trafic in the NSG associated to AKS"
+  type = object({
+    name                       = string
+    priority                   = number
+    direction                  = string
+    access                     = string
+    protocol                   = string
+    source_port_range          = string
+    destination_port_range     = string
+    source_address_prefix      = string
+    destination_address_prefix = string
+  })
+
+  default = {
+    name                       = null
+    priority                   = null
+    direction                  = null
+    access                     = null
+    protocol                   = null
+    source_port_range          = null
+    destination_port_range     = null
+    source_address_prefix      = null
+    destination_address_prefix = null
+  }
+}

--- a/modules/azure/aks/variables.tf
+++ b/modules/azure/aks/variables.tf
@@ -358,15 +358,5 @@ variable "nsg_rules" {
     destination_address_prefix = string
   })
 
-  default = {
-    name                       = null
-    priority                   = null
-    direction                  = null
-    access                     = null
-    protocol                   = null
-    source_port_range          = null
-    destination_port_range     = null
-    source_address_prefix      = null
-    destination_address_prefix = null
-  }
+  default = {}
 }

--- a/modules/azure/core/README.md
+++ b/modules/azure/core/README.md
@@ -41,7 +41,6 @@ Easiest is to define this RG in the governance module.
 | [azurerm_route_table.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/route_table) | resource |
 | [azurerm_storage_account.log](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/storage_account) | resource |
 | [azurerm_storage_account.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/storage_account) | resource |
-| [azurerm_subnet.aks](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/subnet) | resource |
 | [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/subnet) | resource |
 | [azurerm_subnet_network_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/subnet_network_security_group_association) | resource |
 | [azurerm_subnet_route_table_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/subnet_route_table_association) | resource |
@@ -82,7 +81,7 @@ Easiest is to define this RG in the governance module.
 | <a name="input_route_config"></a> [route\_config](#input\_route\_config) | Route configuration. Not applied to AKS subnets | <pre>list(object({<br/>    subnet_name                   = string                # Short name for the subnet<br/>    disable_bgp_route_propagation = optional(bool, false) # Controls propagation of routes learned by BGP on that route table<br/>    routes = list(object({<br/>      name                   = string # Name of the route<br/>      address_prefix         = string # Example: 192.168.0.0/24<br/>      next_hop_type          = string # VirtualNetworkGateway, VnetLocal, Internet, VirtualAppliance and None<br/>      next_hop_in_ip_address = string # Only set if next_hop_type is VirtualAppliance<br/>    }))<br/><br/>  }))</pre> | `[]` | no |
 | <a name="input_subscription_name"></a> [subscription\_name](#input\_subscription\_name) | The subscription commonName to use for the deploy | `string` | n/a | yes |
 | <a name="input_unique_suffix"></a> [unique\_suffix](#input\_unique\_suffix) | Unique suffix that is used in globally unique resources names | `string` | n/a | yes |
-| <a name="input_vnet_config"></a> [vnet\_config](#input\_vnet\_config) | Address spaces used by virtual network | <pre>object({<br/>    address_space = list(string)<br/>    dns_servers   = list(string)<br/>    subnets = list(object({<br/>      name              = string<br/>      cidr              = string<br/>      service_endpoints = list(string)<br/>      aks_subnet        = bool<br/>    }))<br/>  })</pre> | n/a | yes |
+| <a name="input_vnet_config"></a> [vnet\_config](#input\_vnet\_config) | Address spaces used by virtual network | <pre>object({<br/>    address_space = list(string)<br/>    dns_servers   = list(string)<br/>    subnets = list(object({<br/>      name              = string<br/>      cidr              = string<br/>      service_endpoints = list(string)<br/>    }))<br/>  })</pre> | n/a | yes |
 
 ## Outputs
 

--- a/modules/azure/core/locals.tf
+++ b/modules/azure/core/locals.tf
@@ -32,7 +32,6 @@ locals {
       subnet_short_name        = subnet.name
       subnet_cidr              = subnet.cidr
       subnet_service_endpoints = subnet.service_endpoints
-      subnet_aks_subnet        = subnet.aks_subnet
     }
   ]
 

--- a/modules/azure/core/nsg.tf
+++ b/modules/azure/core/nsg.tf
@@ -2,7 +2,6 @@ data "azurecaf_name" "azurerm_network_security_group_this" {
   for_each = {
     for subnet in local.subnets :
     subnet.subnet_full_name => subnet
-    if subnet.subnet_aks_subnet == false
   }
 
   name          = each.value.subnet_short_name
@@ -16,7 +15,6 @@ resource "azurerm_network_security_group" "this" {
   for_each = {
     for subnet in local.subnets :
     subnet.subnet_full_name => subnet
-    if subnet.subnet_aks_subnet == false
   }
 
   name                = data.azurecaf_name.azurerm_network_security_group_this[each.key].result
@@ -28,7 +26,6 @@ resource "azurerm_subnet_network_security_group_association" "this" {
   for_each = {
     for subnet in local.subnets :
     subnet.subnet_full_name => subnet
-    if subnet.subnet_aks_subnet == false
   }
 
   subnet_id                 = azurerm_subnet.this[each.key].id

--- a/modules/azure/core/subnets.tf
+++ b/modules/azure/core/subnets.tf
@@ -4,23 +4,6 @@ resource "azurerm_subnet" "this" {
   for_each = {
     for subnet in local.subnets :
     subnet.subnet_full_name => subnet
-    if subnet.subnet_aks_subnet == false
-  }
-
-  name                                          = each.value.subnet_full_name
-  resource_group_name                           = data.azurerm_resource_group.this.name
-  virtual_network_name                          = azurerm_virtual_network.this.name
-  address_prefixes                              = [each.value.subnet_cidr]
-  service_endpoints                             = each.value.subnet_service_endpoints
-  private_link_service_network_policies_enabled = true
-  private_endpoint_network_policies             = "Enabled"
-}
-
-resource "azurerm_subnet" "aks" {
-  for_each = {
-    for subnet in local.subnets :
-    subnet.subnet_full_name => subnet
-    if subnet.subnet_aks_subnet == true
   }
 
   name                                          = each.value.subnet_full_name

--- a/modules/azure/core/variables.tf
+++ b/modules/azure/core/variables.tf
@@ -27,7 +27,6 @@ variable "vnet_config" {
       name              = string
       cidr              = string
       service_endpoints = list(string)
-      aks_subnet        = bool
     }))
   })
 }

--- a/validation/azure/core/main.tf
+++ b/validation/azure/core/main.tf
@@ -22,19 +22,16 @@ module "core" {
         name              = "servers"
         cidr              = "10.180.0.0/24"
         service_endpoints = []
-        aks_subnet        = false
       },
       {
         name              = "aks1"
         cidr              = "10.180.1.0/24"
         service_endpoints = []
-        aks_subnet        = true
       },
       {
         name              = "aks2"
         cidr              = "10.180.2.0/24"
         service_endpoints = []
-        aks_subnet        = true
       },
     ]
   }


### PR DESCRIPTION
This PR make the `core` module always associate an NSG with the subnet created, while also allowing the NSG to be used by AKS and to be edited and adding rules to it on a custom basis.

State movings:

```bash
tofu state mv 'module.core.azurerm_subnet.aks["sn-dev-we-core-aks1"]' 'module.core.azurerm_subnet.this["sn-dev-we-core-aks1"]'

tofu state mv 'module.core.azurerm_subnet.aks["sn-dev-we-core-aks2"]' 'module.core.azurerm_subnet.this["sn-dev-we-core-aks2"]'
```

Config:
`nsg_rules_enabled=true`

And configure some rules as follow:  

```bash
  nsg_rules = [
    {
      name                       = "test1"
      priority                   = 100
      direction                  = "Inbound"
      access                     = "Allow"
      protocol                   = "Tcp"
      source_port_range          = "*"
      destination_port_range     = "80,443"
      source_address_prefix      = "*"
      destination_address_prefix = "*"
    },
    {
      name                       = "test2"
      priority                   = 110
      direction                  = "Inbound"
      access                     = "Allow"
      protocol                   = "Tcp"
      source_port_range          = "*"
      destination_port_range     = "8080"
      source_address_prefix      = "1.2.3.4"
      destination_address_prefix = "4.3.2.1"
    },
  ]
 ```