### PR TITLE
chore: bump vpa charts to latest

### DIFF
--- a/modules/kubernetes/trivy/templates/trivy-operator.yaml.tpl
+++ b/modules/kubernetes/trivy/templates/trivy-operator.yaml.tpl
@@ -38,7 +38,7 @@ spec:
 
     operator:
       # metricsVulnIdEnabled the flag to enable metrics about cve vulns id
-      metricsVulnIdEnabled: true
+      metricsVulnIdEnabled: ${metrics_vulnerability_id_enabled}
       # configAuditScannerEnabled the flag to enable configuration audit scanner
       configAuditScannerEnabled: false
       # vulnerabilityScannerScanOnlyCurrentRevisions the flag to only create vulnerability scans on the current revision of a deployment.

--- a/modules/kubernetes/vpa/templates/vpa.yaml.tpl
+++ b/modules/kubernetes/vpa/templates/vpa.yaml.tpl
@@ -36,10 +36,6 @@ spec:
   values:
     priorityClassName: platform-medium
     recommender:
-      image:
-        repository: registry.k8s.io/autoscaling/vpa-recommender
-        pullPolicy: IfNotPresent
-        tag: "0.12.0"
       extraArgs:
         pod-recommendation-min-cpu-millicores: 15
         pod-recommendation-min-memory-mb: 24
@@ -70,6 +66,8 @@ spec:
       version: 9.0.1
   interval: 1m0s
   values:
+    image:
+      tag: v4.13.4
     dashboard:
       enabled: false
     controller:
@@ -86,6 +84,12 @@ spec:
               - 'get'
               - 'list'
               - 'watch'
+          - apiGroups:
+              - 'operator.tigera.io'
+            resources:
+              - 'installations'
+            verbs:
+              - 'list'
       resources:
         limits:
           cpu: 100m

--- a/modules/kubernetes/vpa/templates/vpa.yaml.tpl
+++ b/modules/kubernetes/vpa/templates/vpa.yaml.tpl
@@ -27,7 +27,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: fairwinds
-      version: 1.6.1
+      version: 4.7.2
   interval: 1m0s
   install:
     crds: CreateReplace
@@ -67,7 +67,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: fairwinds
-      version: 6.5.1
+      version: 9.0.1
   interval: 1m0s
   values:
     dashboard:

--- a/modules/kubernetes/vpa/templates/vpa.yaml.tpl
+++ b/modules/kubernetes/vpa/templates/vpa.yaml.tpl
@@ -73,7 +73,7 @@ spec:
     controller:
       flags:
         on-by-default: "true"
-        exclude-namespaces: "kube-system"
+        exclude-namespaces: "calico-system,kube-system,tigera-operator"
       rbac:
         extraRules:
           - apiGroups:
@@ -84,12 +84,6 @@ spec:
               - 'get'
               - 'list'
               - 'watch'
-          - apiGroups:
-              - 'operator.tigera.io'
-            resources:
-              - 'installations'
-            verbs:
-              - 'list'
       resources:
         limits:
           cpu: 100m


### PR DESCRIPTION
This PR bumps the goldilocks and vpa charts to latest versions. 