### PR TITLE
refactor!: create required AD-groups in governance module

### DIFF
--- a/modules/azure/governance-global/README.md
+++ b/modules/azure/governance-global/README.md
@@ -40,6 +40,9 @@ This module is used for governance on a global level and not using any specific 
 | [azuread_group.acr_pull](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
 | [azuread_group.acr_push](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
 | [azuread_group.acr_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
+| [azuread_group.all_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
+| [azuread_group.all_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
+| [azuread_group.all_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
 | [azuread_group.rg_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
 | [azuread_group.rg_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
 | [azuread_group.rg_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/resources/group) | resource |
@@ -71,9 +74,6 @@ This module is used for governance on a global level and not using any specific 
 | [pal_management_partner.aad_sp](https://registry.terraform.io/providers/xenitab/pal/0.2.5/docs/resources/management_partner) | resource |
 | [pal_management_partner.owner_spn](https://registry.terraform.io/providers/xenitab/pal/0.2.5/docs/resources/management_partner) | resource |
 | [azuread_application.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/application) | data source |
-| [azuread_group.all_contributor](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
-| [azuread_group.all_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
-| [azuread_group.all_reader](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/group) | data source |
 | [azuread_service_principal.owner_spn](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/service_principal) | data source |
 | [azuread_service_principal.sp_all_owner](https://registry.terraform.io/providers/hashicorp/azuread/2.50.0/docs/data-sources/service_principal) | data source |
 | [azurecaf_name.azuread_application_aad_app](https://registry.terraform.io/providers/aztfmod/azurecaf/2.0.0-preview3/docs/data-sources/name) | data source |

--- a/modules/azure/governance-global/aad-group-sub-delegation.tf
+++ b/modules/azure/governance-global/aad-group-sub-delegation.tf
@@ -23,8 +23,7 @@ resource "azuread_group" "all_owner" {
 
   display_name  = data.azurecaf_name.azuread_group_all_owner["delegate_sub_groups"].result
   mail_nickname = "az-sub-${var.subscription_name}-all-owner"
-  mail_enabled  = true
-  types         = ["DynamicMembership"]
+  mail_enabled  = false
 }
 
 resource "azuread_group_member" "sub_all_owner" {
@@ -63,8 +62,7 @@ resource "azuread_group" "all_contributor" {
 
   display_name  = data.azurecaf_name.azuread_group_all_contributor["delegate_sub_groups"].result
   mail_nickname = "az-sub-${var.subscription_name}-all-contributor"
-  mail_enabled  = true
-  types         = ["DynamicMembership"]
+  mail_enabled  = false
 }
 
 resource "azuread_group_member" "sub_all_contributor" {
@@ -103,8 +101,7 @@ resource "azuread_group" "all_reader" {
 
   display_name  = data.azurecaf_name.azuread_group_all_reader["delegate_sub_groups"].result
   mail_nickname = "az-sub-${var.subscription_name}-all-reader"
-  mail_enabled  = true
-  types         = ["DynamicMembership"]
+  mail_enabled  = false
 }
 
 resource "azuread_group_member" "sub_all_reader" {

--- a/modules/azure/governance-global/aad-group-sub-delegation.tf
+++ b/modules/azure/governance-global/aad-group-sub-delegation.tf
@@ -14,14 +14,16 @@ data "azurecaf_name" "azuread_group_all_owner" {
   use_slug      = false
 }
 
-data "azuread_group" "all_owner" {
+resource "azuread_group" "all_owner" {
   for_each = {
     for s in ["delegate_sub_groups"] :
     s => s
     if var.delegate_sub_groups
   }
 
-  display_name = data.azurecaf_name.azuread_group_all_owner["delegate_sub_groups"].result
+  display_name  = data.azurecaf_name.azuread_group_all_owner["delegate_sub_groups"].result
+  mail_nickname = "az-sub-${var.subscription_name}-all-owner"
+  mail_enabled  = true
 }
 
 resource "azuread_group_member" "sub_all_owner" {
@@ -32,7 +34,7 @@ resource "azuread_group_member" "sub_all_owner" {
   }
 
   group_object_id  = azuread_group.sub_owner.object_id
-  member_object_id = data.azuread_group.all_owner["delegate_sub_groups"].object_id
+  member_object_id = azuread_group.all_owner["delegate_sub_groups"].object_id
 }
 
 # Example: az-sub-<subName>-all-contributor
@@ -51,14 +53,16 @@ data "azurecaf_name" "azuread_group_all_contributor" {
   use_slug      = false
 }
 
-data "azuread_group" "all_contributor" {
+resource "azuread_group" "all_contributor" {
   for_each = {
     for s in ["delegate_sub_groups"] :
     s => s
     if var.delegate_sub_groups
   }
 
-  display_name = data.azurecaf_name.azuread_group_all_contributor["delegate_sub_groups"].result
+  display_name  = data.azurecaf_name.azuread_group_all_contributor["delegate_sub_groups"].result
+  mail_nickname = "az-sub-${var.subscription_name}-all-contributor"
+  mail_enabled  = true
 }
 
 resource "azuread_group_member" "sub_all_contributor" {
@@ -69,7 +73,7 @@ resource "azuread_group_member" "sub_all_contributor" {
   }
 
   group_object_id  = azuread_group.sub_contributor.object_id
-  member_object_id = data.azuread_group.all_contributor["delegate_sub_groups"].object_id
+  member_object_id = azuread_group.all_contributor["delegate_sub_groups"].object_id
 }
 
 # Example: az-sub-<subName>-all-reader
@@ -88,14 +92,16 @@ data "azurecaf_name" "azuread_group_all_reader" {
   use_slug      = false
 }
 
-data "azuread_group" "all_reader" {
+resource "azuread_group" "all_reader" {
   for_each = {
     for s in ["delegate_sub_groups"] :
     s => s
     if var.delegate_sub_groups
   }
 
-  display_name = data.azurecaf_name.azuread_group_all_reader["delegate_sub_groups"].result
+  display_name  = data.azurecaf_name.azuread_group_all_reader["delegate_sub_groups"].result
+  mail_nickname = "az-sub-${var.subscription_name}-all-reader"
+  mail_enabled  = true
 }
 
 resource "azuread_group_member" "sub_all_reader" {
@@ -106,7 +112,7 @@ resource "azuread_group_member" "sub_all_reader" {
   }
 
   group_object_id  = azuread_group.sub_reader.object_id
-  member_object_id = data.azuread_group.all_reader["delegate_sub_groups"].object_id
+  member_object_id = azuread_group.all_reader["delegate_sub_groups"].object_id
 }
 
 data "azuread_service_principal" "sp_all_owner" {

--- a/modules/azure/governance-global/aad-group-sub-delegation.tf
+++ b/modules/azure/governance-global/aad-group-sub-delegation.tf
@@ -24,6 +24,7 @@ resource "azuread_group" "all_owner" {
   display_name  = data.azurecaf_name.azuread_group_all_owner["delegate_sub_groups"].result
   mail_nickname = "az-sub-${var.subscription_name}-all-owner"
   mail_enabled  = true
+  types         = ["DynamicMembership"]
 }
 
 resource "azuread_group_member" "sub_all_owner" {
@@ -63,6 +64,7 @@ resource "azuread_group" "all_contributor" {
   display_name  = data.azurecaf_name.azuread_group_all_contributor["delegate_sub_groups"].result
   mail_nickname = "az-sub-${var.subscription_name}-all-contributor"
   mail_enabled  = true
+  types         = ["DynamicMembership"]
 }
 
 resource "azuread_group_member" "sub_all_contributor" {
@@ -102,6 +104,7 @@ resource "azuread_group" "all_reader" {
   display_name  = data.azurecaf_name.azuread_group_all_reader["delegate_sub_groups"].result
   mail_nickname = "az-sub-${var.subscription_name}-all-reader"
   mail_enabled  = true
+  types         = ["DynamicMembership"]
 }
 
 resource "azuread_group_member" "sub_all_reader" {


### PR DESCRIPTION
This PR adds support for creating required AD groups as part of the governance module, instead of having to create them manually in advance. The following AD-groups are now created automatically:

- az-sub-<subscription_name>-all-owner
- az-sub-<subscription_name>-all-contributor
- az-sub-<subscription_name>-all-reader

Existing AD-groups must be imported using

```
terraform import module.governance_global.azuread_group.all_owner["delegate_sub_groups"] 00000000-0000-0000-0000-000000000000
terraform import module.governance_global.azuread_group.all_contributor["delegate_sub_groups"] 00000000-0000-0000-0000-000000000000
terraform import module.governance_global.azuread_group.all_reader["delegate_sub_groups"] 00000000-0000-0000-0000-000000000000
```