### PR TITLE
fix: only create nginx_ingress_healthz for public ingress

### DIFF
--- a/modules/kubernetes/ingress-nginx/main.tf
+++ b/modules/kubernetes/ingress-nginx/main.tf
@@ -62,6 +62,7 @@ resource "git_repository_file" "ingress_nginx" {
     extra_headers                       = var.customization.extra_headers
     linkerd_enabled                     = var.linkerd_enabled
     datadog_enabled                     = var.datadog_enabled
+    nginx_healthz_ingress_enabled       = true
     nginx_healthz_ingress_whitelist_ips = var.nginx_healthz_ingress_whitelist_ips
     nginx_healthz_ingress_hostname      = var.nginx_healthz_ingress_hostname
   })
@@ -96,6 +97,7 @@ resource "git_repository_file" "ingress_nginx_private" {
     extra_headers                       = merge(var.customization.extra_headers, var.customization_private.extra_config)
     linkerd_enabled                     = var.linkerd_enabled
     datadog_enabled                     = var.datadog_enabled
+    nginx_healthz_ingress_enabled       = false
     nginx_healthz_ingress_whitelist_ips = var.nginx_healthz_ingress_whitelist_ips
     nginx_healthz_ingress_hostname      = var.nginx_healthz_ingress_hostname
   })

--- a/modules/kubernetes/ingress-nginx/templates/ingress-nginx.yaml.tpl
+++ b/modules/kubernetes/ingress-nginx/templates/ingress-nginx.yaml.tpl
@@ -147,7 +147,7 @@ spec:
     kind: ClusterIssuer
     name: letsencrypt
 %{~ endif ~}
-
+%{~ if nginx_healthz_ingress_enabled ~}
 ---
 
 apiVersion: networking.k8s.io/v1
@@ -177,3 +177,4 @@ spec:
             name: ingress-nginx-controller-metrics
             port:
               number: 10254
+%{~ endif ~}


### PR DESCRIPTION
When running the previous setup, we got errors due to duplicate ingresses was being created. This will fix that and only create an ingress for the public ingress.