### PR TITLE
fix: Upgrade Velero and plugin to support Workload Identity

### DIFF
--- a/modules/kubernetes/velero/main.tf
+++ b/modules/kubernetes/velero/main.tf
@@ -35,6 +35,7 @@ resource "git_repository_file" "velero" {
     resource_group_name = var.resource_group_name,
     subscription_id     = var.subscription_id,
     unique_suffix       = var.unique_suffix,
+    tenant_id           = azurerm_user_assigned_identity.velero.tenant_id,
   })
 }
 

--- a/modules/kubernetes/velero/templates/velero-extras.yaml.tpl
+++ b/modules/kubernetes/velero/templates/velero-extras.yaml.tpl
@@ -23,5 +23,5 @@ spec:
   schedule: "15 */1 * * *"
   template:
     snapshotVolumes: false
-    ttl: 960h0m0s
+    ttl: 96h0m0s
 

--- a/modules/kubernetes/velero/templates/velero.yaml.tpl
+++ b/modules/kubernetes/velero/templates/velero.yaml.tpl
@@ -63,6 +63,8 @@ spec:
             name: "plugins"
     podLabels:
       azure.workload.identity/use: "true"
+    labels:
+      azure.workload.identity/use: "true"
     priorityClassName: "platform-low"
     serviceAccount:
       server:
@@ -70,3 +72,5 @@ spec:
         name: velero
         annotations:
           azure.workload.identity/client-id: ${client_id}
+          azure.workload.identity/tenant-id: ${tenant_id}
+

--- a/modules/kubernetes/velero/templates/velero.yaml.tpl
+++ b/modules/kubernetes/velero/templates/velero.yaml.tpl
@@ -27,15 +27,15 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: velero
-      version: v2.23.6
+      version: v5.1.5
   interval: 1m0s
   values:
     configuration:
-      provider: "azure"
       logLevel: "warning"
       logFormat: "json"
       backupStorageLocation:
-        name: "default"
+      - name: "default"
+        provider: azure
         %{ if azure_config.storage_account_container != "" }
         bucket: "${azure_config.storage_account_container}"
         %{ else }
@@ -57,7 +57,7 @@ spec:
             AZURE_CLOUD_NAME=AzurePublicCloud
     initContainers:
       - name: "velero-plugin-for-microsoft-azure"
-        image: "velero/velero-plugin-for-microsoft-azure:v1.1.1"
+        image: "velero/velero-plugin-for-microsoft-azure:v1.8.0"
         volumeMounts:
           - mountPath: "/target"
             name: "plugins"


### PR DESCRIPTION
Since migration of Velero was done to use Workload Identity, it hasnt worked since it wasnt supported in the old version we were running.
only upgraded it to the point were Workload Identity was introduced.

This change upgrades the chart and azure-plugin to solve that. 