### PR TITLE
chore: version control-plane-logs to 0.46.0

### DIFF
--- a/modules/kubernetes/control-plane-logs/templates/vector.yaml.tpl
+++ b/modules/kubernetes/control-plane-logs/templates/vector.yaml.tpl
@@ -31,7 +31,7 @@ spec:
     - .spec.template.spec.securityContext
   source:
     repoURL: https://helm.vector.dev
-    targetRevision: 0.41.0
+    targetRevision: 0.46.0
     chart: vector
     helm:
       valuesObject:


### PR DESCRIPTION
vector
appversion 0.50.0
helmversion 0.46.0