### PR TITLE
chore: upgrade datadog

### DIFF
--- a/modules/kubernetes/datadog/templates/datadog-agent.yaml.tpl
+++ b/modules/kubernetes/datadog/templates/datadog-agent.yaml.tpl
@@ -25,7 +25,7 @@ spec:
       tolerations:
         - operator: Exists
       image:
-        name: "gcr.io/datadoghq/agent:7.45.0"
+        name: "gcr.io/datadoghq/agent:7.66.0"
       env:
         - name: DD_CONTAINER_EXCLUDE_LOGS
           value: "name:datadog-agent"
@@ -39,7 +39,7 @@ spec:
       replicas: 2
       priorityClassName: platform-low
       image:
-        name: "gcr.io/datadoghq/cluster-agent:7.45.0"
+        name: "gcr.io/datadoghq/cluster-agent:7.66.0"
       tolerations:
         - operator: Exists
       containers:

--- a/modules/kubernetes/datadog/templates/datadog-operator.yaml.tpl
+++ b/modules/kubernetes/datadog/templates/datadog-operator.yaml.tpl
@@ -23,15 +23,13 @@ spec:
     - Replace=true
   source:
     repoURL: https://helm.datadoghq.com
-    targetRevision: 1.0.2
+    targetRevision: 2.9.2
     chart: datadog
     helm:
       valuesObject:
         apiKeyExistingSecret: datadog-operator-apikey
         appKeyExistingSecret: datadog-operator-appkey
         installCRDs: true
-        image:
-          tag: 1.0.2
         datadogMonitor:
           enabled: true
         resources:


### PR DESCRIPTION
This PR upgrades the datadog agent to v7.66.0 and the datadog operator to the 2.9.2 chart version. 