### PR TITLE
feat: allow cert-manager to run on spot nodes

### DIFF
--- a/modules/kubernetes/cert-manager/templates/cert-manager.yaml.tpl
+++ b/modules/kubernetes/cert-manager/templates/cert-manager.yaml.tpl
@@ -35,6 +35,11 @@ spec:
     serviceAccount:
       annotations:
         azure.workload.identity/client-id: ${client_id}
+    tolerations:
+      - key: "kubernetes.azure.com/scalesetpriority"
+        operator: "Equal"
+        value: "spot"
+        effect: "NoSchedule"
     webhook:
       resources:
         requests:


### PR DESCRIPTION
This PR makes it possible to run cert-manager on spot nodes