### PR TITLE
fix: add required network contributor role at subscription level

### DIFF
--- a/modules/azure/aks/README.md
+++ b/modules/azure/aks/README.md
@@ -57,6 +57,7 @@ https://pumpingco.de/blog/modify-aks-default-node-pool-in-terraform-without-rede
 | [azurerm_role_assignment.cluster_admin](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.cluster_view](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.edit](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.network_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.view](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/role_assignment) | resource |
 | [azurerm_security_center_auto_provisioning.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/security_center_auto_provisioning) | resource |
 | [azurerm_security_center_subscription_pricing.containers](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/resources/security_center_subscription_pricing) | resource |
@@ -71,6 +72,7 @@ https://pumpingco.de/blog/modify-aks-default-node-pool-in-terraform-without-rede
 | [azurerm_resources.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/resources) | data source |
 | [azurerm_storage_account.log](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/storage_account) | data source |
 | [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/subnet) | data source |
+| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/4.7.0/docs/data-sources/subscription) | data source |
 
 ## Inputs
 

--- a/modules/azure/aks/aad-group.tf
+++ b/modules/azure/aks/aad-group.tf
@@ -26,6 +26,12 @@ resource "azurerm_role_assignment" "cluster_view" {
   principal_id         = var.aad_groups.cluster_view.id
 }
 
+resource "azurerm_role_assignment" "network_contributor" {
+  scope                = data.azurerm_subscription.current.id
+  role_definition_name = "Network Contributor"
+  principal_id         = azurerm_kubernetes_cluster.this.identity[0].principal_id
+}
+
 resource "azuread_group_member" "aks_managed_identity" {
   group_object_id  = var.aad_groups.aks_managed_identity.id
   member_object_id = azurerm_kubernetes_cluster.this.kubelet_identity[0].object_id

--- a/modules/azure/aks/main.tf
+++ b/modules/azure/aks/main.tf
@@ -31,6 +31,9 @@ terraform {
   }
 }
 
+data "azurerm_subscription" "current" {
+}
+
 data "azurerm_resource_group" "this" {
   name = "rg-${var.environment}-${var.location_short}-${var.name}"
 }


### PR DESCRIPTION
This PR adds the Network Contributor role that is required to be able to create Load Balancers. 