### PR TITLE
chore: Update cluster components

### DIFF
--- a/modules/kubernetes/aks-core/modules.tf
+++ b/modules/kubernetes/aks-core/modules.tf
@@ -147,7 +147,7 @@ module "cert_manager_crd" {
 
   chart_repository = "https://charts.jetstack.io"
   chart_name       = "cert-manager"
-  chart_version    = "v1.15.3"
+  chart_version    = "v1.16.3"
   values = {
     "installCRDs" = "true"
   }
@@ -712,7 +712,7 @@ module "trivy_crd" {
 
   chart_repository = "https://aquasecurity.github.io/helm-charts/"
   chart_name       = "trivy-operator"
-  chart_version    = "0.11.0"
+  chart_version    = "0.23.0"
 }
 
 module "velero" {

--- a/modules/kubernetes/azure-metrics/templates/azure-metrics.yaml.tpl
+++ b/modules/kubernetes/azure-metrics/templates/azure-metrics.yaml.tpl
@@ -27,7 +27,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: azure-metrics
-      version: v1.2.1
+      version: v1.2.8
   interval: 1m0s
   values:
     fullnameOverride: "azure-metrics-exporter"

--- a/modules/kubernetes/cert-manager/templates/cert-manager.yaml.tpl
+++ b/modules/kubernetes/cert-manager/templates/cert-manager.yaml.tpl
@@ -35,14 +35,15 @@ spec:
     serviceAccount:
       annotations:
         azure.workload.identity/client-id: ${client_id}
+    resources:
+      requests:
+        cpu: 15m
+        memory: 150Mi
     webhook:
       resources:
         requests:
           cpu: 30m
           memory: 100Mi
-    requests:
-      cpu: 15m
-      memory: 150Mi
     cainjector:
       resources:
         requests:

--- a/modules/kubernetes/cert-manager/templates/cert-manager.yaml.tpl
+++ b/modules/kubernetes/cert-manager/templates/cert-manager.yaml.tpl
@@ -19,7 +19,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: cert-manager
-      version: v1.15.3
+      version: v1.16.3
   interval: 1m0s
   values:
     global:

--- a/modules/kubernetes/control-plane-logs/templates/vector.yaml.tpl
+++ b/modules/kubernetes/control-plane-logs/templates/vector.yaml.tpl
@@ -27,7 +27,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: vector
-      version: v0.32.1
+      version: v0.40.0
   interval: 1m0s
   values:
     role: "Stateless-Aggregator"

--- a/modules/kubernetes/external-dns/templates/external-dns.yaml.tpl
+++ b/modules/kubernetes/external-dns/templates/external-dns.yaml.tpl
@@ -19,7 +19,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: external-dns
-      version: 8.3.8
+      version: 8.7.3
   interval: 1m0s
   values:
     provider: "azure"

--- a/modules/kubernetes/external-dns/templates/external-dns.yaml.tpl
+++ b/modules/kubernetes/external-dns/templates/external-dns.yaml.tpl
@@ -5,7 +5,8 @@ metadata:
   namespace: external-dns
 spec:
   interval: 1m0s
-  url: "https://charts.bitnami.com/bitnami"
+  type: "oci"
+  url: "oci://registry-1.docker.io/bitnamicharts/external-dns"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease

--- a/modules/kubernetes/external-dns/templates/external-dns.yaml.tpl
+++ b/modules/kubernetes/external-dns/templates/external-dns.yaml.tpl
@@ -6,7 +6,7 @@ metadata:
 spec:
   interval: 1m0s
   type: "oci"
-  url: "oci://registry-1.docker.io/bitnamicharts/external-dns"
+  url: "oci://registry-1.docker.io/bitnamicharts"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease

--- a/modules/kubernetes/falco/templates/falco.yaml.tpl
+++ b/modules/kubernetes/falco/templates/falco.yaml.tpl
@@ -36,7 +36,7 @@ spec:
 
     falcoctl:
       artifact:
-        install
+        install:
           enabled: false
         follow:
           enabled: false

--- a/modules/kubernetes/falco/templates/falco.yaml.tpl
+++ b/modules/kubernetes/falco/templates/falco.yaml.tpl
@@ -34,6 +34,13 @@ spec:
     driver:
       kind: ebpf
 
+    falcoctl:
+      artifact:
+        install
+          enabled: false
+        follow:
+          enabled: false
+
     falco:
       grpc:
         enabled: true

--- a/modules/kubernetes/falco/templates/falco.yaml.tpl
+++ b/modules/kubernetes/falco/templates/falco.yaml.tpl
@@ -27,7 +27,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: falco
-      version: v2.3.0
+      version: v4.17.2
   interval: 1m0s
   values:
     # Use EBPF instead of kernel module

--- a/modules/kubernetes/gatekeeper/templates/gatekeeper.yaml.tpl
+++ b/modules/kubernetes/gatekeeper/templates/gatekeeper.yaml.tpl
@@ -28,7 +28,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: gatekeeper
-      version: 3.9.0
+      version: 3.18.2
   interval: 1m0s
   install:
     crds: CreateReplace

--- a/modules/kubernetes/node-local-dns/templates/node-local-dns.yaml.tpl
+++ b/modules/kubernetes/node-local-dns/templates/node-local-dns.yaml.tpl
@@ -165,7 +165,7 @@ spec:
           operator: "Exists"
       containers:
         - name: node-cache
-          image: "registry.k8s.io/dns/k8s-dns-node-cache:1.22.20"
+          image: "registry.k8s.io/dns/k8s-dns-node-cache:1.25.0"
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/modules/kubernetes/spegel/templates/spegel.yaml.tpl
+++ b/modules/kubernetes/spegel/templates/spegel.yaml.tpl
@@ -28,7 +28,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: spegel
-      version: v0.0.23
+      version: v0.0.30
   interval: 1m0s
   values:
     resources:

--- a/modules/kubernetes/trivy/templates/starboard-exporter.yaml.tpl
+++ b/modules/kubernetes/trivy/templates/starboard-exporter.yaml.tpl
@@ -19,7 +19,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: starboard-exporter
-      version: v0.7.8
+      version: v0.8.0
   interval: 1m0s
   values:
     global:

--- a/modules/kubernetes/trivy/templates/trivy-operator.yaml.tpl
+++ b/modules/kubernetes/trivy/templates/trivy-operator.yaml.tpl
@@ -34,7 +34,7 @@ spec:
       mode: ClientServer
       severity: MEDIUM,HIGH,CRITICAL
       ignoreUnfixed: true
-      serverUrl: "http://trivy.trivy.svc.cluster.local:4954"
+      serverURL: "http://trivy.trivy.svc.cluster.local:4954"
 
     operator:
       # configAuditScannerEnabled the flag to enable configuration audit scanner

--- a/modules/kubernetes/trivy/templates/trivy-operator.yaml.tpl
+++ b/modules/kubernetes/trivy/templates/trivy-operator.yaml.tpl
@@ -19,7 +19,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: trivy-operator
-      version: 0.21.4
+      version: 0.23.0
   interval: 1m0s
   values:
     # targetNamespace defines where you want trivy-operator to operate. By

--- a/modules/kubernetes/trivy/templates/trivy.yaml.tpl
+++ b/modules/kubernetes/trivy/templates/trivy.yaml.tpl
@@ -27,7 +27,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: trivy
-      version: v0.7.0
+      version: v0.10.1
   interval: 1m0s
   values:
     trivy:


### PR DESCRIPTION
This updats the following project to the latest versions:

- Cert-manager  ----------------- v1.15.3 -> v1.16.3
- External-dns -------------------- v8.3.8 -> v8.7.3
- Gatekeeper --------------------- v3.9.0 -> v3.18.2
- azure-metrics-exporter ----- v1.2.1 -> v1.2.8
- Falco ------------------------------- v2.3.0 -> v4.17.2
- Trivy -------------------------------- v0.7.0 -> v0.10.1
- Trivy-operator ------------------ v0.21.4 -> v0.23.0
- Starboard-exporter ----------- v0.7.8 -> v0.8.0
- Spegel ----------------------------- v0.0.23 -> v0.0.30
- Node-local-dns ----------------- v1.22.20 -> v1.25.0
- control-plane-logs (vector) - v0.32.1 -> v0.40.0

Not sure if we want to make one big PR with all changes or one per component.