### PR TITLE
chore: upgrade node-ttl to v0.0.9

### DIFF
--- a/modules/kubernetes/node-ttl/templates/node-ttl.yaml.tpl
+++ b/modules/kubernetes/node-ttl/templates/node-ttl.yaml.tpl
@@ -28,7 +28,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: node-ttl
-      version: v0.0.7
+      version: v0.0.9
   interval: 1m0s
   values:
     resources:


### PR DESCRIPTION
This PR upgrades node-ttl to latest version, where the integration with cluster-autoscaler v1.30+ works again.