### PR TITLE
feat: allow scheduling ingress-nginx on spot nodes

### DIFF
--- a/modules/kubernetes/ingress-nginx/templates/ingress-nginx.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/ingress-nginx.yaml.tpl
@@ -125,6 +125,12 @@ spec:
                 topologyKey: topology.kubernetes.io/zone
               weight: 100
 
+      tolerations:
+        - key: "kubernetes.azure.com/scalesetpriority"
+          operator: "Equal"
+          value: "spot"
+          effect: "NoSchedule"
+
 %{~ if default_certificate.enabled ~}
 ---
 apiVersion: cert-manager.io/v1


### PR DESCRIPTION
This PR makes it possible to schedule ingress nginx pods on spot nodes