### PR TITLE
fix: aks validation should allow no nodepools elements

### DIFF
--- a/modules/azure/aks/variables.tf
+++ b/modules/azure/aks/variables.tf
@@ -160,7 +160,7 @@ variable "aks_config" {
   })
 
   validation {
-    condition = alltrue([
+    condition = length(var.aks_config.node_pools) == 0 || alltrue([
       for np in concat(var.aks_config.node_pools, [{ version : var.aks_config.version }]) : can(regex("^1.(28|29|30|31)", np.version))
     ])
     error_message = "The Kubernetes version has not been validated yet, supported versions are 1.28, 1.29, 1.30 or 1.31."
@@ -172,35 +172,35 @@ variable "aks_config" {
   }
 
   validation {
-    condition = alltrue([
+    condition = length(var.aks_config.node_pools) == 0 || alltrue([
       for np in var.aks_config.node_pools : split(".", np.version)[1] <= split(".", var.aks_config.version)[1]
     ])
     error_message = "The node Kubernetes version should not be newer than the cluster version, upgrade the cluster first."
   }
 
   validation {
-    condition = alltrue([
+    condition = length(var.aks_config.node_pools) == 0 || alltrue([
       for np in var.aks_config.node_pools : length(np.name) <= 12
     ])
     error_message = "The name value cannot be longer than 12 characters."
   }
 
   validation {
-    condition = alltrue([
+    condition = length(var.aks_config.node_pools) == 0 || alltrue([
       for np in var.aks_config.node_pools : can(regex("^[a-z0-9]+$", np.name))
     ])
     error_message = "The name value has to be lowercase alphanumeric."
   }
 
   validation {
-    condition = alltrue([
+    condition = length(var.aks_config.node_pools) == 0 || alltrue([
       for np in var.aks_config.node_pools : can(regex("^[a-z]", np.name))
     ])
     error_message = "The name value has to begin with a lowercase letter."
   }
 
   validation {
-    condition = alltrue([
+    condition = length(var.aks_config.node_pools) == 0 || alltrue([
       for np in var.aks_config.node_pools : can(regex("[12]$", np.name))
     ])
     error_message = "The name value should end with a 1 or 2 to enable blue green pool creation."
@@ -208,7 +208,7 @@ variable "aks_config" {
 
   # Spot max price is set when spot is enabled
   validation {
-    condition = alltrue([
+    condition = length(var.aks_config.node_pools) == 0 || alltrue([
       for np in var.aks_config.node_pools : (!np.spot_enabled && np.spot_max_price == null) || (np.spot_enabled && np.spot_max_price != null)
     ])
     error_message = "The spot_max_price cannot be null when spot_enabled is true."

--- a/validation/azure/aks/main.tf
+++ b/validation/azure/aks/main.tf
@@ -24,7 +24,7 @@ module "aks" {
   aks_name_suffix   = "1"
 
   aks_config = {
-    version                  = "1.28.9"
+    version                  = "1.31.2"
     sku_tier                 = "Standard"
     default_node_pool_size   = 2
     priority_expander_config = { "10" : [".*standard.*"], "20" : [".*spot.*"] }
@@ -36,7 +36,7 @@ module "aks" {
     node_pools = [
       {
         name      = "pool1"
-        version   = "1.28.9"
+        version   = "1.31.2"
         vm_size   = "Standard_B2s"
         min_count = 1
         max_count = 1


### PR DESCRIPTION
This PR adjusts the aks validation to allow the creation of a cluster without any nodepools, except the system one.